### PR TITLE
feat: add user management schema (guest_profiles, user_details, plan_invites)

### DIFF
--- a/drizzle/0005_harsh_korg.sql
+++ b/drizzle/0005_harsh_korg.sql
@@ -1,0 +1,46 @@
+CREATE TYPE "public"."invite_send_status" AS ENUM('pending', 'sent', 'failed', 'accepted');--> statement-breakpoint
+CREATE TYPE "public"."invite_status" AS ENUM('pending', 'invited', 'accepted');--> statement-breakpoint
+CREATE TABLE "guest_profiles" (
+	"guest_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"last_name" varchar(255) NOT NULL,
+	"phone" varchar(50) NOT NULL,
+	"email" varchar(255),
+	"food_preferences" text,
+	"allergies" text,
+	"adults_count" integer,
+	"kids_count" integer,
+	"last_accessed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "plan_invites" (
+	"invite_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"plan_id" uuid NOT NULL,
+	"participant_id" uuid NOT NULL,
+	"token_hash" varchar(128) NOT NULL,
+	"status" "invite_send_status" DEFAULT 'pending' NOT NULL,
+	"sent_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"accepted_at" timestamp with time zone,
+	"accepted_by_user_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_details" (
+	"user_id" uuid PRIMARY KEY NOT NULL,
+	"food_preferences" text,
+	"allergies" text,
+	"default_equipment" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "participants" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+ALTER TABLE "participants" ADD COLUMN "guest_profile_id" uuid;--> statement-breakpoint
+ALTER TABLE "participants" ADD COLUMN "invite_status" "invite_status" DEFAULT 'pending' NOT NULL;--> statement-breakpoint
+ALTER TABLE "plans" ADD COLUMN "created_by_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "plan_invites" ADD CONSTRAINT "plan_invites_plan_id_plans_plan_id_fk" FOREIGN KEY ("plan_id") REFERENCES "public"."plans"("plan_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plan_invites" ADD CONSTRAINT "plan_invites_participant_id_participants_participant_id_fk" FOREIGN KEY ("participant_id") REFERENCES "public"."participants"("participant_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_guest_profile_id_guest_profiles_guest_id_fk" FOREIGN KEY ("guest_profile_id") REFERENCES "public"."guest_profiles"("guest_id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,702 @@
+{
+  "id": "01b37849-0764-45c0-ac86-de248c369ef2",
+  "prevId": "ec5db1c0-6b78-4bcd-8e37-f70c3d7d87aa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_participant_id": {
+          "name": "assigned_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_assigned_participant_id_participants_participant_id_fk": {
+          "name": "items_assigned_participant_id_participants_participant_id_fk",
+          "tableFrom": "items",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "assigned_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1771745960777,
       "tag": "0004_far_mercury",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1771834667407,
+      "tag": "0005_harsh_korg",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,6 +10,38 @@ import {
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 
+export const guestProfiles = pgTable('guest_profiles', {
+  guestId: uuid('guest_id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 255 }).notNull(),
+  lastName: varchar('last_name', { length: 255 }).notNull(),
+  phone: varchar('phone', { length: 50 }).notNull(),
+  email: varchar('email', { length: 255 }),
+  foodPreferences: text('food_preferences'),
+  allergies: text('allergies'),
+  adultsCount: integer('adults_count'),
+  kidsCount: integer('kids_count'),
+  lastAccessedAt: timestamp('last_accessed_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+})
+
+export const userDetails = pgTable('user_details', {
+  userId: uuid('user_id').primaryKey(),
+  foodPreferences: text('food_preferences'),
+  allergies: text('allergies'),
+  defaultEquipment: jsonb('default_equipment'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+})
+
 export const planStatusEnum = pgEnum('plan_status', [
   'draft',
   'active',
@@ -24,6 +56,11 @@ export const participantRoleEnum = pgEnum('participant_role', [
   'owner',
   'participant',
   'viewer',
+])
+export const inviteStatusEnum = pgEnum('invite_status', [
+  'pending',
+  'invited',
+  'accepted',
 ])
 export const itemCategoryEnum = pgEnum('item_category', ['equipment', 'food'])
 export const itemStatusEnum = pgEnum('item_status', [
@@ -64,6 +101,7 @@ export const plans = pgTable('plans', {
   status: planStatusEnum('status').default('draft').notNull(),
   visibility: visibilityEnum('visibility').default('public').notNull(),
   ownerParticipantId: uuid('owner_participant_id'),
+  createdByUserId: uuid('created_by_user_id'),
   location: jsonb('location').$type<Location>(),
   startDate: timestamp('start_date', { withTimezone: true }),
   endDate: timestamp('end_date', { withTimezone: true }),
@@ -81,6 +119,11 @@ export const participants = pgTable('participants', {
   planId: uuid('plan_id')
     .notNull()
     .references(() => plans.planId, { onDelete: 'cascade' }),
+  userId: uuid('user_id'),
+  guestProfileId: uuid('guest_profile_id').references(
+    () => guestProfiles.guestId,
+    { onDelete: 'set null' }
+  ),
   name: varchar('name', { length: 255 }).notNull(),
   lastName: varchar('last_name', { length: 255 }).notNull(),
   contactPhone: varchar('contact_phone', { length: 50 }).notNull(),
@@ -89,6 +132,7 @@ export const participants = pgTable('participants', {
   avatarUrl: text('avatar_url'),
   contactEmail: varchar('contact_email', { length: 255 }),
   inviteToken: varchar('invite_token', { length: 64 }).unique(),
+  inviteStatus: inviteStatusEnum('invite_status').default('pending').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()
     .notNull(),
@@ -120,9 +164,40 @@ export const items = pgTable('items', {
     .notNull(),
 })
 
+export const inviteSendStatusEnum = pgEnum('invite_send_status', [
+  'pending',
+  'sent',
+  'failed',
+  'accepted',
+])
+
+export const planInvites = pgTable('plan_invites', {
+  inviteId: uuid('invite_id').primaryKey().defaultRandom(),
+  planId: uuid('plan_id')
+    .notNull()
+    .references(() => plans.planId, { onDelete: 'cascade' }),
+  participantId: uuid('participant_id')
+    .notNull()
+    .references(() => participants.participantId, { onDelete: 'cascade' }),
+  tokenHash: varchar('token_hash', { length: 128 }).notNull(),
+  status: inviteSendStatusEnum('status').default('pending').notNull(),
+  sentAt: timestamp('sent_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  acceptedAt: timestamp('accepted_at', { withTimezone: true }),
+  acceptedByUserId: uuid('accepted_by_user_id'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+})
+
+export const guestProfilesRelations = relations(guestProfiles, ({ many }) => ({
+  participants: many(participants),
+}))
+
 export const plansRelations = relations(plans, ({ many }) => ({
   items: many(items),
   participants: many(participants),
+  invites: many(planInvites),
 }))
 
 export const itemsRelations = relations(items, ({ one }) => ({
@@ -141,11 +216,33 @@ export const participantsRelations = relations(participants, ({ one }) => ({
     fields: [participants.planId],
     references: [plans.planId],
   }),
+  guestProfile: one(guestProfiles, {
+    fields: [participants.guestProfileId],
+    references: [guestProfiles.guestId],
+  }),
+  invite: one(planInvites),
 }))
 
+export const planInvitesRelations = relations(planInvites, ({ one }) => ({
+  plan: one(plans, {
+    fields: [planInvites.planId],
+    references: [plans.planId],
+  }),
+  participant: one(participants, {
+    fields: [planInvites.participantId],
+    references: [participants.participantId],
+  }),
+}))
+
+export type GuestProfile = typeof guestProfiles.$inferSelect
+export type NewGuestProfile = typeof guestProfiles.$inferInsert
+export type UserDetail = typeof userDetails.$inferSelect
+export type NewUserDetail = typeof userDetails.$inferInsert
 export type Plan = typeof plans.$inferSelect
 export type NewPlan = typeof plans.$inferInsert
 export type Participant = typeof participants.$inferSelect
 export type NewParticipant = typeof participants.$inferInsert
 export type Item = typeof items.$inferSelect
 export type NewItem = typeof items.$inferInsert
+export type PlanInvite = typeof planInvites.$inferSelect
+export type NewPlanInvite = typeof planInvites.$inferInsert

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -40,8 +40,11 @@ export async function cleanupTestDatabase() {
   const testDb = await getTestDb()
 
   await testDb.delete(schema.items)
+  await testDb.delete(schema.planInvites)
   await testDb.delete(schema.participants)
   await testDb.delete(schema.plans)
+  await testDb.delete(schema.guestProfiles)
+  await testDb.delete(schema.userDetails)
 }
 
 export async function closeTestDatabase() {


### PR DESCRIPTION
## Summary

- Add `guest_profiles` table for temporary PII of unregistered participants (deleted on sign-up)
- Add `user_details` table for app-specific preferences of registered Supabase users (no PII)
- Add `plan_invites` table with hashed token storage, invite status tracking, and participant linking
- Add `invite_status` and `invite_send_status` enums for tracking invite lifecycle
- Add new columns: `plans.createdByUserId`, `participants.userId`, `participants.guestProfileId`, `participants.inviteStatus`
- Update test cleanup to include new tables

**Zero behavior change** — all existing routes work identically with API key. This is schema-only prep for the user management feature.

## Test plan

- [x] All 205 existing tests pass (unit + integration + E2E)
- [x] Migration is additive only (new tables, nullable columns with defaults)
- [x] No route logic changed — FE fully backward compatible

Closes #77
Relates to #73