### PR TITLE
feat: add PATCH /plans/:planId endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1204,6 +1204,85 @@
           }
         }
       },
+      "patch": {
+        "summary": "Update a plan",
+        "tags": [
+          "plans"
+        ],
+        "description": "Update an existing plan by its ID",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-10"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-5"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "summary": "Delete a plan",
         "tags": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Add PATCH /plans/:planId route handler to update existing plans
- Add 12 integration tests covering happy paths, validation, 404, and persistence
- Regenerate OpenAPI spec with new endpoint
- Bump version to 1.2.0

Closes #24

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 170 tests pass (56 plans, 48 items, 33 participants, 10+8 unit, 8 CORS, 6 e2e, 1 health)
- [x] OpenAPI spec regenerated

Made with [Cursor](https://cursor.com)