### PR TITLE
add DELETE /items/:itemId endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -571,6 +571,18 @@
       "def-16": {
         "type": "object",
         "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "DeleteItemResponse"
+      },
+      "def-17": {
+        "type": "object",
+        "properties": {
           "planId": {
             "type": "string",
             "format": "uuid"
@@ -653,7 +665,7 @@
         ],
         "title": "PlanWithItems"
       },
-      "def-17": {
+      "def-18": {
         "type": "object",
         "properties": {
           "participantId": {
@@ -714,14 +726,14 @@
         ],
         "title": "Participant"
       },
-      "def-18": {
+      "def-19": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-17"
+          "$ref": "#/components/schemas/def-18"
         },
         "title": "ParticipantList"
       },
-      "def-19": {
+      "def-20": {
         "type": "object",
         "properties": {
           "displayName": {
@@ -762,7 +774,7 @@
         ],
         "title": "CreateParticipantBody"
       },
-      "def-20": {
+      "def-21": {
         "type": "object",
         "properties": {
           "displayName": {
@@ -805,7 +817,7 @@
         },
         "title": "UpdateParticipantBody"
       },
-      "def-21": {
+      "def-22": {
         "type": "object",
         "properties": {
           "participantId": {
@@ -818,7 +830,7 @@
         ],
         "title": "ParticipantIdParam"
       },
-      "def-22": {
+      "def-23": {
         "type": "object",
         "properties": {
           "ok": {
@@ -977,7 +989,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-16"
+                  "$ref": "#/components/schemas/def-17"
                 }
               }
             }
@@ -1109,7 +1121,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-18"
+                  "$ref": "#/components/schemas/def-19"
                 }
               }
             }
@@ -1156,7 +1168,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-19"
+                "$ref": "#/components/schemas/def-20"
               }
             }
           }
@@ -1178,7 +1190,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-17"
+                  "$ref": "#/components/schemas/def-18"
                 }
               }
             }
@@ -1250,7 +1262,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-17"
+                  "$ref": "#/components/schemas/def-18"
                 }
               }
             }
@@ -1297,7 +1309,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-20"
+                "$ref": "#/components/schemas/def-21"
               }
             }
           }
@@ -1319,7 +1331,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-17"
+                  "$ref": "#/components/schemas/def-18"
                 }
               }
             }
@@ -1389,7 +1401,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-22"
+                  "$ref": "#/components/schemas/def-23"
                 }
               }
             }
@@ -1622,6 +1634,66 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item",
+        "tags": [
+          "items"
+        ],
+        "description": "Delete an item by its ID. Cascade delete handles related assignments.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "itemId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-16"
                 }
               }
             }

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,27 +16,31 @@ export interface AppDependencies {
 
 export interface BuildAppOptions {
   enableDocs?: boolean
+  logger?: false
 }
 
 export async function buildApp(
   deps: AppDependencies,
   options: BuildAppOptions = {}
 ) {
-  const { enableDocs = config.isDev } = options
+  const { enableDocs = config.isDev, logger } = options
 
   const fastify = Fastify({
-    logger: {
-      level: config.logLevel,
-      transport: config.isDev
-        ? {
-            target: 'pino-pretty',
-            options: {
-              translateTime: 'HH:MM:ss Z',
-              ignore: 'pid,hostname',
-            },
-          }
-        : undefined,
-    },
+    logger:
+      logger === false
+        ? false
+        : {
+            level: config.logLevel,
+            transport: config.isDev
+              ? {
+                  target: 'pino-pretty',
+                  options: {
+                    translateTime: 'HH:MM:ss Z',
+                    ignore: 'pid,hostname',
+                  },
+                }
+              : undefined,
+          },
   })
 
   fastify.decorate('db', deps.db)

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -21,6 +21,7 @@ import {
   createItemBodySchema,
   updateItemBodySchema,
   itemIdParamSchema,
+  deleteItemResponseSchema,
 } from './item.schema.js'
 import {
   participantSchema,
@@ -48,6 +49,7 @@ const schemas = [
   createItemBodySchema,
   updateItemBodySchema,
   itemIdParamSchema,
+  deleteItemResponseSchema,
   planWithItemsSchema,
   participantSchema,
   participantListSchema,

--- a/src/schemas/item.schema.ts
+++ b/src/schemas/item.schema.ts
@@ -88,3 +88,12 @@ export const itemIdParamSchema = {
   },
   required: ['itemId'],
 } as const
+
+export const deleteItemResponseSchema = {
+  $id: 'DeleteItemResponse',
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean' },
+  },
+  required: ['ok'],
+} as const

--- a/tests/integration/cors.test.ts
+++ b/tests/integration/cors.test.ts
@@ -24,7 +24,7 @@ describe('CORS Preflight', () => {
   beforeAll(async () => {
     const { buildApp } = await import('../../src/app.js')
     const db = await setupTestDatabase()
-    app = await buildApp({ db })
+    app = await buildApp({ db }, { logger: false })
   })
 
   afterAll(async () => {

--- a/tests/integration/health.test.ts
+++ b/tests/integration/health.test.ts
@@ -8,7 +8,7 @@ describe('Health Route', () => {
 
   beforeAll(async () => {
     const db = await setupTestDatabase()
-    app = await buildApp({ db })
+    app = await buildApp({ db }, { logger: false })
   })
 
   afterAll(async () => {

--- a/tests/integration/participants.test.ts
+++ b/tests/integration/participants.test.ts
@@ -14,7 +14,7 @@ describe('Participants Route', () => {
 
   beforeAll(async () => {
     const db = await setupTestDatabase()
-    app = await buildApp({ db })
+    app = await buildApp({ db }, { logger: false })
   })
 
   afterAll(async () => {

--- a/tests/integration/plans.test.ts
+++ b/tests/integration/plans.test.ts
@@ -14,7 +14,7 @@ describe('Plans Route', () => {
 
   beforeAll(async () => {
     const db = await setupTestDatabase()
-    app = await buildApp({ db })
+    app = await buildApp({ db }, { logger: false })
   })
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
- Implement `DELETE /items/:itemId` endpoint that verifies item existence and returns `{ ok: true }` on success (cascade delete handles related assignments)
- Add `deleteItemResponseSchema` to the OpenAPI schema registry
- Disable Fastify logger in integration tests via new `logger: false` build option to reduce test output noise

## Test plan
- [x] Integration tests: success (200), not found (404), invalid UUID (400), does not affect sibling items
- [x] All 130 tests pass (typecheck, lint, vitest)
- [x] OpenAPI spec regenerated

Closes #30

Made with [Cursor](https://cursor.com)