### PR TITLE
feat: add owner PATCH endpoint to manage join requests (issue #110)

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -11,6 +11,10 @@ If a task requires frontend changes, stop and tell the user to switch to the fro
 
 The ONE exception: you MAY read and write files in ../chillist-docs/ (the shared docs repo) to read rules/docs and update dev-lessons, guides, specs, or rules when needed.
 
+# Issue Creation
+
+When asked to create GitHub issues: see `../chillist-docs/guides/issue-management.md`.
+
 # How to Start Every Task
 
 Before writing any code, FIRST use the Read tool on ALL of these files:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,16 @@ Server runs at `http://localhost:3333`. Swagger UI at `http://localhost:3333/doc
 
 - Routes: `src/routes/participants.route.ts`
 - Schemas: `src/schemas/participant.schema.ts`
+- Service: `src/services/participant.service.ts` (shared participant creation logic)
 - Invite interactions: `src/routes/invite.route.ts`
+
+### Join requests
+
+- Routes: `src/routes/join-request.route.ts`
+- Schemas: `src/schemas/join-request.schema.ts`
+- Service: `src/services/participant.service.ts` (participant creation from approved join request)
+- DB: `participantJoinRequests` in `src/db/schema.ts`
+- Tests: `tests/integration/join-request.test.ts`, `tests/integration/join-requests-schema.test.ts`
 
 ### Items
 
@@ -109,7 +118,8 @@ Server runs at `http://localhost:3333`. Swagger UI at `http://localhost:3333/doc
 1. Identify domain route file in `src/routes/`.
 2. Add or update schema in `src/schemas/` (do not inline complex schemas in route files).
 3. Register schema in `src/schemas/index.ts` if it is new.
-4. Implement or update the route handler in `src/routes/<domain>.route.ts`.
+4. Implement or update the route handler in `src/routes/<domain>.route.ts`. If the handler needs reusable business logic (e.g., creating a participant, syncing profiles), put it in `src/services/`. Services are pure functions that receive `db` as an argument (DI) — no Fastify coupling.
+
 5. If needed, update plugin/type wiring (`src/plugins/*`, `src/types/fastify.d.ts`, `src/app.ts` route/plugin registration).
 6. Add or update tests in `tests/integration/` (and unit tests where relevant).
 7. Regenerate OpenAPI: `npm run openapi:generate`.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1002,7 +1002,7 @@
             "$ref": "#/components/schemas/def-18"
           },
           "joinRequests": {
-            "$ref": "#/components/schemas/def-28"
+            "$ref": "#/components/schemas/def-30"
           }
         },
         "required": [
@@ -1153,6 +1153,40 @@
       "def-27": {
         "type": "object",
         "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "requestId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "planId",
+          "requestId"
+        ],
+        "title": "JoinRequestActionParams"
+      },
+      "def-28": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "rejected"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "UpdateJoinRequestStatusBody"
+      },
+      "def-29": {
+        "type": "object",
+        "properties": {
           "status": {
             "type": "string",
             "enum": [
@@ -1180,14 +1214,14 @@
         ],
         "title": "PlanNotParticipantResponse"
       },
-      "def-28": {
+      "def-30": {
         "type": "array",
         "items": {
           "$ref": "#/components/schemas/def-26"
         },
         "title": "JoinRequestList"
       },
-      "def-29": {
+      "def-31": {
         "type": "object",
         "properties": {
           "name": {
@@ -1239,7 +1273,7 @@
         ],
         "title": "CreateJoinRequestBody"
       },
-      "def-30": {
+      "def-32": {
         "type": "object",
         "properties": {
           "planId": {
@@ -1258,7 +1292,7 @@
         ],
         "title": "InviteParams"
       },
-      "def-31": {
+      "def-33": {
         "type": "object",
         "properties": {
           "participantId": {
@@ -1284,14 +1318,14 @@
         ],
         "title": "InviteParticipant"
       },
-      "def-32": {
+      "def-34": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-31"
+          "$ref": "#/components/schemas/def-33"
         },
         "title": "InviteParticipantList"
       },
-      "def-33": {
+      "def-35": {
         "type": "object",
         "properties": {
           "adultsCount": {
@@ -1317,7 +1351,7 @@
         },
         "title": "InviteMyPreferences"
       },
-      "def-34": {
+      "def-36": {
         "type": "object",
         "properties": {
           "planId": {
@@ -1378,7 +1412,7 @@
             "$ref": "#/components/schemas/def-13"
           },
           "participants": {
-            "$ref": "#/components/schemas/def-32"
+            "$ref": "#/components/schemas/def-34"
           },
           "myParticipantId": {
             "type": "string",
@@ -1393,7 +1427,7 @@
             ]
           },
           "myPreferences": {
-            "$ref": "#/components/schemas/def-33"
+            "$ref": "#/components/schemas/def-35"
           }
         },
         "required": [
@@ -1410,7 +1444,7 @@
         ],
         "title": "InvitePlanResponse"
       },
-      "def-35": {
+      "def-37": {
         "type": "object",
         "properties": {
           "planId": {
@@ -1428,7 +1462,7 @@
         ],
         "title": "RegenerateTokenParams"
       },
-      "def-36": {
+      "def-38": {
         "type": "object",
         "properties": {
           "inviteToken": {
@@ -1440,7 +1474,7 @@
         ],
         "title": "RegenerateTokenResponse"
       },
-      "def-37": {
+      "def-39": {
         "type": "object",
         "properties": {
           "displayName": {
@@ -1480,7 +1514,7 @@
         },
         "title": "UpdateInvitePreferencesBody"
       },
-      "def-38": {
+      "def-40": {
         "type": "object",
         "properties": {
           "participantId": {
@@ -1535,7 +1569,7 @@
         ],
         "title": "InvitePreferencesResponse"
       },
-      "def-39": {
+      "def-41": {
         "type": "object",
         "properties": {
           "planId": {
@@ -1559,7 +1593,7 @@
         ],
         "title": "InviteItemParams"
       },
-      "def-40": {
+      "def-42": {
         "type": "object",
         "properties": {
           "name": {
@@ -1611,7 +1645,7 @@
         ],
         "title": "CreateInviteItemBody"
       },
-      "def-41": {
+      "def-43": {
         "type": "object",
         "properties": {
           "name": {
@@ -1667,7 +1701,7 @@
         },
         "title": "UpdateInviteItemBody"
       },
-      "def-42": {
+      "def-44": {
         "type": "object",
         "properties": {
           "items": {
@@ -1683,7 +1717,7 @@
         ],
         "title": "BulkCreateItemBody"
       },
-      "def-43": {
+      "def-45": {
         "type": "object",
         "properties": {
           "itemId": {
@@ -1751,13 +1785,13 @@
         ],
         "title": "BulkUpdateItemEntry"
       },
-      "def-44": {
+      "def-46": {
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-43"
+              "$ref": "#/components/schemas/def-45"
             },
             "minItems": 1
           }
@@ -1767,7 +1801,7 @@
         ],
         "title": "BulkUpdateItemBody"
       },
-      "def-45": {
+      "def-47": {
         "type": "object",
         "properties": {
           "name": {
@@ -1783,7 +1817,7 @@
         ],
         "title": "BulkItemError"
       },
-      "def-46": {
+      "def-48": {
         "type": "object",
         "properties": {
           "items": {
@@ -1792,7 +1826,7 @@
           "errors": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-45"
+              "$ref": "#/components/schemas/def-47"
             }
           }
         },
@@ -1802,13 +1836,13 @@
         ],
         "title": "BulkItemResponse"
       },
-      "def-47": {
+      "def-49": {
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-40"
+              "$ref": "#/components/schemas/def-42"
             },
             "minItems": 1
           }
@@ -1818,7 +1852,7 @@
         ],
         "title": "BulkCreateInviteItemBody"
       },
-      "def-48": {
+      "def-50": {
         "type": "object",
         "properties": {
           "itemId": {
@@ -1881,13 +1915,13 @@
         ],
         "title": "BulkUpdateInviteItemEntry"
       },
-      "def-49": {
+      "def-51": {
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-48"
+              "$ref": "#/components/schemas/def-50"
             },
             "minItems": 1
           }
@@ -1897,7 +1931,7 @@
         ],
         "title": "BulkUpdateInviteItemBody"
       },
-      "def-50": {
+      "def-52": {
         "type": "object",
         "properties": {
           "foodPreferences": {
@@ -1921,7 +1955,7 @@
         },
         "title": "UserPreferences"
       },
-      "def-51": {
+      "def-53": {
         "type": "object",
         "properties": {
           "user": {
@@ -1946,7 +1980,7 @@
           "preferences": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-50"
+                "$ref": "#/components/schemas/def-52"
               },
               {
                 "type": "null"
@@ -1961,7 +1995,7 @@
         ],
         "title": "ProfileResponse"
       },
-      "def-52": {
+      "def-54": {
         "type": "object",
         "properties": {
           "foodPreferences": {
@@ -1985,11 +2019,11 @@
         },
         "title": "UpdateProfileBody"
       },
-      "def-53": {
+      "def-55": {
         "type": "object",
         "properties": {
           "preferences": {
-            "$ref": "#/components/schemas/def-50"
+            "$ref": "#/components/schemas/def-52"
           }
         },
         "required": [
@@ -2241,7 +2275,7 @@
                       "$ref": "#/components/schemas/def-23"
                     },
                     {
-                      "$ref": "#/components/schemas/def-27"
+                      "$ref": "#/components/schemas/def-29"
                     }
                   ]
                 }
@@ -2835,7 +2869,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-36"
+                  "$ref": "#/components/schemas/def-38"
                 }
               }
             }
@@ -3106,7 +3140,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-42"
+                "$ref": "#/components/schemas/def-44"
               }
             }
           }
@@ -3128,7 +3162,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3138,7 +3172,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3185,7 +3219,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-44"
+                "$ref": "#/components/schemas/def-46"
               }
             }
           }
@@ -3207,7 +3241,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3217,7 +3251,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3279,7 +3313,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-34"
+                  "$ref": "#/components/schemas/def-36"
                 }
               }
             }
@@ -3328,7 +3362,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-37"
+                "$ref": "#/components/schemas/def-39"
               }
             }
           }
@@ -3360,7 +3394,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-38"
+                  "$ref": "#/components/schemas/def-40"
                 }
               }
             }
@@ -3419,7 +3453,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-40"
+                "$ref": "#/components/schemas/def-42"
               }
             }
           }
@@ -3510,7 +3544,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-41"
+                "$ref": "#/components/schemas/def-43"
               }
             }
           }
@@ -3620,7 +3654,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-47"
+                "$ref": "#/components/schemas/def-49"
               }
             }
           }
@@ -3652,7 +3686,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3662,7 +3696,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3709,7 +3743,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-49"
+                "$ref": "#/components/schemas/def-51"
               }
             }
           }
@@ -3741,7 +3775,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3751,7 +3785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-46"
+                  "$ref": "#/components/schemas/def-48"
                 }
               }
             }
@@ -3847,7 +3881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-51"
+                  "$ref": "#/components/schemas/def-53"
                 }
               }
             }
@@ -3864,7 +3898,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-52"
+                "$ref": "#/components/schemas/def-54"
               }
             }
           }
@@ -3875,7 +3909,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-53"
+                  "$ref": "#/components/schemas/def-55"
                 }
               }
             }
@@ -4035,7 +4069,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-29"
+                "$ref": "#/components/schemas/def-31"
               }
             }
           }
@@ -4083,6 +4117,124 @@
             }
           },
           "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans/{planId}/join-requests/{requestId}": {
+      "patch": {
+        "summary": "Approve or reject a join request",
+        "tags": [
+          "plans"
+        ],
+        "description": "Owner or admin updates a pending join request. Approved requests create a new participant linked to the requester. Rejected requests update status only.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-28"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "403": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/routes/join-request.route.ts
+++ b/src/routes/join-request.route.ts
@@ -2,6 +2,8 @@ import { FastifyInstance } from 'fastify'
 import { eq, and } from 'drizzle-orm'
 import { plans, participantJoinRequests } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
+import { isAdmin } from '../utils/admin.js'
+import { addParticipantToPlan } from '../services/participant.service.js'
 
 interface CreateJoinRequestBody {
   name: string
@@ -179,6 +181,167 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
 
         return reply.status(500).send({
           message: 'Failed to create join request',
+        })
+      }
+    }
+  )
+
+  fastify.patch<{
+    Params: { planId: string; requestId: string }
+    Body: { status: 'approved' | 'rejected' }
+  }>(
+    '/plans/:planId/join-requests/:requestId',
+    {
+      schema: {
+        tags: ['plans'],
+        summary: 'Approve or reject a join request',
+        description:
+          'Owner or admin updates a pending join request. Approved requests create a new participant linked to the requester. Rejected requests update status only.',
+        params: { $ref: 'JoinRequestActionParams#' },
+        body: { $ref: 'UpdateJoinRequestStatusBody#' },
+        response: {
+          200: {},
+          400: { $ref: 'ErrorResponse#' },
+          401: { $ref: 'ErrorResponse#' },
+          403: { $ref: 'ErrorResponse#' },
+          404: { $ref: 'ErrorResponse#' },
+          409: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { planId, requestId } = request.params
+      const { status: newStatus } = request.body
+      const userId = request.user!.id
+
+      try {
+        const [plan] = await fastify.db
+          .select()
+          .from(plans)
+          .where(eq(plans.planId, planId))
+          .limit(1)
+
+        if (!plan) {
+          return reply.status(404).send({ message: 'Plan not found' })
+        }
+
+        if (plan.createdByUserId !== userId && !isAdmin(request.user)) {
+          request.log.warn(
+            { planId, userId, requestId },
+            'Join request action rejected — not owner or admin'
+          )
+          return reply
+            .status(403)
+            .send({ message: 'Only the plan owner can manage join requests' })
+        }
+
+        const [joinRequest] = await fastify.db
+          .select()
+          .from(participantJoinRequests)
+          .where(
+            and(
+              eq(participantJoinRequests.requestId, requestId),
+              eq(participantJoinRequests.planId, planId)
+            )
+          )
+          .limit(1)
+
+        if (!joinRequest) {
+          return reply.status(404).send({ message: 'Join request not found' })
+        }
+
+        if (joinRequest.status !== 'pending') {
+          return reply.status(409).send({
+            message: `Join request has already been ${joinRequest.status}`,
+          })
+        }
+
+        if (newStatus === 'approved') {
+          const participant = await addParticipantToPlan(fastify.db, {
+            planId,
+            userId: joinRequest.supabaseUserId,
+            name: joinRequest.name,
+            lastName: joinRequest.lastName,
+            contactPhone: joinRequest.contactPhone,
+            contactEmail: joinRequest.contactEmail,
+            displayName: joinRequest.displayName,
+            adultsCount: joinRequest.adultsCount,
+            kidsCount: joinRequest.kidsCount,
+            foodPreferences: joinRequest.foodPreferences,
+            allergies: joinRequest.allergies,
+            notes: joinRequest.notes,
+          })
+
+          await fastify.db
+            .update(participantJoinRequests)
+            .set({ status: 'approved', updatedAt: new Date() })
+            .where(eq(participantJoinRequests.requestId, requestId))
+
+          const result = participant
+
+          request.log.info(
+            {
+              planId,
+              requestId,
+              participantId: result.participantId,
+              approvedUserId: joinRequest.supabaseUserId,
+            },
+            'Join request approved — participant created'
+          )
+
+          return reply.status(200).send(result)
+        }
+
+        const [updated] = await fastify.db
+          .update(participantJoinRequests)
+          .set({ status: 'rejected', updatedAt: new Date() })
+          .where(eq(participantJoinRequests.requestId, requestId))
+          .returning()
+
+        request.log.info(
+          { planId, requestId, rejectedUserId: joinRequest.supabaseUserId },
+          'Join request rejected'
+        )
+
+        return reply.status(200).send({
+          requestId: updated.requestId,
+          planId: updated.planId,
+          supabaseUserId: updated.supabaseUserId,
+          name: updated.name,
+          lastName: updated.lastName,
+          contactPhone: updated.contactPhone,
+          contactEmail: updated.contactEmail,
+          displayName: updated.displayName,
+          adultsCount: updated.adultsCount,
+          kidsCount: updated.kidsCount,
+          foodPreferences: updated.foodPreferences,
+          allergies: updated.allergies,
+          notes: updated.notes,
+          status: updated.status,
+          createdAt: updated.createdAt,
+          updatedAt: updated.updatedAt,
+        })
+      } catch (error) {
+        request.log.error(
+          { err: error, planId, requestId, userId },
+          'Failed to update join request'
+        )
+
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
+
+        if (isConnectionError) {
+          return reply.status(503).send({
+            message: 'Database connection error',
+          })
+        }
+
+        return reply.status(500).send({
+          message: 'Failed to update join request',
         })
       }
     }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -22,6 +22,8 @@ import {
 import {
   joinRequestSchema,
   joinRequestListSchema,
+  joinRequestActionParamsSchema,
+  updateJoinRequestStatusBodySchema,
   createJoinRequestBodySchema,
 } from './join-request.schema.js'
 import {
@@ -96,6 +98,8 @@ const schemas = [
   planNotLoggedInResponseSchema,
   planPreviewFieldsSchema,
   joinRequestSchema,
+  joinRequestActionParamsSchema,
+  updateJoinRequestStatusBodySchema,
   planNotParticipantResponseSchema,
   joinRequestListSchema,
   createJoinRequestBodySchema,

--- a/src/schemas/join-request.schema.ts
+++ b/src/schemas/join-request.schema.ts
@@ -16,6 +16,25 @@ export const createJoinRequestBodySchema = {
   required: ['name', 'lastName', 'contactPhone'],
 } as const
 
+export const joinRequestActionParamsSchema = {
+  $id: 'JoinRequestActionParams',
+  type: 'object',
+  properties: {
+    planId: { type: 'string', format: 'uuid' },
+    requestId: { type: 'string', format: 'uuid' },
+  },
+  required: ['planId', 'requestId'],
+} as const
+
+export const updateJoinRequestStatusBodySchema = {
+  $id: 'UpdateJoinRequestStatusBody',
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['approved', 'rejected'] },
+  },
+  required: ['status'],
+} as const
+
 export const joinRequestListSchema = {
   $id: 'JoinRequestList',
   type: 'array',

--- a/src/services/participant.service.ts
+++ b/src/services/participant.service.ts
@@ -1,0 +1,70 @@
+import { eq } from 'drizzle-orm'
+import type { Database } from '../db/index.js'
+import { participants, userDetails, Participant } from '../db/schema.js'
+
+export interface AddParticipantData {
+  planId: string
+  userId: string
+  name: string
+  lastName: string
+  contactPhone: string
+  contactEmail?: string | null
+  displayName?: string | null
+  adultsCount?: number | null
+  kidsCount?: number | null
+  foodPreferences?: string | null
+  allergies?: string | null
+  notes?: string | null
+  role?: 'participant' | 'viewer'
+  inviteToken?: string | null
+  inviteStatus?: 'pending' | 'invited' | 'accepted'
+  rsvpStatus?: 'pending' | 'confirmed' | 'not_sure'
+}
+
+export async function addParticipantToPlan(
+  db: Database,
+  data: AddParticipantData
+): Promise<Participant> {
+  let foodPreferences = data.foodPreferences ?? null
+  let allergies = data.allergies ?? null
+
+  if ((!foodPreferences || !allergies) && data.userId) {
+    const [defaults] = await db
+      .select()
+      .from(userDetails)
+      .where(eq(userDetails.userId, data.userId))
+
+    if (defaults) {
+      if (!foodPreferences && defaults.foodPreferences) {
+        foodPreferences = defaults.foodPreferences
+      }
+      if (!allergies && defaults.allergies) {
+        allergies = defaults.allergies
+      }
+    }
+  }
+
+  const [created] = await db
+    .insert(participants)
+    .values({
+      planId: data.planId,
+      userId: data.userId,
+      name: data.name,
+      lastName: data.lastName,
+      contactPhone: data.contactPhone,
+      contactEmail: data.contactEmail ?? null,
+      displayName: data.displayName ?? null,
+      adultsCount: data.adultsCount ?? null,
+      kidsCount: data.kidsCount ?? null,
+      foodPreferences,
+      allergies,
+      notes: data.notes ?? null,
+      role: data.role ?? 'participant',
+      inviteToken: data.inviteToken ?? null,
+      inviteStatus: data.inviteStatus ?? 'accepted',
+      rsvpStatus: data.rsvpStatus ?? 'confirmed',
+    })
+    .returning()
+
+  return created
+}

--- a/tests/integration/join-request.test.ts
+++ b/tests/integration/join-request.test.ts
@@ -1,0 +1,657 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  seedTestJoinRequests,
+  seedTestParticipantWithUser,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+} from '../helpers/auth.js'
+import { Database } from '../../src/db/index.js'
+import { plans, participants, userDetails } from '../../src/db/schema.js'
+import { randomBytes } from 'node:crypto'
+
+const OWNER_USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const REQUESTER_USER_ID = 'bbbbbbbb-1111-2222-3333-444444444444'
+const OTHER_USER_ID = 'cccccccc-1111-2222-3333-444444444444'
+const ADMIN_USER_ID = 'dddddddd-1111-2222-3333-444444444444'
+const FAKE_REQUEST_ID = 'eeeeeeee-1111-2222-3333-444444444444'
+const FAKE_PLAN_ID = 'ffffffff-1111-2222-3333-444444444444'
+
+async function createPlanWithOwner(db: Database, ownerUserId: string) {
+  const [plan] = await db
+    .insert(plans)
+    .values({
+      title: 'Test Plan',
+      status: 'active',
+      visibility: 'invite_only',
+      createdByUserId: ownerUserId,
+    })
+    .returning()
+
+  const [owner] = await db
+    .insert(participants)
+    .values({
+      planId: plan.planId,
+      name: 'Owner',
+      lastName: 'User',
+      contactPhone: '+1-555-000-0001',
+      role: 'owner',
+      userId: ownerUserId,
+      inviteToken: randomBytes(32).toString('hex'),
+    })
+    .returning()
+
+  return { plan, owner }
+}
+
+describe('Join Request Management', () => {
+  let app: FastifyInstance
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('PATCH /plans/:planId/join-requests/:requestId — approve', () => {
+    it('owner approves pending request — 200, returns participant with correct fields', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        {
+          name: 'Jane',
+          lastName: 'Doe',
+          contactPhone: '+1-555-999-0000',
+          contactEmail: 'jane@example.com',
+          displayName: 'JaneD',
+          adultsCount: 2,
+          kidsCount: 1,
+          foodPreferences: 'vegetarian',
+          allergies: 'nuts',
+          notes: 'Excited to join!',
+        }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.userId).toBe(REQUESTER_USER_ID)
+      expect(body.planId).toBe(plan.planId)
+      expect(body.name).toBe('Jane')
+      expect(body.lastName).toBe('Doe')
+      expect(body.contactPhone).toBe('+1-555-999-0000')
+      expect(body.contactEmail).toBe('jane@example.com')
+      expect(body.displayName).toBe('JaneD')
+      expect(body.adultsCount).toBe(2)
+      expect(body.kidsCount).toBe(1)
+      expect(body.foodPreferences).toBe('vegetarian')
+      expect(body.allergies).toBe('nuts')
+      expect(body.notes).toBe('Excited to join!')
+      expect(body.role).toBe('participant')
+      expect(body.rsvpStatus).toBe('confirmed')
+      expect(body.inviteToken).toBeNull()
+      expect(body.inviteStatus).toBe('accepted')
+      expect(body.participantId).toBeDefined()
+    })
+
+    it('approved participant appears in GET /plans/:planId/participants', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      const listResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/participants`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+      })
+
+      expect(listResponse.statusCode).toBe(200)
+      const list = listResponse.json()
+      const requesterParticipant = list.find(
+        (p: { userId: string }) => p.userId === REQUESTER_USER_ID
+      )
+      expect(requesterParticipant).toBeDefined()
+      expect(requesterParticipant.role).toBe('participant')
+    })
+
+    it('approved user can access full plan via GET /plans/:planId', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      const requesterToken = await signTestJwt({ sub: REQUESTER_USER_ID })
+      const planResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+      })
+
+      expect(planResponse.statusCode).toBe(200)
+      const body = planResponse.json()
+      expect(body.planId).toBe(plan.planId)
+      expect(body.status).not.toBe('not_participant')
+      expect(body.participants).toBeDefined()
+    })
+
+    it('pre-fills foodPreferences/allergies from user_details when missing on request', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+
+      await db.insert(userDetails).values({
+        userId: REQUESTER_USER_ID,
+        foodPreferences: 'kosher',
+        allergies: 'shellfish',
+      })
+
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        { foodPreferences: null, allergies: null }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.foodPreferences).toBe('kosher')
+      expect(body.allergies).toBe('shellfish')
+    })
+
+    it('does not overwrite existing foodPreferences/allergies from join request', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+
+      await db.insert(userDetails).values({
+        userId: REQUESTER_USER_ID,
+        foodPreferences: 'kosher',
+        allergies: 'shellfish',
+      })
+
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        { foodPreferences: 'vegan', allergies: 'peanuts' }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.foodPreferences).toBe('vegan')
+      expect(body.allergies).toBe('peanuts')
+    })
+
+    it('returns 409 for already-approved request', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(409)
+      expect(response.json().message).toContain('already been approved')
+    })
+
+    it('returns 409 for already-rejected request', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        { status: 'rejected' }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(409)
+      expect(response.json().message).toContain('already been rejected')
+    })
+
+    it('returns 403 for non-owner participant', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      await seedTestParticipantWithUser(plan.planId, OTHER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const otherToken = await signTestJwt({ sub: OTHER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${otherToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(403)
+    })
+
+    it('returns 401 without JWT', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+
+    it('returns 404 for non-existent requestId', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${FAKE_REQUEST_ID}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json().message).toContain('Join request not found')
+    })
+
+    it('returns 404 for non-existent planId', async () => {
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${FAKE_PLAN_ID}/join-requests/${FAKE_REQUEST_ID}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json().message).toContain('Plan not found')
+    })
+
+    it('admin can approve', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const adminToken = await signTestJwt({
+        sub: ADMIN_USER_ID,
+        app_metadata: { role: 'admin' },
+      })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().userId).toBe(REQUESTER_USER_ID)
+    })
+  })
+
+  describe('PATCH /plans/:planId/join-requests/:requestId — reject', () => {
+    it('owner rejects pending request — 200, returns join request with status rejected', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        { name: 'Bob', lastName: 'Smith' }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.status).toBe('rejected')
+      expect(body.requestId).toBe(joinRequest.requestId)
+      expect(body.planId).toBe(plan.planId)
+      expect(body.name).toBe('Bob')
+      expect(body.lastName).toBe('Smith')
+    })
+
+    it('rejected user still sees not_participant when accessing plan', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      const requesterToken = await signTestJwt({ sub: REQUESTER_USER_ID })
+      const planResponse = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+      })
+
+      expect(planResponse.statusCode).toBe(200)
+      const body = planResponse.json()
+      expect(body.status).toBe('not_participant')
+      expect(body.joinRequest).toBeDefined()
+      expect(body.joinRequest.status).toBe('rejected')
+    })
+
+    it('returns 409 for already-rejected request', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        { status: 'rejected' }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(409)
+      expect(response.json().message).toContain('already been rejected')
+    })
+
+    it('returns 409 for already-approved request', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        { status: 'approved' }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(409)
+      expect(response.json().message).toContain('already been approved')
+    })
+
+    it('returns 403 for non-owner participant', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      await seedTestParticipantWithUser(plan.planId, OTHER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const otherToken = await signTestJwt({ sub: OTHER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${otherToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(403)
+    })
+
+    it('returns 401 without JWT', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+
+    it('returns 404 for non-existent requestId', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${FAKE_REQUEST_ID}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('admin can reject', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID
+      )
+
+      const adminToken = await signTestJwt({
+        sub: ADMIN_USER_ID,
+        app_metadata: { role: 'admin' },
+      })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { status: 'rejected' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().status).toBe('rejected')
+    })
+  })
+
+  describe('Join request full lifecycle flow', () => {
+    it('user submits join request with profile, owner approves, user becomes participant and can access plan', async () => {
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const requesterToken = await signTestJwt({ sub: REQUESTER_USER_ID })
+
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/plans',
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: {
+          title: 'Lifecycle Test Plan',
+          owner: {
+            name: 'Owner',
+            lastName: 'Person',
+            contactPhone: '+1-555-000-0001',
+          },
+        },
+      })
+      expect(createRes.statusCode).toBe(201)
+      const { planId } = createRes.json()
+
+      const submitRes = await app.inject({
+        method: 'POST',
+        url: `/plans/${planId}/join-requests`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+        payload: {
+          name: 'Requester',
+          lastName: 'Person',
+          contactPhone: '+1-555-999-0000',
+          contactEmail: 'req@example.com',
+          displayName: 'ReqP',
+          adultsCount: 3,
+          kidsCount: 2,
+          foodPreferences: 'halal',
+          allergies: 'dairy',
+          notes: 'Looking forward to it',
+        },
+      })
+      expect(submitRes.statusCode).toBe(201)
+      const submitted = submitRes.json()
+      expect(submitted.status).toBe('pending')
+
+      const requesterPlanRes = await app.inject({
+        method: 'GET',
+        url: `/plans/${planId}`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+      })
+      expect(requesterPlanRes.statusCode).toBe(200)
+      const notParticipant = requesterPlanRes.json()
+      expect(notParticipant.status).toBe('not_participant')
+      expect(notParticipant.joinRequest.status).toBe('pending')
+      expect(notParticipant.joinRequest.name).toBe('Requester')
+
+      const ownerPlanRes = await app.inject({
+        method: 'GET',
+        url: `/plans/${planId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+      })
+      expect(ownerPlanRes.statusCode).toBe(200)
+      const ownerPlan = ownerPlanRes.json()
+      expect(ownerPlan.joinRequests).toHaveLength(1)
+      expect(ownerPlan.joinRequests[0].status).toBe('pending')
+      const { requestId } = ownerPlan.joinRequests[0]
+
+      const approveRes = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${planId}/join-requests/${requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+      expect(approveRes.statusCode).toBe(200)
+      const approved = approveRes.json()
+      expect(approved.userId).toBe(REQUESTER_USER_ID)
+      expect(approved.name).toBe('Requester')
+      expect(approved.lastName).toBe('Person')
+      expect(approved.foodPreferences).toBe('halal')
+      expect(approved.allergies).toBe('dairy')
+      expect(approved.rsvpStatus).toBe('confirmed')
+      expect(approved.inviteToken).toBeNull()
+
+      const fullPlanRes = await app.inject({
+        method: 'GET',
+        url: `/plans/${planId}`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+      })
+      expect(fullPlanRes.statusCode).toBe(200)
+      const fullPlan = fullPlanRes.json()
+      expect(fullPlan.planId).toBe(planId)
+      expect(fullPlan.status).not.toBe('not_participant')
+      const reqParticipant = fullPlan.participants.find(
+        (p: { userId: string }) => p.userId === REQUESTER_USER_ID
+      )
+      expect(reqParticipant).toBeDefined()
+
+      const participantsRes = await app.inject({
+        method: 'GET',
+        url: `/plans/${planId}/participants`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+      })
+      expect(participantsRes.statusCode).toBe(200)
+      const participantsList = participantsRes.json()
+      const found = participantsList.find(
+        (p: { userId: string }) => p.userId === REQUESTER_USER_ID
+      )
+      expect(found).toBeDefined()
+      expect(found.foodPreferences).toBe('halal')
+      expect(found.allergies).toBe('dairy')
+      expect(found.adultsCount).toBe(3)
+      expect(found.kidsCount).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
Closes #110

## Summary

Adds owner-only (and admin) endpoint to approve or reject join requests. Uses a single `PATCH` endpoint with a `status` body to handle both actions. Participant creation is extracted into a reusable service for future extensibility.

## Changes

### New endpoint

- **`PATCH /plans/:planId/join-requests/:requestId`** — body `{ status: 'approved' | 'rejected' }`
  - **Approve:** Creates participant from request data, links to `supabaseUserId`, pre-fills preferences from `user_details` when missing. No invite token (user is authenticated and directly approved).
  - **Reject:** Updates request status to `rejected` only.
  - **Authorization:** Plan owner (`createdByUserId === userId`) or admin. Non-owner returns 403. Already approved/rejected returns 409.

### Service layer

- **`src/services/participant.service.ts`** — new `addParticipantToPlan()` function
  - Central place for participant creation (join approval, future invite flows)
  - Pure function, receives `db` as argument (DI), no Fastify coupling
  - Pre-fills `foodPreferences` and `allergies` from `user_details` when not provided

### Schemas

- `joinRequestActionParamsSchema` — URL params (`planId`, `requestId`)
- `updateJoinRequestStatusBodySchema` — body (`status: 'approved' | 'rejected'`)

### Tests

- `tests/integration/join-request.test.ts` — 21 tests
  - Approve: happy path, participant visibility, access after approval, user_details pre-fill, 409 for already processed, 403/401/404, admin approval
  - Reject: happy path, requester still sees `not_participant`, 409/403/401/404, admin reject
  - Full lifecycle: submit request → owner approves → requester becomes participant and can access plan

### Documentation

- README: Join requests and Participants sections updated with service reference; workflow note for `src/services/`
- OpenAPI spec regenerated
- Version bumped to 1.17.0

## Acceptance criteria (from issue)

- [x] Owner can approve and reject via API
- [x] Approved user becomes participant and can access full plan
- [x] Rejected user cannot access full plan
- [x] Non-owner receives 403
