### PR TITLE
feat: add Supabase JWT verification and GET /auth/me endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ DATABASE_URL_PUBLIC=
 FRONTEND_URL=http://localhost:5173
 # API key for request authentication (generate a strong random string for production)
 API_KEY=
+
+# Supabase Auth
+# Project URL from Supabase dashboard (Settings > API)
+# Backend uses this to fetch JWKS public keys for JWT verification
+SUPABASE_URL=

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,6 +11,11 @@
         "type": "apiKey",
         "name": "x-api-key",
         "in": "header"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     },
     "schemas": {
@@ -2281,6 +2286,51 @@
           }
         }
       }
+    },
+    "/auth/me": {
+      "get": {
+        "summary": "Get current user from JWT",
+        "tags": [
+          "auth"
+        ],
+        "description": "Returns the authenticated user identity extracted from the JWT. Returns 401 if no valid JWT is provided.",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "email",
+                        "role"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [
@@ -2303,6 +2353,10 @@
     {
       "name": "invite",
       "description": "Invite link access"
+    },
+    {
+      "name": "auth",
+      "description": "Authentication"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "chillist-be",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chillist-be",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "dependencies": {
         "@fastify/cors": "11.0.0",
         "@fastify/swagger": "9.4.2",
         "@fastify/swagger-ui": "5.2.1",
         "drizzle-orm": "0.45.1",
         "fastify": "5.2.1",
+        "fastify-plugin": "5.1.0",
         "fastify-type-provider-zod": "4.0.2",
+        "jose": "6.1.3",
         "postgres": "3.4.8",
         "zod": "3.24.1"
       },
@@ -5345,6 +5347,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {
@@ -36,7 +36,9 @@
     "@fastify/swagger-ui": "5.2.1",
     "drizzle-orm": "0.45.1",
     "fastify": "5.2.1",
+    "fastify-plugin": "5.1.0",
     "fastify-type-provider-zod": "4.0.2",
+    "jose": "6.1.3",
     "postgres": "3.4.8",
     "zod": "3.24.1"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,4 +9,5 @@ export const config = {
   databaseUrl: env.DATABASE_URL,
   frontendUrl: env.FRONTEND_URL,
   apiKey: env.API_KEY,
+  supabaseUrl: env.SUPABASE_URL,
 } as const

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,6 +12,7 @@ const envSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
   FRONTEND_URL: z.string().url().default('http://localhost:5173'),
   API_KEY: z.string().optional(),
+  SUPABASE_URL: z.string().url().optional(),
 })
 
 export type Env = z.infer<typeof envSchema>

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -1,0 +1,89 @@
+import fp from 'fastify-plugin'
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  JWTPayload,
+  FlattenedJWSInput,
+  JWSHeaderParameters,
+} from 'jose'
+import { FastifyInstance, FastifyRequest } from 'fastify'
+import { config } from '../config.js'
+
+export interface JwtUser {
+  id: string
+  email: string
+  role: string
+}
+
+export type JWKSResolver = (
+  protectedHeader?: JWSHeaderParameters,
+  token?: FlattenedJWSInput
+) => Promise<CryptoKey>
+
+interface SupabaseJwtPayload extends JWTPayload {
+  email?: string
+  role?: string
+}
+
+function extractUser(payload: SupabaseJwtPayload): JwtUser | null {
+  if (!payload.sub) return null
+
+  return {
+    id: payload.sub,
+    email: payload.email ?? '',
+    role: payload.role ?? 'authenticated',
+  }
+}
+
+export interface AuthPluginOptions {
+  jwks?: JWKSResolver
+  issuer?: string
+}
+
+async function authPlugin(
+  fastify: FastifyInstance,
+  opts: AuthPluginOptions = {}
+) {
+  fastify.decorateRequest('user', null)
+  fastify.decorate('jwtEnabled', false)
+
+  let jwks = opts.jwks
+  let issuer = opts.issuer
+
+  if (!jwks) {
+    if (!config.supabaseUrl) {
+      fastify.log.warn(
+        'SUPABASE_URL not configured — JWT verification disabled'
+      )
+      return
+    }
+
+    const jwksUrl = new URL(
+      '/auth/v1/.well-known/jwks.json',
+      config.supabaseUrl
+    )
+    jwks = createRemoteJWKSet(jwksUrl) as JWKSResolver
+    issuer = issuer ?? `${config.supabaseUrl}/auth/v1`
+  }
+
+  fastify.jwtEnabled = true
+
+  const verifyOpts = issuer ? { issuer } : undefined
+
+  fastify.addHook('onRequest', async (request: FastifyRequest) => {
+    const authHeader = request.headers.authorization
+    if (!authHeader?.startsWith('Bearer ')) return
+
+    const token = authHeader.slice(7)
+
+    try {
+      const { payload } = await jwtVerify(token, jwks!, verifyOpts)
+
+      request.user = extractUser(payload as SupabaseJwtPayload)
+    } catch (err) {
+      request.log.debug({ err }, 'JWT verification failed')
+    }
+  })
+}
+
+export default fp(authPlugin, { name: 'auth' })

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -1,0 +1,39 @@
+import { FastifyInstance } from 'fastify'
+
+export async function authRoutes(fastify: FastifyInstance) {
+  fastify.get(
+    '/auth/me',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Get current user from JWT',
+        description:
+          'Returns the authenticated user identity extracted from the JWT. Returns 401 if no valid JWT is provided.',
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              user: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  email: { type: 'string' },
+                  role: { type: 'string' },
+                },
+                required: ['id', 'email', 'role'],
+              },
+            },
+            required: ['user'],
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.status(401).send({ message: 'Unauthorized' })
+      }
+
+      return { user: request.user }
+    }
+  )
+}

--- a/src/types/fastify.d.ts
+++ b/src/types/fastify.d.ts
@@ -1,7 +1,13 @@
 import { Database } from '../db/index.js'
+import { JwtUser } from '../plugins/auth.js'
 
 declare module 'fastify' {
   interface FastifyInstance {
     db: Database
+    jwtEnabled: boolean
+  }
+
+  interface FastifyRequest {
+    user: JwtUser | null
   }
 }

--- a/tests/e2e/auth-prod.test.ts
+++ b/tests/e2e/auth-prod.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { FastifyInstance } from 'fastify'
+import { closeTestDatabase, setupTestDatabase } from '../helpers/db.js'
+
+function loadEnvFile() {
+  try {
+    const envFile = readFileSync(resolve(process.cwd(), '.env'), 'utf-8')
+    for (const line of envFile.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eqIndex = trimmed.indexOf('=')
+      if (eqIndex === -1) continue
+      const key = trimmed.slice(0, eqIndex)
+      const value = trimmed.slice(eqIndex + 1)
+      if (!process.env[key]) {
+        process.env[key] = value
+      }
+    }
+  } catch {
+    // .env file not found
+  }
+}
+
+loadEnvFile()
+
+const SUPABASE_URL = process.env.SUPABASE_URL
+
+describe.skipIf(!SUPABASE_URL)('Auth E2E — Real Supabase JWKS', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    const { buildApp } = await import('../../src/app.js')
+
+    app = await buildApp({ db }, { logger: false })
+  }, 30000)
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  describe('JWKS endpoint connectivity', () => {
+    it('fetches keys from Supabase JWKS endpoint', async () => {
+      const jwksUrl = `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`
+      const response = await fetch(jwksUrl)
+
+      expect(response.status).toBe(200)
+
+      const body = await response.json()
+      expect(body).toHaveProperty('keys')
+      expect(Array.isArray(body.keys)).toBe(true)
+      expect(body.keys.length).toBeGreaterThan(0)
+    })
+
+    it('JWKS keys have required JWK fields', async () => {
+      const jwksUrl = `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`
+      const response = await fetch(jwksUrl)
+      const body = await response.json()
+
+      for (const key of body.keys) {
+        expect(key).toHaveProperty('kty')
+        expect(key).toHaveProperty('kid')
+        expect(key).toHaveProperty('alg')
+        expect(['EC', 'RSA', 'OKP']).toContain(key.kty)
+        expect(key.key_ops).toContain('verify')
+      }
+    })
+  })
+
+  describe('App initialization with real Supabase URL', () => {
+    it('enables JWT auth when SUPABASE_URL is set', () => {
+      expect(app.jwtEnabled).toBe(true)
+    })
+  })
+
+  describe('GET /auth/me with real JWKS', () => {
+    it('returns 401 without JWT', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+
+    it('returns 401 with fabricated JWT', async () => {
+      const fakeToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+        'eyJzdWIiOiIxMjM0NTY3ODkwIn0.' +
+        'dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${fakeToken}` },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+  })
+
+  describe('Plans routes still work without auth', () => {
+    it('GET /plans accessible without JWT', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/plans',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('health endpoint accessible without auth', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/health',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+})

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,0 +1,90 @@
+import { generateKeyPair, SignJWT } from 'jose'
+import { JWKSResolver } from '../../src/plugins/auth.js'
+
+const TEST_ISSUER = 'https://test.supabase.co/auth/v1'
+const TEST_KID = 'test-key-id'
+
+let privateKey: CryptoKey
+let publicKey: CryptoKey
+
+export async function setupTestKeys() {
+  const keyPair = await generateKeyPair('ES256')
+  privateKey = keyPair.privateKey
+  publicKey = keyPair.publicKey
+}
+
+export function getTestJWKS(): JWKSResolver {
+  return async () => publicKey
+}
+
+export function getTestIssuer(): string {
+  return TEST_ISSUER
+}
+
+interface TestTokenClaims {
+  sub?: string
+  email?: string | null
+  role?: string | null
+  exp?: number
+}
+
+export async function signTestJwt(
+  claims: TestTokenClaims = {}
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+
+  const payload: Record<string, unknown> = {}
+
+  if (claims.email !== null) {
+    payload.email = claims.email ?? 'test@example.com'
+  }
+
+  if (claims.role !== null) {
+    payload.role = claims.role ?? 'authenticated'
+  }
+
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+    .setSubject(claims.sub ?? 'a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    .setIssuer(TEST_ISSUER)
+    .setIssuedAt(now)
+    .setExpirationTime(claims.exp ?? now + 3600)
+    .sign(privateKey)
+}
+
+export async function signExpiredJwt(): Promise<string> {
+  const pastTime = Math.floor(Date.now() / 1000) - 3600
+
+  return signTestJwt({ exp: pastTime })
+}
+
+export async function signJwtWithWrongKey(): Promise<string> {
+  const { privateKey: wrongKey } = await generateKeyPair('ES256')
+  const now = Math.floor(Date.now() / 1000)
+
+  return new SignJWT({
+    email: 'test@example.com',
+    role: 'authenticated',
+  })
+    .setProtectedHeader({ alg: 'ES256', kid: 'wrong-key' })
+    .setSubject('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    .setIssuer(TEST_ISSUER)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(wrongKey)
+}
+
+export async function signJwtWithWrongIssuer(): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+
+  return new SignJWT({
+    email: 'test@example.com',
+    role: 'authenticated',
+  })
+    .setProtectedHeader({ alg: 'ES256', kid: TEST_KID })
+    .setSubject('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    .setIssuer('https://wrong-project.supabase.co/auth/v1')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(privateKey)
+}

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  seedTestParticipants,
+  seedTestPlans,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+  signExpiredJwt,
+  signJwtWithWrongKey,
+  signJwtWithWrongIssuer,
+} from '../helpers/auth.js'
+
+describe('JWT Auth (injected JWKS)', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    await setupTestKeys()
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('GET /auth/me — returns user from JWT', () => {
+    it('returns user identity with valid JWT', async () => {
+      const token = await signTestJwt({
+        sub: 'user-uuid-1234',
+        email: 'alex@example.com',
+        role: 'authenticated',
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        user: {
+          id: 'user-uuid-1234',
+          email: 'alex@example.com',
+          role: 'authenticated',
+        },
+      })
+    })
+
+    it('defaults email to empty string when not in token', async () => {
+      const token = await signTestJwt({ email: null })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().user.email).toBe('')
+    })
+
+    it('defaults role to authenticated when not in token', async () => {
+      const token = await signTestJwt({ role: null })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().user.role).toBe('authenticated')
+    })
+
+    it('returns 401 without JWT', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+
+    it.each([
+      ['expired', () => signExpiredJwt()],
+      ['wrong signing key', () => signJwtWithWrongKey()],
+      ['wrong issuer', () => signJwtWithWrongIssuer()],
+    ])('returns 401 with %s JWT', async (_label, signFn) => {
+      const token = await signFn()
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+
+    it('returns 401 with malformed JWT', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: 'Bearer not.a.jwt' },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+  })
+
+  describe('Plans routes remain accessible without auth', () => {
+    it('GET /plans works without JWT', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/plans',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('POST /plans/with-owner works without JWT', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/with-owner',
+        payload: {
+          title: 'Test Plan',
+          owner: {
+            name: 'Owner',
+            lastName: 'Test',
+            contactPhone: '+1-555-000-0001',
+          },
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+    })
+  })
+
+  describe('Public routes bypass auth', () => {
+    it('health endpoint accessible without auth', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/health',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('invite route accessible without auth', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participants = await seedTestParticipants(plan.planId, 1)
+      const token = participants[0].inviteToken!
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${token}`,
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('jwtEnabled flag', () => {
+    it('sets jwtEnabled to true when JWKS is configured', () => {
+      expect(app.jwtEnabled).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add JWKS-based JWT verification using `jose` library (asymmetric keys, no secrets stored)
- Auth plugin decorates `request.user` with `{ id, email, role }` from Supabase JWT claims
- New `GET /auth/me` route — requires valid JWT, returns user identity (proof-of-auth endpoint)
- All other routes (plans, items, participants, invite) remain public
- API key still works as fallback during transition
- 13 integration tests (fake JWKS) + 7 E2E tests (real Supabase JWKS)

## Test plan

- [x] Valid JWT accepted on /auth/me, returns correct user claims
- [x] Expired/wrong-key/wrong-issuer/malformed JWT returns 401
- [x] Plans routes work without any auth
- [x] Health, invite, OPTIONS bypass auth
- [x] Real Supabase JWKS endpoint reachable and returns valid keys
- [x] Fabricated JWT rejected by real JWKS
- [x] All 205 tests pass

Closes #66

Made with [Cursor](https://cursor.com)