### PR TITLE
feat: add claim endpoint to link guest participant to authenticated user

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -26,14 +26,18 @@ Do NOT scan the entire codebase upfront - only look at files directly related to
 
 # Before Committing
 
-Always pull main and merge into your feature branch before committing:
+Always do the following before committing:
 
-1. `git fetch origin main`
-2. `git merge origin/main` (resolve conflicts if any)
-3. Run `npm run openapi:generate` to regenerate the OpenAPI spec
+1. Pull main and merge: `git fetch origin main && git merge origin/main` (resolve conflicts if any)
+2. Run `npm run openapi:generate` to regenerate the OpenAPI spec
+3. Update docs in `../chillist-docs/` if the change affects them:
+   - `guides/backend.md` — update "What's next" section when phases/steps are completed
+   - `specs/mvp-v1.md` — update Auth status row when auth milestones are reached
+   - `specs/user-management.md` — update phase/step status and endpoint tables
+   - `dev-lessons/backend.md` — add entry if a bug was fixed or a non-obvious lesson learned
 4. Then stage, commit, and push
 
-This prevents branch conflicts in PRs caused by stale branches.
+This prevents branch conflicts and keeps documentation in sync with code.
 
 # Updating Documentation
 


### PR DESCRIPTION
## Summary

- Add `POST /plans/:planId/claim/:inviteToken` endpoint that links a signed-up user's Supabase account to their existing guest participant record
- Validates token ownership, prevents double-claiming, pre-fills empty preferences from `user_details` defaults
- Idempotent for same-user re-claims
- Add `inviteStatus` field to Participant response schema
- 13 integration tests covering happy path, auth errors, business rule violations, preference handling, and idempotency
- Version bump 1.11.0 to 1.12.0

Closes #93

## Test plan

- [x] Happy path: valid JWT + valid invite token links participant
- [x] Plan appears in user plan list after claiming
- [x] Idempotent: re-claiming same spot returns 200
- [x] Pre-fills empty preferences from user_details defaults
- [x] Preserves existing guest-set preferences
- [x] 401 without JWT / expired JWT / wrong key JWT
- [x] 404 for invalid token / cross-plan token
- [x] 400 for already claimed by other user / user already in plan
- [x] Owner can claim their own participant spot
- [x] All 336 existing tests still pass