### PR TITLE
feat: add claim endpoint to link guest participant to authenticated user

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -24,6 +24,17 @@ Before writing any code, FIRST use the Read tool on ALL of these files:
 Read the docs FIRST, then explore the specific files in this repo that are relevant to the task.
 Do NOT scan the entire codebase upfront - only look at files directly related to the work.
 
+# Before Committing
+
+Always pull main and merge into your feature branch before committing:
+
+1. `git fetch origin main`
+2. `git merge origin/main` (resolve conflicts if any)
+3. Run `npm run openapi:generate` to regenerate the OpenAPI spec
+4. Then stage, commit, and push
+
+This prevents branch conflicts in PRs caused by stale branches.
+
 # Updating Documentation
 
 When you fix a bug, learn something new, or change workflow:
@@ -31,4 +42,4 @@ When you fix a bug, learn something new, or change workflow:
 - If the fix implies a new rule, propose adding it to ../chillist-docs/rules/backend.md
 - If specs changed (features done, new endpoints), update ../chillist-docs/specs/mvp-v1.md
 - If setup/scripts changed, update ../chillist-docs/guides/backend.md
-- If API routes or schemas changed, run npm run openapi:generate and commit docs/openapi.json
+- If API routes or schemas changed, run npm run openapi:generate and commit docs/openapi.json (note: the pre-commit hook now auto-generates and stages this, but run it manually when validating changes before commit)


### PR DESCRIPTION
## Summary

- Add `POST /plans/:planId/claim/:inviteToken` endpoint that links a signed-up user's Supabase account to their existing guest participant record
- Validates token ownership, prevents double-claiming, pre-fills empty preferences from `user_details` defaults
- Idempotent for same-user re-claims
- Add `inviteStatus` field to Participant response schema
- 13 integration tests covering happy path, auth errors, business rule violations, preference handling, and idempotency
- Version bump 1.11.0 → 1.12.0

Closes #93

## Test plan

- [x] Happy path: valid JWT + valid invite token links participant
- [x] Plan appears in user's plan list after claiming
- [x] Idempotent: re-claiming same spot returns 200
- [x] Pre-fills empty preferences from user_details defaults
- [x] Preserves existing guest-set preferences
- [x] 401 without JWT / expired JWT / wrong key JWT
- [x] 404 for invalid token / cross-plan token
- [x] 400 for already claimed by other user / user already in plan
- [x] Owner can claim their own participant spot
- [x] All 336 existing tests still pass


Made with [Cursor](https://cursor.com)