### PR TITLE
feat: add invite token share links for plan sharing

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -721,6 +721,10 @@
             "type": "string",
             "nullable": true
           },
+          "inviteToken": {
+            "type": "string",
+            "nullable": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -949,6 +953,163 @@
           "participants"
         ],
         "title": "PlanWithDetails"
+      },
+      "def-26": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "inviteToken": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          }
+        },
+        "required": [
+          "planId",
+          "inviteToken"
+        ],
+        "title": "InviteParams"
+      },
+      "def-27": {
+        "type": "object",
+        "properties": {
+          "participantId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "participant",
+              "viewer"
+            ]
+          }
+        },
+        "required": [
+          "participantId",
+          "role"
+        ],
+        "title": "InviteParticipant"
+      },
+      "def-28": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/def-27"
+        },
+        "title": "InviteParticipantList"
+      },
+      "def-29": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "archived"
+            ]
+          },
+          "location": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-4"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "items": {
+            "$ref": "#/components/schemas/def-14"
+          },
+          "participants": {
+            "$ref": "#/components/schemas/def-28"
+          }
+        },
+        "required": [
+          "planId",
+          "title",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "items",
+          "participants"
+        ],
+        "title": "InvitePlanResponse"
+      },
+      "def-30": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "participantId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "planId",
+          "participantId"
+        ],
+        "title": "RegenerateTokenParams"
+      },
+      "def-31": {
+        "type": "object",
+        "properties": {
+          "inviteToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inviteToken"
+        ],
+        "title": "RegenerateTokenResponse"
       }
     }
   },
@@ -1977,6 +2138,149 @@
           }
         }
       }
+    },
+    "/plans/{planId}/invite/{inviteToken}": {
+      "get": {
+        "summary": "Access a plan via invite link",
+        "tags": [
+          "invite"
+        ],
+        "description": "Public endpoint. Validates the invite token and returns plan data with items. Participant PII is stripped — only displayName and role are included.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            },
+            "in": "path",
+            "name": "inviteToken",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-29"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans/{planId}/participants/{participantId}/regenerate-token": {
+      "post": {
+        "summary": "Regenerate invite token for a participant",
+        "tags": [
+          "invite"
+        ],
+        "description": "Generates a new invite token for the specified participant, invalidating the previous one. Requires API key (owner action).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "participantId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-31"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [
@@ -1995,6 +2299,10 @@
     {
       "name": "items",
       "description": "Item management"
+    },
+    {
+      "name": "invite",
+      "description": "Invite link access"
     }
   ]
 }

--- a/drizzle/0003_amusing_devos.sql
+++ b/drizzle/0003_amusing_devos.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "participants" ADD COLUMN "invite_token" varchar(64);--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_invite_token_unique" UNIQUE("invite_token");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,399 @@
+{
+  "id": "d707c6f6-047b-4ac4-a8ac-a42a45f20fee",
+  "prevId": "56e83c07-aca8-4176-abc4-88c618077b4d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_participant_id": {
+          "name": "assigned_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_assigned_participant_id_participants_participant_id_fk": {
+          "name": "items_assigned_participant_id_participants_participant_id_fk",
+          "tableFrom": "items",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "assigned_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1770895169937,
       "tag": "0002_mute_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1771227877482,
+      "tag": "0003_amusing_devos",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { healthRoutes } from './routes/health.route.js'
 import { plansRoutes } from './routes/plans.route.js'
 import { itemsRoutes } from './routes/items.route.js'
 import { participantsRoutes } from './routes/participants.route.js'
+import { inviteRoutes } from './routes/invite.route.js'
 import { Database } from './db/index.js'
 
 export interface AppDependencies {
@@ -61,6 +62,7 @@ export async function buildApp(
           { name: 'plans', description: 'Plan management' },
           { name: 'participants', description: 'Participant management' },
           { name: 'items', description: 'Item management' },
+          { name: 'invite', description: 'Invite link access' },
         ],
         components: {
           securitySchemes: {
@@ -110,6 +112,11 @@ export async function buildApp(
       return
     }
 
+    const invitePattern = /^\/plans\/[^/]+\/invite\/[^/]+$/
+    if (invitePattern.test(request.url)) {
+      return
+    }
+
     if (config.apiKey && request.headers['x-api-key'] !== config.apiKey) {
       return reply.status(401).send({ message: 'Unauthorized' })
     }
@@ -136,6 +143,7 @@ export async function buildApp(
   await fastify.register(plansRoutes)
   await fastify.register(participantsRoutes)
   await fastify.register(itemsRoutes)
+  await fastify.register(inviteRoutes)
 
   return fastify
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -86,6 +86,7 @@ export const participants = pgTable('participants', {
   role: participantRoleEnum('role').default('participant').notNull(),
   avatarUrl: text('avatar_url'),
   contactEmail: varchar('contact_email', { length: 255 }),
+  inviteToken: varchar('invite_token', { length: 64 }).unique(),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()
     .notNull(),

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,6 +1,11 @@
+import { randomBytes } from 'node:crypto'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import { plans, participants, items, type Location } from './schema.js'
+
+function generateInviteToken(): string {
+  return randomBytes(32).toString('hex')
+}
 
 const connectionString = process.env.DATABASE_URL
 
@@ -55,6 +60,7 @@ async function seed() {
         role: 'owner',
         avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=alex',
         contactEmail: 'alex@example.com',
+        inviteToken: generateInviteToken(),
       })
       .returning()
 
@@ -73,6 +79,7 @@ async function seed() {
         role: 'participant',
         avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=sarah',
         contactEmail: 'sarah@example.com',
+        inviteToken: generateInviteToken(),
       })
       .returning()
 
@@ -87,6 +94,7 @@ async function seed() {
         role: 'participant',
         avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=mike',
         contactEmail: 'mike@example.com',
+        inviteToken: generateInviteToken(),
       })
       .returning()
 
@@ -167,6 +175,394 @@ async function seed() {
     console.log('Participants: 3')
     console.log('Items: 6')
     console.log('---------------------------\n')
+
+    const negevLocation: Location = {
+      locationId: crypto.randomUUID(),
+      name: 'Negev Desert',
+      country: 'Israel',
+      region: 'Southern District',
+      city: 'Mitzpe Ramon',
+      latitude: 30.6103,
+      longitude: 34.8015,
+      timezone: 'Asia/Jerusalem',
+    }
+
+    const [negevPlan] = await db
+      .insert(plans)
+      .values({
+        title: 'Desert Camping — Negev Family Trip',
+        description:
+          '5 adults and 5 toddlers camping in the Negev desert. ' +
+          'Kid-friendly activities, short hikes, and stargazing. ' +
+          'Extra shade structures and water supply are essential for the little ones.',
+        status: 'active',
+        visibility: 'public',
+        location: negevLocation,
+        startDate: new Date('2026-04-03T08:00:00+03:00'),
+        endDate: new Date('2026-04-04T16:00:00+03:00'),
+        tags: ['camping', 'desert', 'negev', 'family', 'toddlers'],
+      })
+      .returning()
+
+    console.log('Created Negev plan:', negevPlan.planId)
+
+    const [negevOwner] = await db
+      .insert(participants)
+      .values({
+        planId: negevPlan.planId,
+        name: 'Dan',
+        lastName: 'Levy',
+        contactPhone: '+972-50-111-2222',
+        displayName: 'Dan L.',
+        role: 'owner',
+        avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=dan',
+        contactEmail: 'dan@example.com',
+        inviteToken: generateInviteToken(),
+      })
+      .returning()
+
+    await db.update(plans).set({ ownerParticipantId: negevOwner.participantId })
+
+    const [negevP1] = await db
+      .insert(participants)
+      .values({
+        planId: negevPlan.planId,
+        name: 'Yael',
+        lastName: 'Cohen',
+        contactPhone: '+972-52-222-3333',
+        displayName: 'Yael C.',
+        role: 'participant',
+        avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=yael',
+        contactEmail: 'yael@example.com',
+        inviteToken: generateInviteToken(),
+      })
+      .returning()
+
+    const [negevP2] = await db
+      .insert(participants)
+      .values({
+        planId: negevPlan.planId,
+        name: 'Omer',
+        lastName: 'Ben-David',
+        contactPhone: '+972-54-333-4444',
+        displayName: 'Omer B.',
+        role: 'participant',
+        avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=omer',
+        contactEmail: 'omer@example.com',
+        inviteToken: generateInviteToken(),
+      })
+      .returning()
+
+    const [negevP3] = await db
+      .insert(participants)
+      .values({
+        planId: negevPlan.planId,
+        name: 'Noa',
+        lastName: 'Shapira',
+        contactPhone: '+972-53-444-5555',
+        displayName: 'Noa S.',
+        role: 'participant',
+        avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=noa',
+        contactEmail: 'noa@example.com',
+        inviteToken: generateInviteToken(),
+      })
+      .returning()
+
+    const [negevP4] = await db
+      .insert(participants)
+      .values({
+        planId: negevPlan.planId,
+        name: 'Eitan',
+        lastName: 'Mizrahi',
+        contactPhone: '+972-58-555-6666',
+        displayName: 'Eitan M.',
+        role: 'participant',
+        avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=eitan',
+        contactEmail: 'eitan@example.com',
+        inviteToken: generateInviteToken(),
+      })
+      .returning()
+
+    console.log(
+      'Created Negev participants:',
+      negevOwner.participantId,
+      negevP1.participantId,
+      negevP2.participantId,
+      negevP3.participantId,
+      negevP4.participantId
+    )
+
+    await db.insert(items).values([
+      {
+        planId: negevPlan.planId,
+        name: 'Family Tent (6-person)',
+        category: 'equipment',
+        quantity: 3,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'UV-resistant with good ventilation for desert heat',
+        assignedParticipantId: negevOwner.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Pop-up Shade Canopy',
+        category: 'equipment',
+        quantity: 2,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Essential shade for toddlers during daytime',
+        assignedParticipantId: negevP1.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Sleeping Bags (Adult)',
+        category: 'equipment',
+        quantity: 5,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Desert nights get cold — rated for 5°C',
+        assignedParticipantId: negevP2.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Toddler Sleeping Bags',
+        category: 'equipment',
+        quantity: 5,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Small-size sleeping bags for the kids',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Camping Mattresses / Pads',
+        category: 'equipment',
+        quantity: 10,
+        unit: 'pcs',
+        status: 'pending',
+        notes: '5 adult + 5 toddler pads',
+        assignedParticipantId: negevP3.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Portable Camping Stove',
+        category: 'equipment',
+        quantity: 2,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Gas burner with wind guard',
+        assignedParticipantId: negevOwner.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Headlamps / Flashlights',
+        category: 'equipment',
+        quantity: 7,
+        unit: 'pcs',
+        status: 'pending',
+        notes: '5 for adults + 2 extra kid-safe lanterns',
+        assignedParticipantId: negevP4.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'First Aid Kit',
+        category: 'equipment',
+        quantity: 2,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Include child-safe meds, sunburn cream, insect repellent',
+        assignedParticipantId: negevP1.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Portable High Chairs',
+        category: 'equipment',
+        quantity: 3,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Collapsible camping high chairs for toddlers',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Cooler Box (Large)',
+        category: 'equipment',
+        quantity: 2,
+        unit: 'pcs',
+        status: 'pending',
+        notes: '60L coolers — one for food, one for drinks',
+        assignedParticipantId: negevP2.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Folding Camping Table',
+        category: 'equipment',
+        quantity: 2,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'For cooking and eating',
+        assignedParticipantId: negevP3.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Camping Chairs',
+        category: 'equipment',
+        quantity: 5,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Foldable chairs for adults',
+        assignedParticipantId: negevP4.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Sunscreen SPF 50+',
+        category: 'equipment',
+        quantity: 5,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Baby-safe sunscreen for toddlers, regular for adults',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Wide-brim Sun Hats',
+        category: 'equipment',
+        quantity: 10,
+        unit: 'pcs',
+        status: 'pending',
+        notes: '5 adult + 5 toddler hats — mandatory for desert',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Portable Toilet / Potty',
+        category: 'equipment',
+        quantity: 1,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'For the toddlers',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Trash Bags',
+        category: 'equipment',
+        quantity: 1,
+        unit: 'pack',
+        status: 'pending',
+        notes: 'Leave no trace — pack out all waste',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Jerry Can (Water)',
+        category: 'equipment',
+        quantity: 3,
+        unit: 'pcs',
+        status: 'pending',
+        notes: '20L each — total 60L for drinking/cooking/washing',
+        assignedParticipantId: negevOwner.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Baby Wipes',
+        category: 'equipment',
+        quantity: 5,
+        unit: 'pack',
+        status: 'pending',
+        notes: 'Essential with toddlers in the desert',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Diapers',
+        category: 'equipment',
+        quantity: 2,
+        unit: 'pack',
+        status: 'pending',
+        notes: 'For the younger toddlers if needed',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Drinking Water (Bottles)',
+        category: 'food',
+        quantity: 30,
+        unit: 'l',
+        status: 'pending',
+        notes: 'Extra water supply — desert hydration is critical',
+        assignedParticipantId: negevP2.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Snack Packs for Kids',
+        category: 'food',
+        quantity: 15,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Crackers, fruit pouches, cheese sticks',
+        assignedParticipantId: negevP1.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Pita Bread',
+        category: 'food',
+        quantity: 3,
+        unit: 'pack',
+        status: 'pending',
+        notes: 'For hummus and campfire meals',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Hummus',
+        category: 'food',
+        quantity: 4,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Keep in cooler',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Canned Beans & Corn',
+        category: 'food',
+        quantity: 6,
+        unit: 'pcs',
+        status: 'pending',
+        notes: 'Easy campfire sides',
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Fruit (Apples, Bananas)',
+        category: 'food',
+        quantity: 3,
+        unit: 'kg',
+        status: 'pending',
+        notes: 'Toddler-friendly snacks',
+        assignedParticipantId: negevP3.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Eggs',
+        category: 'food',
+        quantity: 2,
+        unit: 'pack',
+        status: 'pending',
+        notes: '30-count packs for breakfast',
+        assignedParticipantId: negevP4.participantId,
+      },
+      {
+        planId: negevPlan.planId,
+        name: 'Sausages / Hot Dogs',
+        category: 'food',
+        quantity: 2,
+        unit: 'pack',
+        status: 'pending',
+        notes: 'Campfire dinner',
+        assignedParticipantId: negevOwner.participantId,
+      },
+    ])
+
+    console.log('Created 27 items for Negev plan')
+
+    console.log('\n--- Negev Camping Plan Created ---')
+    console.log('Plan ID:', negevPlan.planId)
+    console.log('Title:', negevPlan.title)
+    console.log('Owner:', negevOwner.name, negevOwner.lastName)
+    console.log('Participants: 5')
+    console.log('Items: 27 (19 equipment + 8 food)')
+    console.log('----------------------------------\n')
 
     console.log('Seeding completed successfully')
   } catch (error) {

--- a/src/routes/invite.route.ts
+++ b/src/routes/invite.route.ts
@@ -1,0 +1,180 @@
+import { randomBytes } from 'node:crypto'
+import { FastifyInstance } from 'fastify'
+import { eq, and } from 'drizzle-orm'
+import { participants } from '../db/schema.js'
+import * as schema from '../db/schema.js'
+
+function generateInviteToken(): string {
+  return randomBytes(32).toString('hex')
+}
+
+export async function inviteRoutes(fastify: FastifyInstance) {
+  fastify.get<{ Params: { planId: string; inviteToken: string } }>(
+    '/plans/:planId/invite/:inviteToken',
+    {
+      schema: {
+        tags: ['invite'],
+        summary: 'Access a plan via invite link',
+        description:
+          'Public endpoint. Validates the invite token and returns plan data with items. Participant PII is stripped — only displayName and role are included.',
+        params: { $ref: 'InviteParams#' },
+        response: {
+          200: { $ref: 'InvitePlanResponse#' },
+          404: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { planId, inviteToken } = request.params
+
+      try {
+        const [participant] = await fastify.db
+          .select({ participantId: participants.participantId })
+          .from(participants)
+          .where(
+            and(
+              eq(participants.planId, planId),
+              eq(participants.inviteToken, inviteToken)
+            )
+          )
+
+        if (!participant) {
+          return reply.status(404).send({
+            message: 'Invalid or expired invite link',
+          })
+        }
+
+        const plan = await fastify.db.query.plans.findFirst({
+          where: eq(schema.plans.planId, planId),
+          with: {
+            items: true,
+            participants: true,
+          },
+        })
+
+        if (!plan) {
+          return reply.status(404).send({
+            message: 'Plan not found',
+          })
+        }
+
+        const filteredParticipants = plan.participants.map((p) => ({
+          participantId: p.participantId,
+          displayName: p.displayName,
+          role: p.role,
+        }))
+
+        request.log.info(
+          { planId, invitedParticipantId: participant.participantId },
+          'Plan accessed via invite link'
+        )
+
+        return {
+          planId: plan.planId,
+          title: plan.title,
+          description: plan.description,
+          status: plan.status,
+          location: plan.location,
+          startDate: plan.startDate,
+          endDate: plan.endDate,
+          tags: plan.tags,
+          createdAt: plan.createdAt,
+          updatedAt: plan.updatedAt,
+          items: plan.items,
+          participants: filteredParticipants,
+        }
+      } catch (error) {
+        request.log.error(
+          { err: error, planId },
+          'Failed to access plan via invite'
+        )
+
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
+
+        if (isConnectionError) {
+          return reply.status(503).send({
+            message: 'Database connection error',
+          })
+        }
+
+        return reply.status(500).send({
+          message: 'Failed to access plan',
+        })
+      }
+    }
+  )
+
+  fastify.post<{ Params: { planId: string; participantId: string } }>(
+    '/plans/:planId/participants/:participantId/regenerate-token',
+    {
+      schema: {
+        tags: ['invite'],
+        summary: 'Regenerate invite token for a participant',
+        description:
+          'Generates a new invite token for the specified participant, invalidating the previous one. Requires API key (owner action).',
+        params: { $ref: 'RegenerateTokenParams#' },
+        response: {
+          200: { $ref: 'RegenerateTokenResponse#' },
+          404: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { planId, participantId } = request.params
+
+      try {
+        const [existing] = await fastify.db
+          .select({
+            participantId: participants.participantId,
+            planId: participants.planId,
+          })
+          .from(participants)
+          .where(eq(participants.participantId, participantId))
+
+        if (!existing || existing.planId !== planId) {
+          return reply.status(404).send({
+            message: 'Participant not found in this plan',
+          })
+        }
+
+        const newToken = generateInviteToken()
+
+        await fastify.db
+          .update(participants)
+          .set({ inviteToken: newToken, updatedAt: new Date() })
+          .where(eq(participants.participantId, participantId))
+
+        request.log.info({ participantId, planId }, 'Invite token regenerated')
+
+        return { inviteToken: newToken }
+      } catch (error) {
+        request.log.error(
+          { err: error, participantId, planId },
+          'Failed to regenerate invite token'
+        )
+
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
+
+        if (isConnectionError) {
+          return reply.status(503).send({
+            message: 'Database connection error',
+          })
+        }
+
+        return reply.status(500).send({
+          message: 'Failed to regenerate invite token',
+        })
+      }
+    }
+  )
+}

--- a/src/routes/participants.route.ts
+++ b/src/routes/participants.route.ts
@@ -1,6 +1,11 @@
+import { randomBytes } from 'node:crypto'
 import { FastifyInstance } from 'fastify'
 import { eq } from 'drizzle-orm'
 import { participants, plans } from '../db/schema.js'
+
+function generateInviteToken(): string {
+  return randomBytes(32).toString('hex')
+}
 
 interface CreateParticipantBody {
   name: string
@@ -128,6 +133,7 @@ export async function participantsRoutes(fastify: FastifyInstance) {
           .values({
             planId,
             ...request.body,
+            inviteToken: generateInviteToken(),
           })
           .returning()
 

--- a/src/routes/plans.route.ts
+++ b/src/routes/plans.route.ts
@@ -1,7 +1,12 @@
+import { randomBytes } from 'node:crypto'
 import { FastifyInstance } from 'fastify'
 import { eq } from 'drizzle-orm'
 import { plans, participants, NewPlan } from '../db/schema.js'
 import * as schema from '../db/schema.js'
+
+function generateInviteToken(): string {
+  return randomBytes(32).toString('hex')
+}
 
 interface OwnerBody {
   name: string
@@ -145,6 +150,7 @@ export async function plansRoutes(fastify: FastifyInstance) {
               role: 'owner',
               avatarUrl: owner.avatarUrl,
               contactEmail: owner.contactEmail,
+              inviteToken: generateInviteToken(),
             })
             .returning()
 
@@ -163,6 +169,7 @@ export async function plansRoutes(fastify: FastifyInstance) {
                   role: p.role ?? ('participant' as const),
                   avatarUrl: p.avatarUrl,
                   contactEmail: p.contactEmail,
+                  inviteToken: generateInviteToken(),
                 }))
               )
               .returning()

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -33,6 +33,14 @@ import {
   participantIdParamSchema,
   deleteParticipantResponseSchema,
 } from './participant.schema.js'
+import {
+  inviteParamsSchema,
+  inviteParticipantSchema,
+  inviteParticipantListSchema,
+  invitePlanResponseSchema,
+  regenerateTokenParamsSchema,
+  regenerateTokenResponseSchema,
+} from './invite.schema.js'
 
 const schemas = [
   errorResponseSchema,
@@ -61,6 +69,12 @@ const schemas = [
   participantIdParamSchema,
   deleteParticipantResponseSchema,
   planWithDetailsSchema,
+  inviteParamsSchema,
+  inviteParticipantSchema,
+  inviteParticipantListSchema,
+  invitePlanResponseSchema,
+  regenerateTokenParamsSchema,
+  regenerateTokenResponseSchema,
 ]
 
 export function registerSchemas(fastify: FastifyInstance) {
@@ -74,3 +88,4 @@ export * from './health.schema.js'
 export * from './plan.schema.js'
 export * from './item.schema.js'
 export * from './participant.schema.js'
+export * from './invite.schema.js'

--- a/src/schemas/invite.schema.ts
+++ b/src/schemas/invite.schema.ts
@@ -1,0 +1,75 @@
+export const inviteParamsSchema = {
+  $id: 'InviteParams',
+  type: 'object',
+  properties: {
+    planId: { type: 'string', format: 'uuid' },
+    inviteToken: { type: 'string', minLength: 1, maxLength: 64 },
+  },
+  required: ['planId', 'inviteToken'],
+} as const
+
+export const inviteParticipantSchema = {
+  $id: 'InviteParticipant',
+  type: 'object',
+  properties: {
+    participantId: { type: 'string', format: 'uuid' },
+    displayName: { type: 'string', nullable: true },
+    role: { type: 'string', enum: ['owner', 'participant', 'viewer'] },
+  },
+  required: ['participantId', 'role'],
+} as const
+
+export const inviteParticipantListSchema = {
+  $id: 'InviteParticipantList',
+  type: 'array',
+  items: { $ref: 'InviteParticipant#' },
+} as const
+
+export const invitePlanResponseSchema = {
+  $id: 'InvitePlanResponse',
+  type: 'object',
+  properties: {
+    planId: { type: 'string', format: 'uuid' },
+    title: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    status: { type: 'string', enum: ['draft', 'active', 'archived'] },
+    location: {
+      oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
+    },
+    startDate: { type: 'string', format: 'date-time', nullable: true },
+    endDate: { type: 'string', format: 'date-time', nullable: true },
+    tags: { type: 'array', items: { type: 'string' }, nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+    items: { $ref: 'ItemList#' },
+    participants: { $ref: 'InviteParticipantList#' },
+  },
+  required: [
+    'planId',
+    'title',
+    'status',
+    'createdAt',
+    'updatedAt',
+    'items',
+    'participants',
+  ],
+} as const
+
+export const regenerateTokenParamsSchema = {
+  $id: 'RegenerateTokenParams',
+  type: 'object',
+  properties: {
+    planId: { type: 'string', format: 'uuid' },
+    participantId: { type: 'string', format: 'uuid' },
+  },
+  required: ['planId', 'participantId'],
+} as const
+
+export const regenerateTokenResponseSchema = {
+  $id: 'RegenerateTokenResponse',
+  type: 'object',
+  properties: {
+    inviteToken: { type: 'string' },
+  },
+  required: ['inviteToken'],
+} as const

--- a/src/schemas/participant.schema.ts
+++ b/src/schemas/participant.schema.ts
@@ -11,6 +11,7 @@ export const participantSchema = {
     role: { type: 'string', enum: ['owner', 'participant', 'viewer'] },
     avatarUrl: { type: 'string', nullable: true },
     contactEmail: { type: 'string', nullable: true },
+    inviteToken: { type: 'string', nullable: true },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
   },

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import { migrate } from 'drizzle-orm/postgres-js/migrator'
 import postgres from 'postgres'
@@ -112,6 +113,7 @@ export async function seedTestParticipants(
       | 'owner'
       | 'participant'
       | 'viewer',
+    inviteToken: randomBytes(32).toString('hex'),
   }))
 
   const inserted = await testDb

--- a/tests/integration/invite.test.ts
+++ b/tests/integration/invite.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  seedTestParticipants,
+  seedTestPlans,
+  setupTestDatabase,
+  seedTestItems,
+} from '../helpers/db.js'
+
+describe('Invite Route', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    app = await buildApp({ db }, { logger: false })
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('GET /plans/:planId/invite/:inviteToken', () => {
+    it('returns plan data with filtered participants when token is valid', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 3)
+      await seedTestItems(plan.planId, 2)
+
+      const token = participants[1].inviteToken!
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${token}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const result = response.json()
+      expect(result.planId).toBe(plan.planId)
+      expect(result.title).toBe('Test Plan 1')
+      expect(result.items).toHaveLength(2)
+      expect(result.participants).toHaveLength(3)
+    })
+
+    it('returns only displayName and role for participants (no PII)', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 2)
+
+      const token = participants[0].inviteToken!
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${token}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const result = response.json()
+      const participant = result.participants[0]
+
+      expect(participant.participantId).toBeDefined()
+      expect(participant.displayName).toBeDefined()
+      expect(participant.role).toBeDefined()
+
+      expect(participant.name).toBeUndefined()
+      expect(participant.lastName).toBeUndefined()
+      expect(participant.contactPhone).toBeUndefined()
+      expect(participant.contactEmail).toBeUndefined()
+      expect(participant.avatarUrl).toBeUndefined()
+      expect(participant.inviteToken).toBeUndefined()
+    })
+
+    it('does not expose ownerParticipantId in response', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${participants[0].inviteToken}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const result = response.json()
+      expect(result.ownerParticipantId).toBeUndefined()
+      expect(result.visibility).toBeUndefined()
+    })
+
+    it('returns 404 when invite token is invalid', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/invalid-token-that-does-not-exist`,
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        message: 'Invalid or expired invite link',
+      })
+    })
+
+    it('returns 404 when token belongs to a different plan', async () => {
+      const [plan1, plan2] = await seedTestPlans(2)
+      const participants1 = await seedTestParticipants(plan1.planId, 1)
+      await seedTestParticipants(plan2.planId, 1)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan2.planId}/invite/${participants1[0].inviteToken}`,
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        message: 'Invalid or expired invite link',
+      })
+    })
+
+    it('does not require API key header', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${participants[0].inviteToken}`,
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('returns 400 for invalid planId format', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/plans/not-a-uuid/invite/some-token',
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe('POST /plans/:planId/participants/:participantId/regenerate-token', () => {
+    it('generates a new token and returns it', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 2)
+      const participant = participants[1]
+      const oldToken = participant.inviteToken
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/participants/${participant.participantId}/regenerate-token`,
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const result = response.json()
+      expect(result.inviteToken).toBeDefined()
+      expect(typeof result.inviteToken).toBe('string')
+      expect(result.inviteToken).toHaveLength(64)
+      expect(result.inviteToken).not.toBe(oldToken)
+    })
+
+    it('invalidates the old token after regeneration', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 1)
+      const oldToken = participants[0].inviteToken!
+
+      const regenResponse = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/participants/${participants[0].participantId}/regenerate-token`,
+      })
+      const newToken = regenResponse.json().inviteToken
+
+      const oldTokenResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${oldToken}`,
+      })
+      expect(oldTokenResponse.statusCode).toBe(404)
+
+      const newTokenResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${newToken}`,
+      })
+      expect(newTokenResponse.statusCode).toBe(200)
+    })
+
+    it('returns 404 when participant does not exist', async () => {
+      const [plan] = await seedTestPlans(1)
+      const nonExistentId = '00000000-0000-0000-0000-000000000000'
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/participants/${nonExistentId}/regenerate-token`,
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        message: 'Participant not found in this plan',
+      })
+    })
+
+    it('returns 404 when participant belongs to a different plan', async () => {
+      const [plan1, plan2] = await seedTestPlans(2)
+      const participants1 = await seedTestParticipants(plan1.planId, 1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan2.planId}/participants/${participants1[0].participantId}/regenerate-token`,
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        message: 'Participant not found in this plan',
+      })
+    })
+
+    it('returns 400 for invalid UUID params', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/bad-uuid/participants/also-bad/regenerate-token',
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe('Invite token generation on participant creation', () => {
+    it('generates inviteToken when creating a participant via POST', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/participants`,
+        payload: {
+          name: 'Test',
+          lastName: 'User',
+          contactPhone: '+1-555-999-0000',
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const participant = response.json()
+      expect(participant.inviteToken).toBeDefined()
+      expect(typeof participant.inviteToken).toBe('string')
+      expect(participant.inviteToken).toHaveLength(64)
+    })
+
+    it('generates unique inviteTokens for each participant', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response1 = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/participants`,
+        payload: {
+          name: 'User',
+          lastName: 'One',
+          contactPhone: '+1-555-111-0001',
+        },
+      })
+
+      const response2 = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/participants`,
+        payload: {
+          name: 'User',
+          lastName: 'Two',
+          contactPhone: '+1-555-111-0002',
+        },
+      })
+
+      const token1 = response1.json().inviteToken
+      const token2 = response2.json().inviteToken
+      expect(token1).not.toBe(token2)
+    })
+
+    it('generates inviteTokens in POST /plans/with-owner', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/with-owner',
+        payload: {
+          title: 'Test Plan',
+          owner: {
+            name: 'Owner',
+            lastName: 'Test',
+            contactPhone: '+1-555-000-0001',
+          },
+          participants: [
+            {
+              name: 'Guest',
+              lastName: 'One',
+              contactPhone: '+1-555-000-0002',
+            },
+          ],
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const result = response.json()
+      expect(result.participants).toHaveLength(2)
+
+      const ownerParticipant = result.participants.find(
+        (p: { role: string }) => p.role === 'owner'
+      )
+      const guestParticipant = result.participants.find(
+        (p: { role: string }) => p.role === 'participant'
+      )
+
+      expect(ownerParticipant.inviteToken).toBeDefined()
+      expect(ownerParticipant.inviteToken).toHaveLength(64)
+      expect(guestParticipant.inviteToken).toBeDefined()
+      expect(guestParticipant.inviteToken).toHaveLength(64)
+      expect(ownerParticipant.inviteToken).not.toBe(
+        guestParticipant.inviteToken
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add per-participant invite tokens and a public invite endpoint for sharing plans via URL without requiring API key authentication
- Each participant gets a unique 64-char crypto-random token on creation
- Public `GET /plans/:planId/invite/:inviteToken` returns plan data with PII stripped from participants (only displayName + role)
- Owner can rotate tokens via `POST /plans/:planId/participants/:participantId/regenerate-token`

## Changes

- `inviteToken` column (nullable, unique) added to `participants` table with Drizzle migration
- Token auto-generated in `POST /plans/:planId/participants` and `POST /plans/with-owner`
- New `src/routes/invite.route.ts` and `src/schemas/invite.schema.ts`
- Invite GET route exempt from API key middleware in `src/app.ts`
- Updated participant response schema, seed data, test helpers, OpenAPI spec
- Version bumped to 1.3.0

## Test plan

- [x] 15 new integration tests covering:
  - Valid invite returns plan with filtered participants (no PII)
  - Invalid/wrong-plan tokens return 404
  - Token regeneration invalidates old token
  - Token auto-generation on participant and plan creation
  - Invite endpoint accessible without API key
- [x] All 185 tests pass (170 existing + 15 new)
- [x] Typecheck and lint pass
- [x] Non-breaking: additive field + new endpoints only

Closes #65


Made with [Cursor](https://cursor.com)