### PR TITLE
Feat/guest invite auth

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -734,6 +734,14 @@
             "type": "string",
             "nullable": true
           },
+          "inviteStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "invited",
+              "accepted"
+            ]
+          },
           "rsvpStatus": {
             "type": "string",
             "enum": [
@@ -2506,6 +2514,98 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-34"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans/{planId}/claim/{inviteToken}": {
+      "post": {
+        "summary": "Claim a participant spot via invite token",
+        "tags": [
+          "auth"
+        ],
+        "description": "Links an authenticated user (JWT) to an existing participant record identified by the invite token. After claiming, the user can access the plan via JWT without the invite token.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            },
+            "in": "path",
+            "name": "inviteToken",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-18"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import { itemsRoutes } from './routes/items.route.js'
 import { participantsRoutes } from './routes/participants.route.js'
 import { inviteRoutes } from './routes/invite.route.js'
 import { authRoutes } from './routes/auth.route.js'
+import { claimRoutes } from './routes/claim.route.js'
 import { Database } from './db/index.js'
 import authPlugin, { AuthPluginOptions } from './plugins/auth.js'
 import guestAuthPlugin from './plugins/guest-auth.js'
@@ -188,6 +189,7 @@ export async function buildApp(
   await fastify.register(itemsRoutes)
   await fastify.register(inviteRoutes)
   await fastify.register(authRoutes)
+  await fastify.register(claimRoutes)
 
   return fastify
 }

--- a/src/routes/claim.route.ts
+++ b/src/routes/claim.route.ts
@@ -1,0 +1,142 @@
+import { FastifyInstance } from 'fastify'
+import { eq, and } from 'drizzle-orm'
+import { participants, userDetails } from '../db/schema.js'
+
+export async function claimRoutes(fastify: FastifyInstance) {
+  fastify.post<{ Params: { planId: string; inviteToken: string } }>(
+    '/plans/:planId/claim/:inviteToken',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Claim a participant spot via invite token',
+        description:
+          'Links an authenticated user (JWT) to an existing participant record identified by the invite token. After claiming, the user can access the plan via JWT without the invite token.',
+        params: { $ref: 'InviteParams#' },
+        response: {
+          200: { $ref: 'Participant#' },
+          400: { $ref: 'ErrorResponse#' },
+          401: { $ref: 'ErrorResponse#' },
+          404: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.status(401).send({ message: 'Unauthorized' })
+      }
+
+      const { planId, inviteToken } = request.params
+      const userId = request.user.id
+
+      try {
+        const [participant] = await fastify.db
+          .select()
+          .from(participants)
+          .where(
+            and(
+              eq(participants.planId, planId),
+              eq(participants.inviteToken, inviteToken)
+            )
+          )
+
+        if (!participant) {
+          return reply
+            .status(404)
+            .send({ message: 'Invalid invite token or plan not found' })
+        }
+
+        if (participant.userId && participant.userId !== userId) {
+          return reply.status(400).send({
+            message: 'This participant is already linked to another account',
+          })
+        }
+
+        if (participant.userId === userId) {
+          request.log.info(
+            { participantId: participant.participantId, planId, userId },
+            'Claim request is idempotent — participant already linked to this user'
+          )
+          return participant
+        }
+
+        const [existingParticipant] = await fastify.db
+          .select({ participantId: participants.participantId })
+          .from(participants)
+          .where(
+            and(
+              eq(participants.planId, planId),
+              eq(participants.userId, userId)
+            )
+          )
+          .limit(1)
+
+        if (existingParticipant) {
+          return reply.status(400).send({
+            message: 'You are already a participant in this plan',
+          })
+        }
+
+        const updateFields: Record<string, unknown> = {
+          userId,
+          inviteStatus: 'accepted' as const,
+          updatedAt: new Date(),
+        }
+
+        if (!participant.foodPreferences || !participant.allergies) {
+          const [defaults] = await fastify.db
+            .select()
+            .from(userDetails)
+            .where(eq(userDetails.userId, userId))
+
+          if (defaults) {
+            if (!participant.foodPreferences && defaults.foodPreferences) {
+              updateFields.foodPreferences = defaults.foodPreferences
+            }
+            if (!participant.allergies && defaults.allergies) {
+              updateFields.allergies = defaults.allergies
+            }
+          }
+        }
+
+        const [updated] = await fastify.db
+          .update(participants)
+          .set(updateFields)
+          .where(eq(participants.participantId, participant.participantId))
+          .returning()
+
+        request.log.info(
+          {
+            participantId: updated.participantId,
+            planId,
+            userId,
+          },
+          'Participant claimed — user linked to participant record'
+        )
+
+        return updated
+      } catch (error) {
+        request.log.error(
+          { err: error, planId, userId },
+          'Failed to claim participant'
+        )
+
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
+
+        if (isConnectionError) {
+          return reply
+            .status(503)
+            .send({ message: 'Database connection error' })
+        }
+
+        return reply
+          .status(500)
+          .send({ message: 'Failed to claim participant' })
+      }
+    }
+  )
+}

--- a/src/schemas/participant.schema.ts
+++ b/src/schemas/participant.schema.ts
@@ -13,6 +13,10 @@ export const participantSchema = {
     avatarUrl: { type: 'string', nullable: true },
     contactEmail: { type: 'string', nullable: true },
     inviteToken: { type: 'string', nullable: true },
+    inviteStatus: {
+      type: 'string',
+      enum: ['pending', 'invited', 'accepted'],
+    },
     rsvpStatus: {
       type: 'string',
       enum: ['pending', 'confirmed', 'not_sure'],

--- a/tests/integration/claim.test.ts
+++ b/tests/integration/claim.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+  signExpiredJwt,
+  signJwtWithWrongKey,
+} from '../helpers/auth.js'
+import { Database } from '../../src/db/index.js'
+import { eq } from 'drizzle-orm'
+import { plans, participants, userDetails } from '../../src/db/schema.js'
+import { randomBytes } from 'node:crypto'
+
+const USER_A_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const USER_B_ID = 'bbbbbbbb-1111-2222-3333-444444444444'
+
+function generateToken(): string {
+  return randomBytes(32).toString('hex')
+}
+
+async function createPlanWithParticipant(
+  db: Database,
+  overrides: {
+    visibility?: 'public' | 'invite_only' | 'private'
+    createdByUserId?: string | null
+    participantUserId?: string | null
+    participantRole?: 'owner' | 'participant' | 'viewer'
+  } = {}
+) {
+  const [plan] = await db
+    .insert(plans)
+    .values({
+      title: 'Test Plan',
+      status: 'active',
+      visibility: overrides.visibility ?? 'invite_only',
+      createdByUserId: overrides.createdByUserId ?? null,
+    })
+    .returning()
+
+  const inviteToken = generateToken()
+  const [participant] = await db
+    .insert(participants)
+    .values({
+      planId: plan.planId,
+      name: 'Guest',
+      lastName: 'User',
+      contactPhone: '+1-555-000-0001',
+      role: overrides.participantRole ?? 'participant',
+      userId: overrides.participantUserId ?? null,
+      inviteToken,
+    })
+    .returning()
+
+  return { plan, participant, inviteToken }
+}
+
+describe('POST /plans/:planId/claim/:inviteToken', () => {
+  let app: FastifyInstance
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  it('links authenticated user to participant record', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db)
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.userId).toBe(USER_A_ID)
+    expect(body.inviteStatus).toBe('accepted')
+    expect(body.planId).toBe(plan.planId)
+    expect(body.name).toBe('Guest')
+    expect(body.lastName).toBe('User')
+  })
+
+  it('plan appears in user plan list after claiming', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db)
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    const listResponse = await app.inject({
+      method: 'GET',
+      url: '/plans',
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(listResponse.statusCode).toBe(200)
+    const planList = listResponse.json()
+    expect(
+      planList.some((p: { planId: string }) => p.planId === plan.planId)
+    ).toBe(true)
+  })
+
+  it('returns 200 idempotently when participant already linked to same user', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db, {
+      participantUserId: USER_A_ID,
+    })
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().userId).toBe(USER_A_ID)
+  })
+
+  it('pre-fills empty participant preferences from user_details defaults', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db)
+
+    await db.insert(userDetails).values({
+      userId: USER_A_ID,
+      foodPreferences: 'Vegetarian',
+      allergies: 'Peanuts',
+    })
+
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.foodPreferences).toBe('Vegetarian')
+    expect(body.allergies).toBe('Peanuts')
+  })
+
+  it('preserves existing participant preferences when user_details exist', async () => {
+    const { plan, participant, inviteToken } =
+      await createPlanWithParticipant(db)
+
+    await db
+      .update(participants)
+      .set({ foodPreferences: 'Vegan', allergies: 'Gluten' })
+      .where(eq(participants.participantId, participant.participantId))
+
+    await db.insert(userDetails).values({
+      userId: USER_A_ID,
+      foodPreferences: 'Vegetarian',
+      allergies: 'Peanuts',
+    })
+
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.foodPreferences).toBe('Vegan')
+    expect(body.allergies).toBe('Gluten')
+  })
+
+  it('returns 401 without JWT', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { 'x-api-key': 'test-key' },
+    })
+
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 401 with expired JWT', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db)
+    const jwt = await signExpiredJwt()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 401 with wrong key JWT', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db)
+    const jwt = await signJwtWithWrongKey()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 404 for non-existent invite token', async () => {
+    const { plan } = await createPlanWithParticipant(db)
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+    const fakeToken = generateToken()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${fakeToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe(
+      'Invalid invite token or plan not found'
+    )
+  })
+
+  it('returns 404 when invite token belongs to a different plan', async () => {
+    const { inviteToken } = await createPlanWithParticipant(db)
+    const { plan: otherPlan } = await createPlanWithParticipant(db)
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${otherPlan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(404)
+  })
+
+  it('returns 400 when participant is already linked to a different user', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db, {
+      participantUserId: USER_B_ID,
+    })
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json().message).toBe(
+      'This participant is already linked to another account'
+    )
+  })
+
+  it('returns 400 when user is already a participant in the plan', async () => {
+    const { plan, inviteToken: firstToken } =
+      await createPlanWithParticipant(db)
+
+    await db.insert(participants).values({
+      planId: plan.planId,
+      name: 'Already',
+      lastName: 'Linked',
+      contactPhone: '+1-555-000-0099',
+      role: 'participant',
+      userId: USER_A_ID,
+      inviteToken: generateToken(),
+    })
+
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${firstToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json().message).toBe(
+      'You are already a participant in this plan'
+    )
+  })
+
+  it('allows owner to claim their own participant spot', async () => {
+    const { plan, inviteToken } = await createPlanWithParticipant(db, {
+      createdByUserId: USER_A_ID,
+      participantRole: 'owner',
+    })
+    const jwt = await signTestJwt({ sub: USER_A_ID })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${plan.planId}/claim/${inviteToken}`,
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().userId).toBe(USER_A_ID)
+    expect(response.json().role).toBe('owner')
+  })
+})


### PR DESCRIPTION
- Add `POST /plans/:planId/claim/:inviteToken` endpoint that links a signed-up user's Supabase account to their existing guest participant record
- Validates token ownership, prevents double-claiming, pre-fills empty preferences from `user_details` defaults
- Idempotent for same-user re-claims
- Add `inviteStatus` field to Participant response schema
- 13 integration tests covering happy path, auth errors, business rule violations, preference handling, and idempotency
- Version bump 1.11.0 → 1.12.0

Closes #93

## Test plan

- [x] Happy path: valid JWT + valid invite token links participant
- [x] Plan appears in user's plan list after claiming
- [x] Idempotent: re-claiming same spot returns 200
- [x] Pre-fills empty preferences from user_details defaults
- [x] Preserves existing guest-set preferences
- [x] 401 without JWT / expired JWT / wrong key JWT
- [x] 404 for invalid token / cross-plan token
- [x] 400 for already claimed by other user / user already in plan
- [x] Owner can claim their own participant spot
- [x] All 336 existing tests still pass