### PR TITLE
Delete Plan (DELETE /plans/:planId)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -347,6 +347,18 @@
       "def-10": {
         "type": "object",
         "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "DeletePlanResponse"
+      },
+      "def-11": {
+        "type": "object",
+        "properties": {
           "itemId": {
             "type": "string",
             "format": "uuid"
@@ -417,14 +429,14 @@
         ],
         "title": "Item"
       },
-      "def-11": {
+      "def-12": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-10"
+          "$ref": "#/components/schemas/def-11"
         },
         "title": "ItemList"
       },
-      "def-12": {
+      "def-13": {
         "type": "object",
         "properties": {
           "name": {
@@ -479,7 +491,7 @@
         ],
         "title": "CreateItemBody"
       },
-      "def-13": {
+      "def-14": {
         "type": "object",
         "properties": {
           "planId": {
@@ -550,7 +562,7 @@
             "format": "date-time"
           },
           "items": {
-            "$ref": "#/components/schemas/def-11"
+            "$ref": "#/components/schemas/def-12"
           }
         },
         "required": [
@@ -711,7 +723,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-13"
+                  "$ref": "#/components/schemas/def-14"
                 }
               }
             }
@@ -722,6 +734,66 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a plan",
+        "tags": [
+          "plans"
+        ],
+        "description": "Delete a plan by its ID. Cascade delete handles related items, participants, and assignments.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-10"
                 }
               }
             }
@@ -770,7 +842,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-12"
+                "$ref": "#/components/schemas/def-13"
               }
             }
           }
@@ -792,7 +864,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-10"
+                  "$ref": "#/components/schemas/def-11"
                 }
               }
             }
@@ -862,7 +934,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-11"
+                  "$ref": "#/components/schemas/def-12"
                 }
               }
             }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -12,6 +12,7 @@ import {
   createPlanBodySchema,
   updatePlanBodySchema,
   planIdParamSchema,
+  deletePlanResponseSchema,
   planWithItemsSchema,
 } from './plan.schema.js'
 import {
@@ -31,6 +32,7 @@ const schemas = [
   createPlanBodySchema,
   updatePlanBodySchema,
   planIdParamSchema,
+  deletePlanResponseSchema,
   itemSchema,
   itemListSchema,
   createItemBodySchema,

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -92,6 +92,15 @@ export const planIdParamSchema = {
   required: ['planId'],
 } as const
 
+export const deletePlanResponseSchema = {
+  $id: 'DeletePlanResponse',
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean' },
+  },
+  required: ['ok'],
+} as const
+
 export const planWithItemsSchema = {
   $id: 'PlanWithItems',
   type: 'object',


### PR DESCRIPTION
## Summary
- Add `DELETE /plans/:planId` endpoint that verifies plan existence, deletes the plan (cascade handles related items/participants/assignments), and returns `{ ok: true }` with status 200
- Add `DeletePlanResponse` OpenAPI schema and register it
- Add 7 integration tests covering happy path, cascade delete, 404, 400 invalid UUID, and isolation

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 71 tests pass (including 7 new DELETE plan tests)
- [x] OpenAPI spec regenerated

Closes #25

Made with [Cursor](https://cursor.com)