### PR TITLE
fix CORS preflight blocked by API key middleware

### DIFF
--- a/tests/integration/cors.test.ts
+++ b/tests/integration/cors.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { FastifyInstance } from 'fastify'
+import { setupTestDatabase, closeTestDatabase } from '../helpers/db.js'
+
+vi.mock('../../src/config.js', () => ({
+  config: {
+    port: 3333,
+    host: '0.0.0.0',
+    nodeEnv: 'production',
+    logLevel: 'error',
+    isDev: false,
+    databaseUrl: '',
+    frontendUrl: 'https://test-frontend.example.com',
+    apiKey: 'test-api-key-123',
+  },
+}))
+
+const TEST_FRONTEND_URL = 'https://test-frontend.example.com'
+const TEST_API_KEY = 'test-api-key-123'
+
+describe('CORS Preflight', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const { buildApp } = await import('../../src/app.js')
+    const db = await setupTestDatabase()
+    app = await buildApp({ db })
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  const routes = [
+    '/plans',
+    '/plans/test-id/items',
+    '/plans/test-id/participants',
+  ]
+
+  it.each(routes)(
+    'OPTIONS %s returns 204 with CORS headers without x-api-key',
+    async (route) => {
+      const response = await app.inject({
+        method: 'OPTIONS',
+        url: route,
+        headers: {
+          origin: TEST_FRONTEND_URL,
+          'access-control-request-method': 'GET',
+        },
+      })
+
+      expect(response.statusCode).toBe(204)
+      expect(response.headers['access-control-allow-origin']).toBe(
+        TEST_FRONTEND_URL
+      )
+      expect(response.headers['access-control-allow-credentials']).toBe('true')
+    }
+  )
+
+  it.each(routes)(
+    'OPTIONS %s includes PATCH and DELETE in allowed methods',
+    async (route) => {
+      const response = await app.inject({
+        method: 'OPTIONS',
+        url: route,
+        headers: {
+          origin: TEST_FRONTEND_URL,
+          'access-control-request-method': 'PATCH',
+        },
+      })
+
+      expect(response.statusCode).toBe(204)
+      const allowedMethods = response.headers[
+        'access-control-allow-methods'
+      ] as string
+      expect(allowedMethods).toContain('PATCH')
+      expect(allowedMethods).toContain('DELETE')
+    }
+  )
+
+  it('rejects non-preflight requests without x-api-key with 401', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plans',
+      headers: {
+        origin: TEST_FRONTEND_URL,
+      },
+    })
+
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns CORS headers on authenticated non-preflight requests', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plans',
+      headers: {
+        origin: TEST_FRONTEND_URL,
+        'x-api-key': TEST_API_KEY,
+      },
+    })
+
+    expect(response.headers['access-control-allow-origin']).toBe(
+      TEST_FRONTEND_URL
+    )
+    expect(response.headers['access-control-allow-credentials']).toBe('true')
+  })
+})


### PR DESCRIPTION
## Summary
- Skip OPTIONS preflight requests in the `onRequest` API key hook — browsers cannot send custom headers (`x-api-key`) on preflight, causing 401 rejections and `FST_ERR_REP_ALREADY_SENT` in Fastify 5
- Add `onRequest` and `onResponse` logging hooks with method, url, origin, API key presence, status code, CORS headers, and response time — so CORS failures are now visible in Railway logs
- Add 8 CORS integration tests (mocking production config with `isDev: false` and `apiKey` set) covering preflight on `/plans`, `/plans/:id/items`, `/plans/:id/participants`

## Test plan
- [x] 8 new CORS integration tests pass
- [x] All 126 existing tests pass
- [x] Typecheck clean
- [x] Lint clean
- [ ] Deploy to Railway and verify `/plans` preflight from `https://chillist-fe.pages.dev` succeeds
- [ ] Verify Railway logs show incoming request and response entries with CORS data

Closes #56

Made with [Cursor](https://cursor.com)