### PR TITLE
chore: add migration step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run production migrations
+        run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PUBLIC }}
+
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 


### PR DESCRIPTION
## Summary

- Add `npm run db:migrate` step to the deploy workflow, running against production DB before deploying new code to Railway
- Requires `DATABASE_URL_PUBLIC` secret (already added)

## Why

Previously, database migrations had to be run manually before each deploy. If forgotten, new code would crash on missing columns/tables. This automates it.

## Flow

```
merge to main → install deps → run migrations on prod DB → deploy to Railway
```


Made with [Cursor](https://cursor.com)