### PR TITLE
feat: plan ownership and visibility-based access control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/utils/plan-access.ts
+++ b/src/utils/plan-access.ts
@@ -1,0 +1,46 @@
+import { eq, and } from 'drizzle-orm'
+import { plans, participants, Plan } from '../db/schema.js'
+import { Database } from '../db/index.js'
+
+export interface PlanAccessResult {
+  allowed: boolean
+  plan: Plan | null
+}
+
+export async function checkPlanAccess(
+  db: Database,
+  planId: string,
+  userId: string | undefined
+): Promise<PlanAccessResult> {
+  const [plan] = await db.select().from(plans).where(eq(plans.planId, planId))
+
+  if (!plan) {
+    return { allowed: false, plan: null }
+  }
+
+  if (plan.visibility === 'public') {
+    return { allowed: true, plan }
+  }
+
+  if (!userId) {
+    return { allowed: false, plan: null }
+  }
+
+  if (plan.createdByUserId === userId) {
+    return { allowed: true, plan }
+  }
+
+  const [linked] = await db
+    .select({ participantId: participants.participantId })
+    .from(participants)
+    .where(
+      and(eq(participants.planId, planId), eq(participants.userId, userId))
+    )
+    .limit(1)
+
+  if (linked) {
+    return { allowed: true, plan }
+  }
+
+  return { allowed: false, plan: null }
+}

--- a/tests/integration/plan-access.test.ts
+++ b/tests/integration/plan-access.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+  signExpiredJwt,
+} from '../helpers/auth.js'
+import { Database } from '../../src/db/index.js'
+import { plans, participants } from '../../src/db/schema.js'
+import { randomBytes } from 'node:crypto'
+
+const OWNER_USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const PARTICIPANT_USER_ID = 'bbbbbbbb-1111-2222-3333-444444444444'
+const UNRELATED_USER_ID = 'cccccccc-1111-2222-3333-444444444444'
+
+const validOwner = {
+  name: 'Alex',
+  lastName: 'Guberman',
+  contactPhone: '+1-555-123-4567',
+}
+
+async function createPlanDirectly(
+  db: Database,
+  overrides: {
+    visibility?: 'public' | 'unlisted' | 'private'
+    createdByUserId?: string | null
+  } = {}
+) {
+  const [plan] = await db
+    .insert(plans)
+    .values({
+      title: 'Test Plan',
+      status: 'active',
+      visibility: overrides.visibility ?? 'public',
+      createdByUserId: overrides.createdByUserId ?? null,
+    })
+    .returning()
+
+  const [owner] = await db
+    .insert(participants)
+    .values({
+      planId: plan.planId,
+      name: 'Owner',
+      lastName: 'User',
+      contactPhone: '+1-555-000-0001',
+      role: 'owner',
+      userId: overrides.createdByUserId ?? null,
+      inviteToken: randomBytes(32).toString('hex'),
+    })
+    .returning()
+
+  return { plan, owner }
+}
+
+async function linkParticipant(
+  db: Database,
+  planId: string,
+  userId: string,
+  role: 'participant' | 'viewer' = 'participant'
+) {
+  const [participant] = await db
+    .insert(participants)
+    .values({
+      planId,
+      name: 'Linked',
+      lastName: 'Participant',
+      contactPhone: '+1-555-000-0002',
+      role,
+      userId,
+      inviteToken: randomBytes(32).toString('hex'),
+    })
+    .returning()
+
+  return participant
+}
+
+describe('Plan Access Control', () => {
+  let app: FastifyInstance
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('POST /plans/with-owner — visibility defaults', () => {
+    it('defaults to unlisted when JWT is present', async () => {
+      const token = await signTestJwt({ sub: OWNER_USER_ID })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/with-owner',
+        headers: { authorization: `Bearer ${token}` },
+        payload: { title: 'Auth Plan', owner: validOwner },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(response.json().visibility).toBe('unlisted')
+    })
+
+    it('defaults to public when no JWT is present', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/with-owner',
+        payload: { title: 'Public Plan', owner: validOwner },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(response.json().visibility).toBe('public')
+    })
+
+    it('respects explicit visibility even with JWT', async () => {
+      const token = await signTestJwt({ sub: OWNER_USER_ID })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans/with-owner',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          title: 'Explicit Public',
+          visibility: 'public',
+          owner: validOwner,
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(response.json().visibility).toBe('public')
+    })
+  })
+
+  describe('GET /plans/:planId — access control', () => {
+    it('returns public plan to anyone', async () => {
+      const { plan } = await createPlanDirectly(db, { visibility: 'public' })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().planId).toBe(plan.planId)
+    })
+
+    it('returns unlisted plan to owner', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const token = await signTestJwt({ sub: OWNER_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().planId).toBe(plan.planId)
+    })
+
+    it('returns unlisted plan to linked participant', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      await linkParticipant(db, plan.planId, PARTICIPANT_USER_ID)
+
+      const token = await signTestJwt({ sub: PARTICIPANT_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().planId).toBe(plan.planId)
+    })
+
+    it('returns 404 for unlisted plan with unrelated JWT user', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const token = await signTestJwt({ sub: UNRELATED_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('returns 404 for unlisted plan without JWT', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('returns 404 for private plan with unrelated JWT user', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'private',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const token = await signTestJwt({ sub: UNRELATED_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('returns 404 for nonexistent plan', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/plans/00000000-0000-0000-0000-000000000000',
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('returns private plan to owner', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'private',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const token = await signTestJwt({ sub: OWNER_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().planId).toBe(plan.planId)
+    })
+
+    it('returns unlisted plan to linked viewer', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      await linkParticipant(db, plan.planId, PARTICIPANT_USER_ID, 'viewer')
+
+      const token = await signTestJwt({ sub: PARTICIPANT_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().planId).toBe(plan.planId)
+    })
+
+    it('returns 404 for unlisted plan with expired JWT', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const expiredToken = await signExpiredJwt()
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${expiredToken}` },
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('returns 404 for unlisted plan with null createdByUserId', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: null,
+      })
+
+      const token = await signTestJwt({ sub: OWNER_USER_ID })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+  })
+
+  describe('Response shape — no information leakage', () => {
+    it('unauthorized 404 is identical to nonexistent 404', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const token = await signTestJwt({ sub: UNRELATED_USER_ID })
+
+      const unauthorizedResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      const nonexistentResponse = await app.inject({
+        method: 'GET',
+        url: '/plans/00000000-0000-0000-0000-000000000000',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(unauthorizedResponse.statusCode).toBe(404)
+      expect(nonexistentResponse.statusCode).toBe(404)
+      expect(unauthorizedResponse.json()).toEqual(nonexistentResponse.json())
+    })
+  })
+
+  describe('Invite route — still works for unlisted plans', () => {
+    it('returns plan data via invite token on unlisted plan', async () => {
+      const { plan, owner } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${owner.inviteToken}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().planId).toBe(plan.planId)
+    })
+
+    it('returns 404 for wrong invite token on unlisted plan', async () => {
+      const { plan } = await createPlanDirectly(db, {
+        visibility: 'unlisted',
+        createdByUserId: OWNER_USER_ID,
+      })
+
+      const fakeToken = randomBytes(32).toString('hex')
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/invite/${fakeToken}`,
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+  })
+})

--- a/tests/integration/user-tracking.test.ts
+++ b/tests/integration/user-tracking.test.ts
@@ -151,6 +151,7 @@ describe('Opportunistic User Tracking', () => {
       const getResponse = await app.inject({
         method: 'GET',
         url: `/plans/${createdPlan.planId}`,
+        headers: { authorization: `Bearer ${token}` },
       })
 
       expect(getResponse.statusCode).toBe(200)

--- a/tests/unit/plans.route.test.ts
+++ b/tests/unit/plans.route.test.ts
@@ -110,10 +110,16 @@ describe('Plans Route - Error Scenarios', () => {
   })
 
   describe('GET /plans/:planId - Database Errors', () => {
+    function mockSelectChainError(error: unknown) {
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockRejectedValue(error),
+        }),
+      })
+    }
+
     it('returns 503 when database connection fails', async () => {
-      mockDb.query.plans.findFirst.mockRejectedValue(
-        new Error('connect ECONNREFUSED')
-      )
+      mockSelectChainError(new Error('connect ECONNREFUSED'))
 
       const response = await app.inject({
         method: 'GET',
@@ -127,9 +133,7 @@ describe('Plans Route - Error Scenarios', () => {
     })
 
     it('returns 500 when database query fails with unknown error', async () => {
-      mockDb.query.plans.findFirst.mockRejectedValue(
-        new Error('Unknown database error')
-      )
+      mockSelectChainError(new Error('Unknown database error'))
 
       const response = await app.inject({
         method: 'GET',
@@ -143,7 +147,7 @@ describe('Plans Route - Error Scenarios', () => {
     })
 
     it('returns 500 when non-Error is thrown', async () => {
-      mockDb.query.plans.findFirst.mockRejectedValue('string error')
+      mockSelectChainError('string error')
 
       const response = await app.inject({
         method: 'GET',
@@ -157,9 +161,7 @@ describe('Plans Route - Error Scenarios', () => {
     })
 
     it('returns 503 when connection timeout occurs', async () => {
-      mockDb.query.plans.findFirst.mockRejectedValue(
-        new Error('connection timeout')
-      )
+      mockSelectChainError(new Error('connection timeout'))
 
       const response = await app.inject({
         method: 'GET',


### PR DESCRIPTION
## Summary

- Plans created by authenticated users (JWT) default to `unlisted` visibility
- `GET /plans/:planId` enforces access control — only owner or linked participants can read non-public plans
- Returns 404 (not 403) for unauthorized access to prevent leaking plan existence
- New `checkPlanAccess()` utility in `src/utils/plan-access.ts`
- 17 integration tests covering all access control scenarios

## What changed

- **`src/utils/plan-access.ts`** (new): Shared access check utility — checks visibility + user relationship (owner via `createdByUserId`, participant via `participants.userId`)
- **`src/routes/plans.route.ts`**: Default `visibility` to `unlisted` when JWT present on `POST /plans/with-owner`. Added access check to `GET /plans/:planId`.
- **`tests/integration/plan-access.test.ts`** (new): 17 tests — visibility defaults, owner/participant/viewer access, expired JWT, orphaned plans, response shape identity, invite route compatibility
- **`tests/integration/user-tracking.test.ts`**: Fixed to send JWT on GET (plans are now unlisted)
- **`tests/unit/plans.route.test.ts`**: Updated DB error mocks for new access check flow
- **`package.json`**: Version bumped to 1.7.0

## Access matrix

| Plan visibility | JWT owner | JWT participant | JWT unrelated | No JWT | Invite token |
|-----------------|-----------|----------------|---------------|--------|-------------|
| public          | 200       | 200            | 200           | 200    | 200 (PII stripped) |
| unlisted        | 200       | 200            | 404           | 404    | 200 (PII stripped) |
| private         | 200       | 200            | 404           | 404    | 200 (PII stripped) |

## Test plan

- [x] Public plans readable by anyone (unchanged behavior)
- [x] Unlisted plans restricted to owner + linked participants
- [x] Private plans restricted to owner + linked participants
- [x] Expired JWT denied access
- [x] Orphaned unlisted plans (null owner) inaccessible
- [x] 404 response identical for unauthorized vs nonexistent
- [x] Invite route still works for unlisted plans
- [x] Wrong invite token returns 404
- [x] All 229 existing + new tests pass

## Related

- Docs updated in chillist-docs (6f9963d)
- FE issue: Alexgub84/chillist-fe#92

Closes #73

Made with [Cursor](https://cursor.com)