### PR TITLE
Add POST /plans/:planId/items endpoint

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,39 @@
+---
+description: Testing conventions for writing concise, comprehensive tests
+globs: tests/**/*.test.ts
+alwaysApply: false
+---
+
+# Testing Conventions
+
+## Combine Similar Tests
+
+Use `it.each` to combine tests that follow the same pattern. Every case must still be covered.
+
+```typescript
+// BAD: repetitive tests with identical structure
+it('returns 400 when name is missing', async () => { ... })
+it('returns 400 when category is missing', async () => { ... })
+it('returns 400 when quantity is missing', async () => { ... })
+
+// GOOD: combined with it.each, all cases still covered
+it.each([
+  ['name', { category: 'equipment', quantity: 1, status: 'pending' }],
+  ['category', { name: 'Tent', quantity: 1, status: 'pending' }],
+  ['quantity', { name: 'Tent', category: 'equipment', status: 'pending' }],
+])('returns 400 when %s is missing', async (_field, payload) => {
+  const response = await app.inject({ method: 'POST', url, payload })
+  expect(response.statusCode).toBe(400)
+})
+```
+
+## Avoid Redundant Tests
+
+Do not write a separate test if its assertions are already fully covered by another test. For example, a "returns correct structure" test is redundant if the main happy-path test already asserts every property.
+
+## When NOT to Combine
+
+Keep tests separate when:
+- They have meaningfully different setup or mock configurations
+- Combining would make the test name unclear or the failure message unhelpful
+- The logic being tested is fundamentally different (e.g., happy path vs error path)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -427,6 +427,61 @@
       "def-12": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "equipment",
+              "food"
+            ]
+          },
+          "quantity": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "unit": {
+            "type": "string",
+            "enum": [
+              "pcs",
+              "kg",
+              "g",
+              "lb",
+              "oz",
+              "l",
+              "ml",
+              "pack",
+              "set"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "purchased",
+              "packed",
+              "canceled"
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "name",
+          "category",
+          "quantity",
+          "status"
+        ],
+        "title": "CreateItemBody"
+      },
+      "def-13": {
+        "type": "object",
+        "properties": {
           "planId": {
             "type": "string",
             "format": "uuid"
@@ -656,7 +711,88 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-12"
+                  "$ref": "#/components/schemas/def-13"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans/{planId}/items": {
+      "post": {
+        "summary": "Add an item to a plan",
+        "tags": [
+          "items"
+        ],
+        "description": "Create a new item in the specified plan. Equipment items always use pcs as the unit. Food items require a unit.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-12"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-10"
                 }
               }
             }

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { config } from './config.js'
 import { registerSchemas } from './schemas/index.js'
 import { healthRoutes } from './routes/health.route.js'
 import { plansRoutes } from './routes/plans.route.js'
+import { itemsRoutes } from './routes/items.route.js'
 import { Database } from './db/index.js'
 
 export interface AppDependencies {
@@ -94,6 +95,7 @@ export async function buildApp(
 
   await fastify.register(healthRoutes)
   await fastify.register(plansRoutes)
+  await fastify.register(itemsRoutes)
 
   return fastify
 }

--- a/src/routes/items.route.ts
+++ b/src/routes/items.route.ts
@@ -1,0 +1,90 @@
+import { FastifyInstance } from 'fastify'
+import { eq } from 'drizzle-orm'
+import { items, plans } from '../db/schema.js'
+
+interface CreateItemBody {
+  name: string
+  category: 'equipment' | 'food'
+  quantity: number
+  status: 'pending' | 'purchased' | 'packed' | 'canceled'
+  unit?: 'pcs' | 'kg' | 'g' | 'lb' | 'oz' | 'l' | 'ml' | 'pack' | 'set'
+  notes?: string | null
+}
+
+export async function itemsRoutes(fastify: FastifyInstance) {
+  fastify.post<{ Params: { planId: string }; Body: CreateItemBody }>(
+    '/plans/:planId/items',
+    {
+      schema: {
+        tags: ['items'],
+        summary: 'Add an item to a plan',
+        description:
+          'Create a new item in the specified plan. Equipment items always use pcs as the unit. Food items require a unit.',
+        params: { $ref: 'PlanIdParam#' },
+        body: { $ref: 'CreateItemBody#' },
+        response: {
+          201: { $ref: 'Item#' },
+          400: { $ref: 'ErrorResponse#' },
+          404: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { planId } = request.params
+      const { category, unit, ...rest } = request.body
+
+      if (category === 'food' && !unit) {
+        return reply.status(400).send({
+          message: 'Unit is required for food items',
+        })
+      }
+
+      const resolvedUnit = category === 'equipment' ? 'pcs' : unit!
+
+      try {
+        const [existingPlan] = await fastify.db
+          .select({ planId: plans.planId })
+          .from(plans)
+          .where(eq(plans.planId, planId))
+
+        if (!existingPlan) {
+          return reply.status(404).send({
+            message: 'Plan not found',
+          })
+        }
+
+        const [createdItem] = await fastify.db
+          .insert(items)
+          .values({
+            planId,
+            category,
+            unit: resolvedUnit,
+            ...rest,
+          })
+          .returning()
+
+        request.log.info({ itemId: createdItem.itemId, planId }, 'Item created')
+        return reply.status(201).send(createdItem)
+      } catch (error) {
+        request.log.error({ err: error, planId }, 'Failed to create item')
+
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
+
+        if (isConnectionError) {
+          return reply.status(503).send({
+            message: 'Database connection error',
+          })
+        }
+
+        return reply.status(500).send({
+          message: 'Failed to create item',
+        })
+      }
+    }
+  )
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -14,7 +14,11 @@ import {
   planIdParamSchema,
   planWithItemsSchema,
 } from './plan.schema.js'
-import { itemSchema, itemListSchema } from './item.schema.js'
+import {
+  itemSchema,
+  itemListSchema,
+  createItemBodySchema,
+} from './item.schema.js'
 
 const schemas = [
   errorResponseSchema,
@@ -29,6 +33,7 @@ const schemas = [
   planIdParamSchema,
   itemSchema,
   itemListSchema,
+  createItemBodySchema,
   planWithItemsSchema,
 ]
 

--- a/src/schemas/item.schema.ts
+++ b/src/schemas/item.schema.ts
@@ -37,3 +37,23 @@ export const itemListSchema = {
   type: 'array',
   items: { $ref: 'Item#' },
 } as const
+
+export const createItemBodySchema = {
+  $id: 'CreateItemBody',
+  type: 'object',
+  properties: {
+    name: { type: 'string', minLength: 1, maxLength: 255 },
+    category: { type: 'string', enum: ['equipment', 'food'] },
+    quantity: { type: 'integer', minimum: 1 },
+    unit: {
+      type: 'string',
+      enum: ['pcs', 'kg', 'g', 'lb', 'oz', 'l', 'ml', 'pack', 'set'],
+    },
+    status: {
+      type: 'string',
+      enum: ['pending', 'purchased', 'packed', 'canceled'],
+    },
+    notes: { type: 'string', nullable: true },
+  },
+  required: ['name', 'category', 'quantity', 'status'],
+} as const

--- a/tests/integration/items.test.ts
+++ b/tests/integration/items.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  seedTestPlans,
+  setupTestDatabase,
+} from '../helpers/db.js'
+
+describe('Items Route', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    app = await buildApp({ db })
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('POST /plans/:planId/items', () => {
+    it('creates equipment item with required fields and returns 201', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Tent',
+          category: 'equipment',
+          quantity: 2,
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const item = response.json()
+      expect(item.itemId).toBeDefined()
+      expect(item.planId).toBe(plan.planId)
+      expect(item.name).toBe('Tent')
+      expect(item.category).toBe('equipment')
+      expect(item.quantity).toBe(2)
+      expect(item.unit).toBe('pcs')
+      expect(item.status).toBe('pending')
+      expect(item.notes).toBeNull()
+      expect(item.createdAt).toBeDefined()
+      expect(item.updatedAt).toBeDefined()
+    })
+
+    it('creates equipment item with optional notes', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Sleeping Bag',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+          notes: 'Bring the warm one',
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const item = response.json()
+      expect(item.name).toBe('Sleeping Bag')
+      expect(item.notes).toBe('Bring the warm one')
+      expect(item.unit).toBe('pcs')
+    })
+
+    it('creates food item with required unit and returns 201', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Rice',
+          category: 'food',
+          quantity: 2,
+          unit: 'kg',
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const item = response.json()
+      expect(item.name).toBe('Rice')
+      expect(item.category).toBe('food')
+      expect(item.quantity).toBe(2)
+      expect(item.unit).toBe('kg')
+      expect(item.status).toBe('pending')
+    })
+
+    it('creates food item with all optional fields', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Water',
+          category: 'food',
+          quantity: 5,
+          unit: 'l',
+          status: 'purchased',
+          notes: 'Spring water preferred',
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const item = response.json()
+      expect(item.name).toBe('Water')
+      expect(item.unit).toBe('l')
+      expect(item.status).toBe('purchased')
+      expect(item.notes).toBe('Spring water preferred')
+    })
+
+    it('allows food item with any valid unit', async () => {
+      const [plan] = await seedTestPlans(1)
+      const validUnits = [
+        'pcs',
+        'kg',
+        'g',
+        'lb',
+        'oz',
+        'l',
+        'ml',
+        'pack',
+        'set',
+      ]
+
+      for (const unit of validUnits) {
+        const response = await app.inject({
+          method: 'POST',
+          url: `/plans/${plan.planId}/items`,
+          payload: {
+            name: `Food with ${unit}`,
+            category: 'food',
+            quantity: 1,
+            unit,
+            status: 'pending',
+          },
+        })
+
+        expect(response.statusCode).toBe(201)
+        expect(response.json().unit).toBe(unit)
+      }
+    })
+
+    it('returns 400 when food item is missing unit', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Rice',
+          category: 'food',
+          quantity: 2,
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 404 when plan does not exist', async () => {
+      const nonExistentId = '00000000-0000-0000-0000-000000000000'
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${nonExistentId}/items`,
+        payload: {
+          name: 'Tent',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        message: 'Plan not found',
+      })
+    })
+
+    it.each([
+      ['name', { category: 'equipment', quantity: 1, status: 'pending' }],
+      ['category', { name: 'Tent', quantity: 1, status: 'pending' }],
+      ['quantity', { name: 'Tent', category: 'equipment', status: 'pending' }],
+      ['status', { name: 'Tent', category: 'equipment', quantity: 1 }],
+    ])('returns 400 when %s is missing', async (_field, payload) => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload,
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it.each([
+      [
+        'category',
+        { name: 'X', category: 'clothing', quantity: 1, status: 'pending' },
+      ],
+      [
+        'unit',
+        {
+          name: 'X',
+          category: 'food',
+          quantity: 1,
+          unit: 'cups',
+          status: 'pending',
+        },
+      ],
+      [
+        'status',
+        { name: 'X', category: 'equipment', quantity: 1, status: 'lost' },
+      ],
+    ])('returns 400 for invalid %s value', async (_field, payload) => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload,
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it.each([0, -1])('returns 400 when quantity is %i', async (quantity) => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Tent',
+          category: 'equipment',
+          quantity,
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 when name is empty string', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: '',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 for invalid planId format', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/invalid-uuid/items',
+        payload: {
+          name: 'Tent',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('created item is retrievable via GET /plans/:planId', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Backpack',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+        },
+      })
+
+      const createdItem = createResponse.json()
+
+      const getResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+      })
+
+      expect(getResponse.statusCode).toBe(200)
+
+      const fetchedPlan = getResponse.json()
+      expect(fetchedPlan.items).toHaveLength(1)
+      expect(fetchedPlan.items[0].itemId).toBe(createdItem.itemId)
+      expect(fetchedPlan.items[0].name).toBe('Backpack')
+      expect(fetchedPlan.items[0].unit).toBe('pcs')
+    })
+  })
+})

--- a/tests/unit/items.route.test.ts
+++ b/tests/unit/items.route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Fastify from 'fastify'
+import { itemsRoutes } from '../../src/routes/items.route.js'
+import { registerSchemas } from '../../src/schemas/index.js'
+
+const VALID_UUID = '00000000-0000-0000-0000-000000000000'
+
+function createMockDb() {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+  }
+}
+
+function mockSelectPlanFound(mockDb: ReturnType<typeof createMockDb>) {
+  mockDb.select.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([{ planId: VALID_UUID }]),
+    }),
+  })
+}
+
+function mockInsertError(
+  mockDb: ReturnType<typeof createMockDb>,
+  error: unknown
+) {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockRejectedValue(error),
+    }),
+  })
+}
+
+const validEquipmentPayload = {
+  name: 'Tent',
+  category: 'equipment',
+  quantity: 1,
+  status: 'pending',
+}
+
+describe('Items Route - Error Scenarios', () => {
+  let app: ReturnType<typeof Fastify>
+  let mockDb: ReturnType<typeof createMockDb>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockDb = createMockDb()
+
+    app = Fastify({ logger: false })
+    app.decorate('db', mockDb)
+    registerSchemas(app)
+    await app.register(itemsRoutes)
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  describe('POST /plans/:planId/items - Plan Lookup Errors', () => {
+    it.each([
+      ['connect ECONNREFUSED', 503, 'Database connection error'],
+      ['connection timeout', 503, 'Database connection error'],
+      ['Unknown database error', 500, 'Failed to create item'],
+    ])(
+      'returns correct status when plan lookup fails with "%s"',
+      async (errorMessage, expectedStatus, expectedMessage) => {
+        mockDb.select.mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockRejectedValue(new Error(errorMessage)),
+          }),
+        })
+
+        const response = await app.inject({
+          method: 'POST',
+          url: `/plans/${VALID_UUID}/items`,
+          payload: validEquipmentPayload,
+        })
+
+        expect(response.statusCode).toBe(expectedStatus)
+        expect(response.json()).toEqual({ message: expectedMessage })
+      }
+    )
+
+    it('returns 500 when non-Error is thrown on plan lookup', async () => {
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockRejectedValue('string error'),
+        }),
+      })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${VALID_UUID}/items`,
+        payload: validEquipmentPayload,
+      })
+
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({ message: 'Failed to create item' })
+    })
+  })
+
+  describe('POST /plans/:planId/items - Insert Errors', () => {
+    it.each([
+      ['connect ECONNREFUSED', 503, 'Database connection error'],
+      ['connection timeout', 503, 'Database connection error'],
+      ['Unknown database error', 500, 'Failed to create item'],
+    ])(
+      'returns correct status when item insert fails with "%s"',
+      async (errorMessage, expectedStatus, expectedMessage) => {
+        mockSelectPlanFound(mockDb)
+        mockInsertError(mockDb, new Error(errorMessage))
+
+        const response = await app.inject({
+          method: 'POST',
+          url: `/plans/${VALID_UUID}/items`,
+          payload: validEquipmentPayload,
+        })
+
+        expect(response.statusCode).toBe(expectedStatus)
+        expect(response.json()).toEqual({ message: expectedMessage })
+      }
+    )
+
+    it('returns 500 when non-Error is thrown on item insert', async () => {
+      mockSelectPlanFound(mockDb)
+      mockInsertError(mockDb, 'string error')
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${VALID_UUID}/items`,
+        payload: validEquipmentPayload,
+      })
+
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({ message: 'Failed to create item' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implement `POST /plans/:planId/items` endpoint to add items to a plan
- Equipment items auto-set `unit` to `pcs`; food items require `unit` in the request body
- Added `CreateItemBody` schema, route handler, and registered in app

## Test plan
- 15 integration tests covering happy paths, validation errors, 404, and business rules
- 8 unit tests covering database error scenarios (503/500)
- All 59 tests pass, typecheck and lint clean

Closes #27

Made with [Cursor](https://cursor.com)