### PR TITLE
fix: require SUPABASE_URL in production and add JWT diagnostic logging

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,6 +25,7 @@ services:
       - HOST=0.0.0.0
       - LOG_LEVEL=warn
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/chillist_test
+      - SUPABASE_URL=https://test-project.supabase.co
     depends_on:
       postgres:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,19 +1,24 @@
 import { z } from 'zod'
 
-const envSchema = z.object({
-  PORT: z.coerce.number().default(3333),
-  HOST: z.string().default('0.0.0.0'),
-  NODE_ENV: z
-    .enum(['development', 'production', 'test'])
-    .default('development'),
-  LOG_LEVEL: z
-    .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace'])
-    .default('info'),
-  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
-  FRONTEND_URL: z.string().url().default('http://localhost:5173'),
-  API_KEY: z.string().optional(),
-  SUPABASE_URL: z.string().url().optional(),
-})
+const envSchema = z
+  .object({
+    PORT: z.coerce.number().default(3333),
+    HOST: z.string().default('0.0.0.0'),
+    NODE_ENV: z
+      .enum(['development', 'production', 'test'])
+      .default('development'),
+    LOG_LEVEL: z
+      .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace'])
+      .default('info'),
+    DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+    FRONTEND_URL: z.string().url().default('http://localhost:5173'),
+    API_KEY: z.string().optional(),
+    SUPABASE_URL: z.string().url().optional(),
+  })
+  .refine((env) => env.NODE_ENV !== 'production' || !!env.SUPABASE_URL, {
+    message: 'SUPABASE_URL is required in production',
+    path: ['SUPABASE_URL'],
+  })
 
 export type Env = z.infer<typeof envSchema>
 


### PR DESCRIPTION
SUPABASE_URL was missing on Railway, silently disabling all JWT verification. Every authenticated request got 401.

- Make SUPABASE_URL required in production via Zod refine (fail-fast)
- Add startup log showing JWKS URL and expected issuer
- Add error type to JWT failure logs (expired vs signature vs issuer)
- Add 30s clockTolerance to jwtVerify for clock skew resilience
- Add SUPABASE_URL to docker-compose.test.yml for E2E tests