### PR TITLE
add centralized OpenAPI schema system with $ref (#18)

### DIFF
--- a/.cursor/rules/backend.mdc
+++ b/.cursor/rules/backend.mdc
@@ -53,7 +53,10 @@ src/
 ├── app.ts            # Fastify setup
 ├── config.ts         # Environment config
 ├── types/            # TypeScript interfaces
-├── schemas/          # Zod validation schemas
+├── schemas/          # OpenAPI JSON schemas (registered via $ref)
+│   ├── index.ts      # registerSchemas() function
+│   ├── common.ts     # ErrorResponse, Pagination
+│   └── *.schema.ts   # Entity-specific schemas
 ├── routes/           # Route handlers
 ├── services/         # Business logic
 └── repositories/     # Data access layer
@@ -93,6 +96,70 @@ const app = await buildApp({ db })
 - Service layer contains business logic (UUID generation, timestamps)
 - Routes handle HTTP concerns only (parsing, status codes)
 - Zod schemas validate all request bodies
+
+## OpenAPI Schema Management (Required)
+
+All API schemas must be centralized in `src/schemas/` and use Fastify's `$ref` system.
+
+### Schema File Convention
+
+```typescript
+// src/schemas/entity.schema.ts
+export const entitySchema = {
+  $id: 'Entity',           // Required: unique ID for $ref
+  type: 'object',
+  properties: { ... },
+  required: ['id', 'name'],
+} as const
+
+export const entityListSchema = {
+  $id: 'EntityList',
+  type: 'array',
+  items: { $ref: 'Entity#' },
+} as const
+```
+
+### Registering Schemas
+
+Add new schemas to `src/schemas/index.ts`:
+
+```typescript
+import { entitySchema, entityListSchema } from './entity.schema.js'
+const schemas = [..., entitySchema, entityListSchema]
+```
+
+### Using Schemas in Routes
+
+Always use `$ref` - never inline schemas in routes:
+
+```typescript
+fastify.get('/entities', {
+  schema: {
+    tags: ['entities'],
+    summary: 'List entities',
+    response: {
+      200: { $ref: 'EntityList#' },
+      500: { $ref: 'ErrorResponse#' },
+    },
+  },
+}, handler)
+```
+
+### Schema Types Reference
+
+| Field Type | Schema |
+|------------|--------|
+| UUID | `{ type: 'string', format: 'uuid' }` |
+| Timestamp | `{ type: 'string', format: 'date-time' }` |
+| Nullable | `{ type: 'string', nullable: true }` |
+| Enum | `{ type: 'string', enum: ['a', 'b'] }` |
+| Ref | `{ $ref: 'SchemaName#' }` |
+| Nullable ref | `{ oneOf: [{ $ref: 'Schema#' }, { type: 'null' }] }` |
+
+### After API Changes
+
+1. Run `npm run openapi:generate`
+2. Commit updated `docs/openapi.json`
 
 ## API Response Codes
 - 200: GET, PATCH success

--- a/DEV-LESSONS.md
+++ b/DEV-LESSONS.md
@@ -11,3 +11,21 @@ A log of bugs, mistakes, and fixes encountered during development. Each entry do
 **Problem:** Routes imported db directly, making tests require env vars before module load and coupling code to specific implementations
 **Solution:** Use DI pattern - buildApp({ db }) accepts dependencies, routes use fastify.db from context, tests inject testcontainer db
 **Prevention:** Always inject services into app, never import directly in routes. Entry point creates real services, tests create test services
+
+### [Config] OpenAPI schemas must use centralized $ref system
+**Date:** 2026-02-05
+**Problem:** Inline JSON schemas in routes cause duplication, are hard to maintain, and result in bloated OpenAPI spec
+**Solution:** Create `src/schemas/` folder with schemas that have `$id`, register via `registerSchemas(fastify)`, reference in routes with `{ $ref: 'SchemaName#' }`
+**Prevention:** Never define schemas inline in routes. Always create in `src/schemas/`, register in index.ts, use $ref
+
+### [Config] Don't hardcode localhost in OpenAPI servers
+**Date:** 2026-02-05
+**Problem:** OpenAPI spec had hardcoded `http://localhost:3333` in servers array, which gets committed and is irrelevant for frontend
+**Solution:** Removed `servers` section entirely - frontend configures API URL via its own environment variables
+**Prevention:** Don't include environment-specific URLs in OpenAPI spec. Let clients configure their own base URL
+
+### [Config] Don't over-engineer error response schemas
+**Date:** 2026-02-05
+**Problem:** Created separate HealthyResponse and UnhealthyResponse schemas for health endpoint, but 503 response body is never parsed by clients
+**Solution:** Single HealthResponse schema for 200 only. Unhealthy = any non-200 status, body doesn't matter
+**Prevention:** Only type responses that clients actually parse. Error responses often just need status code check

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,34 +13,403 @@
         "in": "header"
       }
     },
-    "schemas": {}
+    "schemas": {
+      "def-0": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "ErrorResponse"
+      },
+      "def-1": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 1
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          }
+        },
+        "title": "PaginationQuery"
+      },
+      "def-2": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "totalPages": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page",
+          "limit",
+          "total",
+          "totalPages"
+        ],
+        "title": "PaginationMeta"
+      },
+      "def-3": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "healthy"
+            ]
+          },
+          "database": {
+            "type": "string",
+            "enum": [
+              "connected"
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "database"
+        ],
+        "title": "HealthResponse"
+      },
+      "def-4": {
+        "type": "object",
+        "properties": {
+          "locationId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "region": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "latitude": {
+            "type": "number",
+            "nullable": true
+          },
+          "longitude": {
+            "type": "number",
+            "nullable": true
+          },
+          "timezone": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "locationId",
+          "name"
+        ],
+        "title": "Location"
+      },
+      "def-5": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "archived"
+            ]
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "unlisted",
+              "private"
+            ]
+          },
+          "ownerParticipantId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "location": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-4"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "planId",
+          "title",
+          "status",
+          "visibility",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "Plan"
+      },
+      "def-6": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/def-5"
+        },
+        "title": "PlanList"
+      },
+      "def-7": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "unlisted",
+              "private"
+            ]
+          },
+          "location": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-4"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "title": "CreatePlanBody"
+      },
+      "def-8": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "archived"
+            ]
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "unlisted",
+              "private"
+            ]
+          },
+          "location": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-4"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "title": "UpdatePlanBody"
+      },
+      "def-9": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "planId"
+        ],
+        "title": "PlanIdParam"
+      }
+    }
   },
   "paths": {
     "/health": {
       "get": {
+        "summary": "Health check",
+        "tags": [
+          "health"
+        ],
+        "description": "Check if the server and database are healthy",
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-3"
+                }
+              }
+            }
           }
         }
       }
     },
     "/plans": {
       "get": {
+        "summary": "List all plans",
+        "tags": [
+          "plans"
+        ],
+        "description": "Retrieve all plans ordered by creation date",
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-6"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
           }
         }
       }
     }
   },
-  "servers": [
-    {
-      "url": "http://localhost:3333",
-      "description": "Development server"
-    }
-  ],
   "tags": [
     {
       "name": "health",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors'
 import swagger from '@fastify/swagger'
 import swaggerUI from '@fastify/swagger-ui'
 import { config } from './config.js'
+import { registerSchemas } from './schemas/index.js'
 import { healthRoutes } from './routes/health.route.js'
 import { plansRoutes } from './routes/plans.route.js'
 import { Database } from './db/index.js'
@@ -38,6 +39,8 @@ export async function buildApp(
 
   fastify.decorate('db', deps.db)
 
+  registerSchemas(fastify)
+
   if (enableDocs) {
     await fastify.register(swagger, {
       openapi: {
@@ -47,12 +50,6 @@ export async function buildApp(
           description: 'Trip planning with shared checklists',
           version: '1.0.0',
         },
-        servers: [
-          {
-            url: `http://localhost:${config.port}`,
-            description: 'Development server',
-          },
-        ],
         tags: [
           { name: 'health', description: 'Health check endpoints' },
           { name: 'plans', description: 'Plan management' },

--- a/src/routes/health.route.ts
+++ b/src/routes/health.route.ts
@@ -2,15 +2,28 @@ import { FastifyInstance } from 'fastify'
 import { sql } from 'drizzle-orm'
 
 export async function healthRoutes(fastify: FastifyInstance) {
-  fastify.get('/health', async (_request, reply) => {
-    try {
-      await fastify.db.execute(sql`SELECT 1`)
-      return { status: 'healthy', database: 'connected' }
-    } catch (err) {
-      fastify.log.error({ err }, 'Health check failed - database unreachable')
-      return reply
-        .status(503)
-        .send({ status: 'unhealthy', database: 'disconnected' })
+  fastify.get(
+    '/health',
+    {
+      schema: {
+        tags: ['health'],
+        summary: 'Health check',
+        description: 'Check if the server and database are healthy',
+        response: {
+          200: { $ref: 'HealthResponse#' },
+        },
+      },
+    },
+    async (_request, reply) => {
+      try {
+        await fastify.db.execute(sql`SELECT 1`)
+        return { status: 'healthy', database: 'connected' }
+      } catch (err) {
+        fastify.log.error({ err }, 'Health check failed - database unreachable')
+        return reply
+          .status(503)
+          .send({ status: 'unhealthy', database: 'disconnected' })
+      }
     }
-  })
+  )
 }

--- a/src/routes/plans.route.ts
+++ b/src/routes/plans.route.ts
@@ -2,31 +2,47 @@ import { FastifyInstance } from 'fastify'
 import { plans } from '../db/schema.js'
 
 export async function plansRoutes(fastify: FastifyInstance) {
-  fastify.get('/plans', async (request, reply) => {
-    try {
-      const allPlans = await fastify.db
-        .select()
-        .from(plans)
-        .orderBy(plans.createdAt)
+  fastify.get(
+    '/plans',
+    {
+      schema: {
+        tags: ['plans'],
+        summary: 'List all plans',
+        description: 'Retrieve all plans ordered by creation date',
+        response: {
+          200: { $ref: 'PlanList#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const allPlans = await fastify.db
+          .select()
+          .from(plans)
+          .orderBy(plans.createdAt)
 
-      request.log.info({ count: allPlans.length }, 'Plans retrieved')
-      return allPlans
-    } catch (error) {
-      request.log.error({ err: error }, 'Failed to retrieve plans')
+        request.log.info({ count: allPlans.length }, 'Plans retrieved')
+        return allPlans
+      } catch (error) {
+        request.log.error({ err: error }, 'Failed to retrieve plans')
 
-      const isConnectionError =
-        error instanceof Error &&
-        (error.message.includes('connect') || error.message.includes('timeout'))
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
 
-      if (isConnectionError) {
-        return reply.status(503).send({
-          message: 'Database connection error',
+        if (isConnectionError) {
+          return reply.status(503).send({
+            message: 'Database connection error',
+          })
+        }
+
+        return reply.status(500).send({
+          message: 'Failed to retrieve plans',
         })
       }
-
-      return reply.status(500).send({
-        message: 'Failed to retrieve plans',
-      })
     }
-  })
+  )
 }

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,0 +1,30 @@
+export const errorResponseSchema = {
+  $id: 'ErrorResponse',
+  type: 'object',
+  properties: {
+    message: { type: 'string' },
+    code: { type: 'string' },
+  },
+  required: ['message'],
+} as const
+
+export const paginationQuerySchema = {
+  $id: 'PaginationQuery',
+  type: 'object',
+  properties: {
+    page: { type: 'integer', minimum: 1, default: 1 },
+    limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+  },
+} as const
+
+export const paginationMetaSchema = {
+  $id: 'PaginationMeta',
+  type: 'object',
+  properties: {
+    page: { type: 'integer' },
+    limit: { type: 'integer' },
+    total: { type: 'integer' },
+    totalPages: { type: 'integer' },
+  },
+  required: ['page', 'limit', 'total', 'totalPages'],
+} as const

--- a/src/schemas/health.schema.ts
+++ b/src/schemas/health.schema.ts
@@ -1,0 +1,9 @@
+export const healthResponseSchema = {
+  $id: 'HealthResponse',
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['healthy'] },
+    database: { type: 'string', enum: ['connected'] },
+  },
+  required: ['status', 'database'],
+} as const

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,0 +1,38 @@
+import { FastifyInstance } from 'fastify'
+import {
+  errorResponseSchema,
+  paginationQuerySchema,
+  paginationMetaSchema,
+} from './common.js'
+import { healthResponseSchema } from './health.schema.js'
+import {
+  locationSchema,
+  planSchema,
+  planListSchema,
+  createPlanBodySchema,
+  updatePlanBodySchema,
+  planIdParamSchema,
+} from './plan.schema.js'
+
+const schemas = [
+  errorResponseSchema,
+  paginationQuerySchema,
+  paginationMetaSchema,
+  healthResponseSchema,
+  locationSchema,
+  planSchema,
+  planListSchema,
+  createPlanBodySchema,
+  updatePlanBodySchema,
+  planIdParamSchema,
+]
+
+export function registerSchemas(fastify: FastifyInstance) {
+  for (const schema of schemas) {
+    fastify.addSchema(schema)
+  }
+}
+
+export * from './common.js'
+export * from './health.schema.js'
+export * from './plan.schema.js'

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -1,0 +1,93 @@
+export const locationSchema = {
+  $id: 'Location',
+  type: 'object',
+  properties: {
+    locationId: { type: 'string' },
+    name: { type: 'string' },
+    country: { type: 'string', nullable: true },
+    region: { type: 'string', nullable: true },
+    city: { type: 'string', nullable: true },
+    latitude: { type: 'number', nullable: true },
+    longitude: { type: 'number', nullable: true },
+    timezone: { type: 'string', nullable: true },
+  },
+  required: ['locationId', 'name'],
+} as const
+
+export const planSchema = {
+  $id: 'Plan',
+  type: 'object',
+  properties: {
+    planId: { type: 'string', format: 'uuid' },
+    title: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    status: { type: 'string', enum: ['draft', 'active', 'archived'] },
+    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    ownerParticipantId: { type: 'string', format: 'uuid', nullable: true },
+    location: {
+      oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
+    },
+    startDate: { type: 'string', format: 'date-time', nullable: true },
+    endDate: { type: 'string', format: 'date-time', nullable: true },
+    tags: { type: 'array', items: { type: 'string' }, nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+  required: [
+    'planId',
+    'title',
+    'status',
+    'visibility',
+    'createdAt',
+    'updatedAt',
+  ],
+} as const
+
+export const planListSchema = {
+  $id: 'PlanList',
+  type: 'array',
+  items: { $ref: 'Plan#' },
+} as const
+
+export const createPlanBodySchema = {
+  $id: 'CreatePlanBody',
+  type: 'object',
+  properties: {
+    title: { type: 'string', minLength: 1, maxLength: 255 },
+    description: { type: 'string', nullable: true },
+    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    location: {
+      oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
+    },
+    startDate: { type: 'string', format: 'date-time', nullable: true },
+    endDate: { type: 'string', format: 'date-time', nullable: true },
+    tags: { type: 'array', items: { type: 'string' }, nullable: true },
+  },
+  required: ['title'],
+} as const
+
+export const updatePlanBodySchema = {
+  $id: 'UpdatePlanBody',
+  type: 'object',
+  properties: {
+    title: { type: 'string', minLength: 1, maxLength: 255 },
+    description: { type: 'string', nullable: true },
+    status: { type: 'string', enum: ['draft', 'active', 'archived'] },
+    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    location: {
+      oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
+    },
+    startDate: { type: 'string', format: 'date-time', nullable: true },
+    endDate: { type: 'string', format: 'date-time', nullable: true },
+    tags: { type: 'array', items: { type: 'string' }, nullable: true },
+  },
+} as const
+
+export const planIdParamSchema = {
+  $id: 'PlanIdParam',
+  type: 'object',
+  properties: {
+    planId: { type: 'string', format: 'uuid' },
+  },
+  required: ['planId'],
+} as const

--- a/tests/unit/plans.route.test.ts
+++ b/tests/unit/plans.route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Fastify from 'fastify'
 import { plansRoutes } from '../../src/routes/plans.route.js'
+import { registerSchemas } from '../../src/schemas/index.js'
 
 function createMockDb() {
   return {
@@ -18,6 +19,7 @@ describe('Plans Route - Error Scenarios', () => {
 
     app = Fastify({ logger: false })
     app.decorate('db', mockDb)
+    registerSchemas(app)
     await app.register(plansRoutes)
   })
 


### PR DESCRIPTION
- Created src/schemas/ folder with reusable JSON schemas
- Routes now use $ref instead of inline schemas
- Removed hardcoded localhost from OpenAPI servers
- Simplified health endpoint to single response schema
- Updated README and backend.mdc with schema best practices
- Added dev lessons for schema patterns learned