### PR TITLE
feat: add profile endpoints and security hardening

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1124,6 +1124,106 @@
           "inviteToken"
         ],
         "title": "RegenerateTokenResponse"
+      },
+      "def-31": {
+        "type": "object",
+        "properties": {
+          "foodPreferences": {
+            "type": "string",
+            "nullable": true,
+            "description": "Free-text dietary preferences, e.g. \"vegetarian, no shellfish\""
+          },
+          "allergies": {
+            "type": "string",
+            "nullable": true,
+            "description": "Free-text allergy list, e.g. \"nuts, gluten, dairy\""
+          },
+          "defaultEquipment": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "description": "List of equipment item names the user typically brings on trips, e.g. [\"tent\", \"sleeping bag\", \"headlamp\"]"
+          }
+        },
+        "title": "UserPreferences"
+      },
+      "def-32": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "email",
+              "role"
+            ]
+          },
+          "preferences": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-31"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "App preferences for this user. Null if the user has never saved preferences."
+          }
+        },
+        "required": [
+          "user",
+          "preferences"
+        ],
+        "title": "ProfileResponse"
+      },
+      "def-33": {
+        "type": "object",
+        "properties": {
+          "foodPreferences": {
+            "type": "string",
+            "nullable": true,
+            "description": "Free-text dietary preferences, e.g. \"vegetarian, no shellfish\". Send null to clear."
+          },
+          "allergies": {
+            "type": "string",
+            "nullable": true,
+            "description": "Free-text allergy list, e.g. \"nuts, gluten, dairy\". Send null to clear."
+          },
+          "defaultEquipment": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "description": "List of equipment item names the user typically brings. Send null to clear."
+          }
+        },
+        "title": "UpdateProfileBody"
+      },
+      "def-34": {
+        "type": "object",
+        "properties": {
+          "preferences": {
+            "$ref": "#/components/schemas/def-31"
+          }
+        },
+        "required": [
+          "preferences"
+        ],
+        "title": "UpdateProfileResponse"
       }
     }
   },
@@ -2274,6 +2374,55 @@
                   "required": [
                     "user"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/profile": {
+      "get": {
+        "summary": "Get current user profile",
+        "tags": [
+          "auth"
+        ],
+        "description": "Returns user identity from JWT and app preferences from the database. Returns 401 if no valid JWT is provided.",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-32"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update user preferences",
+        "tags": [
+          "auth"
+        ],
+        "description": "Creates or updates the authenticated user's app preferences. Returns 401 if no valid JWT is provided.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-33"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-34"
                 }
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "chillist-be",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chillist-be",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@fastify/cors": "11.0.0",
+        "@fastify/helmet": "13.0.2",
+        "@fastify/rate-limit": "10.3.0",
         "@fastify/swagger": "9.4.2",
         "@fastify/swagger-ui": "5.2.1",
         "drizzle-orm": "0.45.1",
@@ -1204,6 +1206,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -1241,6 +1263,27 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@fastify/send": {
@@ -5133,6 +5176,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/help-me": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@fastify/cors": "11.0.0",
+    "@fastify/helmet": "13.0.2",
+    "@fastify/rate-limit": "10.3.0",
     "@fastify/swagger": "9.4.2",
     "@fastify/swagger-ui": "5.2.1",
     "drizzle-orm": "0.45.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,7 @@
 import Fastify from 'fastify'
 import cors from '@fastify/cors'
+import helmet from '@fastify/helmet'
+import rateLimit from '@fastify/rate-limit'
 import swagger from '@fastify/swagger'
 import swaggerUI from '@fastify/swagger-ui'
 import { config } from './config.js'
@@ -98,6 +100,15 @@ export async function buildApp(
     origin: config.isDev ? true : config.frontendUrl,
     methods: ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
     credentials: true,
+  })
+
+  await fastify.register(helmet, {
+    contentSecurityPolicy: config.isDev ? false : undefined,
+  })
+
+  await fastify.register(rateLimit, {
+    max: 100,
+    timeWindow: '1 minute',
   })
 
   await fastify.register(authPlugin, auth ?? {})

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -1,9 +1,17 @@
+import { eq } from 'drizzle-orm'
 import { FastifyInstance } from 'fastify'
+import { userDetails } from '../db/schema.js'
+
+const AUTH_RATE_LIMIT = {
+  max: 10,
+  timeWindow: '1 minute',
+}
 
 export async function authRoutes(fastify: FastifyInstance) {
   fastify.get(
     '/auth/me',
     {
+      config: { rateLimit: AUTH_RATE_LIMIT },
       schema: {
         tags: ['auth'],
         summary: 'Get current user from JWT',
@@ -34,6 +42,104 @@ export async function authRoutes(fastify: FastifyInstance) {
       }
 
       return { user: request.user }
+    }
+  )
+
+  fastify.get(
+    '/auth/profile',
+    {
+      config: { rateLimit: AUTH_RATE_LIMIT },
+      schema: {
+        tags: ['auth'],
+        summary: 'Get current user profile',
+        description:
+          'Returns user identity from JWT and app preferences from the database. Returns 401 if no valid JWT is provided.',
+        response: {
+          200: { $ref: 'ProfileResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.status(401).send({ message: 'Unauthorized' })
+      }
+
+      const [row] = await fastify.db
+        .select()
+        .from(userDetails)
+        .where(eq(userDetails.userId, request.user.id))
+
+      return {
+        user: request.user,
+        preferences: row
+          ? {
+              foodPreferences: row.foodPreferences,
+              allergies: row.allergies,
+              defaultEquipment: row.defaultEquipment,
+            }
+          : null,
+      }
+    }
+  )
+
+  fastify.patch(
+    '/auth/profile',
+    {
+      config: { rateLimit: AUTH_RATE_LIMIT },
+      schema: {
+        tags: ['auth'],
+        summary: 'Update user preferences',
+        description:
+          "Creates or updates the authenticated user's app preferences. Returns 401 if no valid JWT is provided.",
+        body: { $ref: 'UpdateProfileBody#' },
+        response: {
+          200: { $ref: 'UpdateProfileResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.status(401).send({ message: 'Unauthorized' })
+      }
+
+      const body = request.body as {
+        foodPreferences?: string | null
+        allergies?: string | null
+        defaultEquipment?: string[] | null
+      }
+
+      const [row] = await fastify.db
+        .insert(userDetails)
+        .values({
+          userId: request.user.id,
+          foodPreferences: body.foodPreferences ?? null,
+          allergies: body.allergies ?? null,
+          defaultEquipment: body.defaultEquipment ?? null,
+        })
+        .onConflictDoUpdate({
+          target: userDetails.userId,
+          set: {
+            ...(body.foodPreferences !== undefined && {
+              foodPreferences: body.foodPreferences,
+            }),
+            ...(body.allergies !== undefined && {
+              allergies: body.allergies,
+            }),
+            ...(body.defaultEquipment !== undefined && {
+              defaultEquipment: body.defaultEquipment,
+            }),
+            updatedAt: new Date(),
+          },
+        })
+        .returning()
+
+      return {
+        preferences: {
+          foodPreferences: row.foodPreferences,
+          allergies: row.allergies,
+          defaultEquipment: row.defaultEquipment,
+        },
+      }
     }
   )
 }

--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -1,0 +1,81 @@
+export const userPreferencesSchema = {
+  $id: 'UserPreferences',
+  type: 'object',
+  properties: {
+    foodPreferences: {
+      type: 'string',
+      nullable: true,
+      description:
+        'Free-text dietary preferences, e.g. "vegetarian, no shellfish"',
+    },
+    allergies: {
+      type: 'string',
+      nullable: true,
+      description: 'Free-text allergy list, e.g. "nuts, gluten, dairy"',
+    },
+    defaultEquipment: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+      description:
+        'List of equipment item names the user typically brings on trips, e.g. ["tent", "sleeping bag", "headlamp"]',
+    },
+  },
+} as const
+
+export const profileResponseSchema = {
+  $id: 'ProfileResponse',
+  type: 'object',
+  properties: {
+    user: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        email: { type: 'string' },
+        role: { type: 'string' },
+      },
+      required: ['id', 'email', 'role'],
+    },
+    preferences: {
+      oneOf: [{ $ref: 'UserPreferences#' }, { type: 'null' }],
+      description:
+        'App preferences for this user. Null if the user has never saved preferences.',
+    },
+  },
+  required: ['user', 'preferences'],
+} as const
+
+export const updateProfileBodySchema = {
+  $id: 'UpdateProfileBody',
+  type: 'object',
+  properties: {
+    foodPreferences: {
+      type: 'string',
+      nullable: true,
+      description:
+        'Free-text dietary preferences, e.g. "vegetarian, no shellfish". Send null to clear.',
+    },
+    allergies: {
+      type: 'string',
+      nullable: true,
+      description:
+        'Free-text allergy list, e.g. "nuts, gluten, dairy". Send null to clear.',
+    },
+    defaultEquipment: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+      description:
+        'List of equipment item names the user typically brings. Send null to clear.',
+    },
+  },
+} as const
+
+export const updateProfileResponseSchema = {
+  $id: 'UpdateProfileResponse',
+  type: 'object',
+  properties: {
+    preferences: { $ref: 'UserPreferences#' },
+  },
+  required: ['preferences'],
+} as const

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -40,6 +40,12 @@ import {
   regenerateTokenParamsSchema,
   regenerateTokenResponseSchema,
 } from './invite.schema.js'
+import {
+  userPreferencesSchema,
+  profileResponseSchema,
+  updateProfileBodySchema,
+  updateProfileResponseSchema,
+} from './auth.schema.js'
 
 const schemas = [
   errorResponseSchema,
@@ -73,6 +79,10 @@ const schemas = [
   invitePlanResponseSchema,
   regenerateTokenParamsSchema,
   regenerateTokenResponseSchema,
+  userPreferencesSchema,
+  profileResponseSchema,
+  updateProfileBodySchema,
+  updateProfileResponseSchema,
 ]
 
 export function registerSchemas(fastify: FastifyInstance) {
@@ -87,3 +97,4 @@ export * from './plan.schema.js'
 export * from './item.schema.js'
 export * from './participant.schema.js'
 export * from './invite.schema.js'
+export * from './auth.schema.js'

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+} from '../helpers/auth.js'
+
+const TEST_USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+const TEST_EMAIL = 'alex@example.com'
+
+describe('Profile Endpoints', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    await setupTestKeys()
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('GET /auth/profile', () => {
+    it('returns user identity with null preferences when no userDetails exist', async () => {
+      const token = await signTestJwt({
+        sub: TEST_USER_ID,
+        email: TEST_EMAIL,
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        user: {
+          id: TEST_USER_ID,
+          email: TEST_EMAIL,
+          role: 'authenticated',
+        },
+        preferences: null,
+      })
+    })
+
+    it('returns user identity with preferences after PATCH', async () => {
+      const token = await signTestJwt({
+        sub: TEST_USER_ID,
+        email: TEST_EMAIL,
+      })
+
+      await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          foodPreferences: 'vegetarian',
+          allergies: 'nuts',
+          defaultEquipment: ['tent', 'sleeping bag'],
+        },
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        user: {
+          id: TEST_USER_ID,
+          email: TEST_EMAIL,
+          role: 'authenticated',
+        },
+        preferences: {
+          foodPreferences: 'vegetarian',
+          allergies: 'nuts',
+          defaultEquipment: ['tent', 'sleeping bag'],
+        },
+      })
+    })
+
+    it('returns 401 without JWT', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/profile',
+        headers: {},
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+  })
+
+  describe('PATCH /auth/profile', () => {
+    it('creates userDetails on first call', async () => {
+      const token = await signTestJwt({
+        sub: TEST_USER_ID,
+        email: TEST_EMAIL,
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          foodPreferences: 'vegan',
+          allergies: 'gluten',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        preferences: {
+          foodPreferences: 'vegan',
+          allergies: 'gluten',
+          defaultEquipment: null,
+        },
+      })
+    })
+
+    it('updates only provided fields on subsequent calls', async () => {
+      const token = await signTestJwt({
+        sub: TEST_USER_ID,
+        email: TEST_EMAIL,
+      })
+
+      await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          foodPreferences: 'vegetarian',
+          allergies: 'nuts',
+          defaultEquipment: ['tent'],
+        },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          allergies: 'dairy',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        preferences: {
+          foodPreferences: 'vegetarian',
+          allergies: 'dairy',
+          defaultEquipment: ['tent'],
+        },
+      })
+    })
+
+    it('allows clearing fields with null', async () => {
+      const token = await signTestJwt({
+        sub: TEST_USER_ID,
+        email: TEST_EMAIL,
+      })
+
+      await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          foodPreferences: 'vegetarian',
+          allergies: 'nuts',
+        },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          foodPreferences: null,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().preferences.foodPreferences).toBeNull()
+      expect(response.json().preferences.allergies).toBe('nuts')
+    })
+
+    it('returns 401 without JWT', async () => {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: {},
+        payload: { foodPreferences: 'vegan' },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `GET /auth/profile` and `PATCH /auth/profile` endpoints for user preferences (foodPreferences, allergies, defaultEquipment) backed by `userDetails` table with upsert-on-conflict
- Add `@fastify/helmet` for HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, CSP)
- Add `@fastify/rate-limit` with global 100 req/min limit and stricter 10 req/min on auth endpoints
- Bump version to 1.6.0

Part of #73 (User & Participant Management — Spec Phase 2: Profile Auto-Provisioning + Security Hardening)

## Test plan
- [x] 7 new integration tests for profile endpoints (GET with/without preferences, PATCH upsert, partial update, clear with null, 401 without JWT)
- [x] All 212 existing + new tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] OpenAPI spec regenerated and validated


Made with [Cursor](https://cursor.com)