### PR TITLE
feat: rename unlisted visibility to invite_only and enforce visibilit…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -163,7 +163,7 @@
             "type": "string",
             "enum": [
               "public",
-              "unlisted",
+              "invite_only",
               "private"
             ]
           },
@@ -284,7 +284,7 @@
             "type": "string",
             "enum": [
               "public",
-              "unlisted",
+              "invite_only",
               "private"
             ]
           },
@@ -337,7 +337,7 @@
             "type": "string",
             "enum": [
               "public",
-              "unlisted",
+              "invite_only",
               "private"
             ]
           },
@@ -408,7 +408,7 @@
             "type": "string",
             "enum": [
               "public",
-              "unlisted",
+              "invite_only",
               "private"
             ]
           },
@@ -959,7 +959,7 @@
             "type": "string",
             "enum": [
               "public",
-              "unlisted",
+              "invite_only",
               "private"
             ]
           },

--- a/drizzle/0007_parched_sage.sql
+++ b/drizzle/0007_parched_sage.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."visibility" RENAME VALUE 'unlisted' TO 'invite_only';

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,732 @@
+{
+  "id": "90cda80d-64bc-418f-a911-9c9495b690ef",
+  "prevId": "778ce7ad-29a9-4869-92e2-13eddcc60ba8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_participant_id": {
+          "name": "assigned_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_assigned_participant_id_participants_participant_id_fk": {
+          "name": "items_assigned_participant_id_participants_participant_id_fk",
+          "tableFrom": "items",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "assigned_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1771842420207,
       "tag": "0006_secret_purple_man",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771863200642,
+      "tag": "0007_parched_sage",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,7 +49,7 @@ export const planStatusEnum = pgEnum('plan_status', [
 ])
 export const visibilityEnum = pgEnum('visibility', [
   'public',
-  'unlisted',
+  'invite_only',
   'private',
 ])
 export const participantRoleEnum = pgEnum('participant_role', [

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -22,7 +22,7 @@ export const planSchema = {
     title: { type: 'string' },
     description: { type: 'string', nullable: true },
     status: { type: 'string', enum: ['draft', 'active', 'archived'] },
-    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    visibility: { type: 'string', enum: ['public', 'invite_only', 'private'] },
     ownerParticipantId: { type: 'string', format: 'uuid', nullable: true },
     createdByUserId: { type: 'string', format: 'uuid', nullable: true },
     location: {
@@ -70,7 +70,7 @@ export const createPlanBodyLegacySchema = {
   properties: {
     title: { type: 'string', minLength: 1, maxLength: 255 },
     description: { type: 'string', nullable: true },
-    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    visibility: { type: 'string', enum: ['public', 'invite_only', 'private'] },
     location: {
       oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
     },
@@ -87,7 +87,7 @@ export const createPlanBodySchema = {
   properties: {
     title: { type: 'string', minLength: 1, maxLength: 255 },
     description: { type: 'string', nullable: true },
-    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    visibility: { type: 'string', enum: ['public', 'invite_only', 'private'] },
     location: {
       oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
     },
@@ -110,7 +110,7 @@ export const updatePlanBodySchema = {
     title: { type: 'string', minLength: 1, maxLength: 255 },
     description: { type: 'string', nullable: true },
     status: { type: 'string', enum: ['draft', 'active', 'archived'] },
-    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    visibility: { type: 'string', enum: ['public', 'invite_only', 'private'] },
     location: {
       oneOf: [{ $ref: 'Location#' }, { type: 'null' }],
     },
@@ -146,7 +146,7 @@ export const planWithDetailsSchema = {
     title: { type: 'string' },
     description: { type: 'string', nullable: true },
     status: { type: 'string', enum: ['draft', 'active', 'archived'] },
-    visibility: { type: 'string', enum: ['public', 'unlisted', 'private'] },
+    visibility: { type: 'string', enum: ['public', 'invite_only', 'private'] },
     ownerParticipantId: { type: 'string', format: 'uuid', nullable: true },
     createdByUserId: { type: 'string', format: 'uuid', nullable: true },
     location: {

--- a/tests/integration/plans.test.ts
+++ b/tests/integration/plans.test.ts
@@ -192,7 +192,6 @@ describe('Plans Route', () => {
         payload: {
           title: 'Beach Trip',
           description: 'A fun beach trip',
-          visibility: 'private',
           location: {
             locationId: 'loc-1',
             name: 'Malibu Beach',
@@ -216,7 +215,7 @@ describe('Plans Route', () => {
       const plan = response.json()
       expect(plan.title).toBe('Beach Trip')
       expect(plan.description).toBe('A fun beach trip')
-      expect(plan.visibility).toBe('private')
+      expect(plan.visibility).toBe('public')
       expect(plan.startDate).toBe('2026-03-01T10:00:00.000Z')
       expect(plan.endDate).toBe('2026-03-05T18:00:00.000Z')
       expect(plan.tags).toEqual(['beach', 'vacation'])
@@ -753,7 +752,6 @@ describe('Plans Route', () => {
           title: 'New Title',
           description: 'New description',
           status: 'archived',
-          visibility: 'private',
           tags: ['camping', 'outdoors'],
         },
       })
@@ -764,7 +762,6 @@ describe('Plans Route', () => {
       expect(updated.title).toBe('New Title')
       expect(updated.description).toBe('New description')
       expect(updated.status).toBe('archived')
-      expect(updated.visibility).toBe('private')
       expect(updated.tags).toEqual(['camping', 'outdoors'])
     })
 


### PR DESCRIPTION
…y rules by auth state

Rename the visibility enum value from 'unlisted' to 'invite_only' for clarity. Add handler-level validation: signed-in users can only use invite_only/private, anonymous users can only use public. Returns descriptive 400 errors. Includes DB migration (ALTER TYPE RENAME VALUE), schema/route/test updates, and FE contract documentation with exact error messages.