### PR TITLE
feat: add item change tracking for audit history

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Server runs at `http://localhost:3333`. Swagger UI at `http://localhost:3333/doc
 - Routes: `src/routes/items.route.ts`
 - Schemas: `src/schemas/item.schema.ts`
 - Invite item routes: `src/routes/invite.route.ts`
+- Change tracking: `src/utils/item-changes.ts` (records creates/updates to `item_changes` table)
 
 ### OpenAPI
 

--- a/drizzle/0011_cynical_daredevil.sql
+++ b/drizzle/0011_cynical_daredevil.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "public"."item_change_type" AS ENUM('created', 'updated');--> statement-breakpoint
+CREATE TABLE "item_changes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"item_id" uuid NOT NULL,
+	"plan_id" uuid NOT NULL,
+	"change_type" "item_change_type" NOT NULL,
+	"changes" jsonb NOT NULL,
+	"changed_by_user_id" uuid,
+	"changed_by_participant_id" uuid,
+	"changed_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "item_changes" ADD CONSTRAINT "item_changes_item_id_items_item_id_fk" FOREIGN KEY ("item_id") REFERENCES "public"."items"("item_id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,993 @@
+{
+  "id": "31905b84-d8bb-45c0-8eb1-32a2aa28b7f4",
+  "prevId": "5352fa9c-f1a8-4bd5-969f-965c80555482",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_participant_id": {
+          "name": "assigned_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_assigned_participant_id_participants_participant_id_fk": {
+          "name": "items_assigned_participant_id_participants_participant_id_fk",
+          "tableFrom": "items",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "assigned_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772456606294,
       "tag": "0010_abnormal_captain_britain",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1772486237567,
+      "tag": "0011_cynical_daredevil",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -86,6 +86,10 @@ export const itemStatusEnum = pgEnum('item_status', [
 export const ITEM_STATUS_VALUES = itemStatusEnum.enumValues
 export type ItemStatus = (typeof ITEM_STATUS_VALUES)[number]
 
+export const itemChangeTypeEnum = pgEnum('item_change_type', [
+  'created',
+  'updated',
+])
 export const unitEnum = pgEnum('unit', [
   'pcs',
   'kg',
@@ -191,6 +195,21 @@ export const items = pgTable('items', {
     .notNull(),
 })
 
+export const itemChanges = pgTable('item_changes', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  itemId: uuid('item_id')
+    .notNull()
+    .references(() => items.itemId, { onDelete: 'cascade' }),
+  planId: uuid('plan_id').notNull(),
+  changeType: itemChangeTypeEnum('change_type').notNull(),
+  changes: jsonb('changes').notNull(),
+  changedByUserId: uuid('changed_by_user_id'),
+  changedByParticipantId: uuid('changed_by_participant_id'),
+  changedAt: timestamp('changed_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+})
+
 export const inviteSendStatusEnum = pgEnum('invite_send_status', [
   'pending',
   'sent',
@@ -262,7 +281,7 @@ export const plansRelations = relations(plans, ({ many }) => ({
   joinRequests: many(participantJoinRequests),
 }))
 
-export const itemsRelations = relations(items, ({ one }) => ({
+export const itemsRelations = relations(items, ({ one, many }) => ({
   plan: one(plans, {
     fields: [items.planId],
     references: [plans.planId],
@@ -270,6 +289,14 @@ export const itemsRelations = relations(items, ({ one }) => ({
   assignedParticipant: one(participants, {
     fields: [items.assignedParticipantId],
     references: [participants.participantId],
+  }),
+  changes: many(itemChanges),
+}))
+
+export const itemChangesRelations = relations(itemChanges, ({ one }) => ({
+  item: one(items, {
+    fields: [itemChanges.itemId],
+    references: [items.itemId],
   }),
 }))
 
@@ -321,3 +348,5 @@ export type NewPlanInvite = typeof planInvites.$inferInsert
 export type ParticipantJoinRequest = typeof participantJoinRequests.$inferSelect
 export type NewParticipantJoinRequest =
   typeof participantJoinRequests.$inferInsert
+export type ItemChange = typeof itemChanges.$inferSelect
+export type NewItemChange = typeof itemChanges.$inferInsert

--- a/src/routes/invite.route.ts
+++ b/src/routes/invite.route.ts
@@ -9,6 +9,7 @@ import {
   ItemStatus,
 } from '../db/schema.js'
 import * as schema from '../db/schema.js'
+import { recordItemCreated, recordItemUpdated } from '../utils/item-changes.js'
 
 interface BulkItemError {
   name: string
@@ -364,6 +365,12 @@ export async function inviteRoutes(fastify: FastifyInstance) {
           },
           'Guest created item via invite token'
         )
+        recordItemCreated(fastify.db, {
+          itemId: createdItem.itemId,
+          planId,
+          snapshot: createdItem as unknown as Record<string, unknown>,
+          changedByParticipantId: participant.participantId,
+        })
         return reply.status(201).send(createdItem)
       } catch (error) {
         request.log.error({ err: error, planId }, 'Failed to create guest item')
@@ -448,11 +455,7 @@ export async function inviteRoutes(fastify: FastifyInstance) {
         }
 
         const [existingItem] = await fastify.db
-          .select({
-            itemId: items.itemId,
-            planId: items.planId,
-            assignedParticipantId: items.assignedParticipantId,
-          })
+          .select()
           .from(items)
           .where(eq(items.itemId, itemId))
 
@@ -484,6 +487,13 @@ export async function inviteRoutes(fastify: FastifyInstance) {
           },
           'Guest updated item via invite token'
         )
+        recordItemUpdated(fastify.db, {
+          itemId,
+          planId,
+          existing: existingItem,
+          updates,
+          changedByParticipantId: participant.participantId,
+        })
         return updatedItem
       } catch (error) {
         request.log.error(
@@ -616,6 +626,14 @@ export async function inviteRoutes(fastify: FastifyInstance) {
             .returning()
         }
 
+        for (const created of createdItems) {
+          recordItemCreated(fastify.db, {
+            itemId: created.itemId,
+            planId,
+            snapshot: created as unknown as Record<string, unknown>,
+            changedByParticipantId: participant.participantId,
+          })
+        }
         const statusCode = errors.length === 0 ? 200 : 207
         request.log.info(
           {
@@ -714,12 +732,7 @@ export async function inviteRoutes(fastify: FastifyInstance) {
 
         const itemIds = itemUpdates.map((entry) => entry.itemId)
         const existingItems = await fastify.db
-          .select({
-            itemId: items.itemId,
-            planId: items.planId,
-            name: items.name,
-            assignedParticipantId: items.assignedParticipantId,
-          })
+          .select()
           .from(items)
           .where(inArray(items.itemId, itemIds))
 
@@ -766,6 +779,13 @@ export async function inviteRoutes(fastify: FastifyInstance) {
             .returning()
 
           updatedItems.push(updatedItem)
+          recordItemUpdated(fastify.db, {
+            itemId,
+            planId: existing.planId,
+            existing,
+            updates,
+            changedByParticipantId: participant.participantId,
+          })
         }
 
         const statusCode = errors.length === 0 ? 200 : 207

--- a/src/routes/items.route.ts
+++ b/src/routes/items.route.ts
@@ -9,6 +9,7 @@ import {
   ItemStatus,
 } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
+import { recordItemCreated, recordItemUpdated } from '../utils/item-changes.js'
 
 interface CreateItemBody {
   name: string
@@ -131,6 +132,12 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           { itemId: createdItem.itemId, planId, assignedParticipantId },
           'Item created'
         )
+        recordItemCreated(fastify.db, {
+          itemId: createdItem.itemId,
+          planId,
+          snapshot: createdItem as unknown as Record<string, unknown>,
+          changedByUserId: request.user?.id ?? null,
+        })
         return reply.status(201).send(createdItem)
       } catch (error) {
         request.log.error({ err: error, planId }, 'Failed to create item')
@@ -250,7 +257,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
 
       try {
         const [existingItem] = await fastify.db
-          .select({ itemId: items.itemId, planId: items.planId })
+          .select()
           .from(items)
           .where(eq(items.itemId, itemId))
 
@@ -297,6 +304,13 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           { itemId, changes: Object.keys(updates) },
           'Item updated'
         )
+        recordItemUpdated(fastify.db, {
+          itemId,
+          planId: existingItem.planId,
+          existing: existingItem,
+          updates,
+          changedByUserId: request.user?.id ?? null,
+        })
         return updatedItem
       } catch (error) {
         request.log.error({ err: error, itemId }, 'Failed to update item')
@@ -437,6 +451,14 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             .returning()
         }
 
+        for (const created of createdItems) {
+          recordItemCreated(fastify.db, {
+            itemId: created.itemId,
+            planId,
+            snapshot: created as unknown as Record<string, unknown>,
+            changedByUserId: request.user?.id ?? null,
+          })
+        }
         const statusCode = errors.length === 0 ? 200 : 207
         request.log.info(
           { planId, created: createdItems.length, failed: errors.length },
@@ -492,11 +514,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
       try {
         const itemIds = itemUpdates.map((entry) => entry.itemId)
         const existingItems = await fastify.db
-          .select({
-            itemId: items.itemId,
-            planId: items.planId,
-            name: items.name,
-          })
+          .select()
           .from(items)
           .where(inArray(items.itemId, itemIds))
 
@@ -583,6 +601,13 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             .returning()
 
           updatedItems.push(updatedItem)
+          recordItemUpdated(fastify.db, {
+            itemId,
+            planId: existing.planId,
+            existing,
+            updates,
+            changedByUserId: request.user?.id ?? null,
+          })
         }
 
         const statusCode = errors.length === 0 ? 200 : 207

--- a/src/utils/item-changes.ts
+++ b/src/utils/item-changes.ts
@@ -1,0 +1,101 @@
+import type { Database } from '../db/index.js'
+import { itemChanges } from '../db/schema.js'
+import type { Item } from '../db/schema.js'
+
+const TRACKED_FIELDS = [
+  'name',
+  'category',
+  'quantity',
+  'unit',
+  'status',
+  'subcategory',
+  'notes',
+  'assignedParticipantId',
+] as const
+
+export function computeItemDiff(
+  existing: Pick<Item, (typeof TRACKED_FIELDS)[number]>,
+  updates: Partial<Pick<Item, (typeof TRACKED_FIELDS)[number]>>
+): Array<{ field: string; from: unknown; to: unknown }> {
+  const result: Array<{ field: string; from: unknown; to: unknown }> = []
+  for (const field of TRACKED_FIELDS) {
+    const newVal = updates[field]
+    if (newVal === undefined) continue
+    const oldVal = existing[field]
+    const oldJson = JSON.stringify(oldVal)
+    const newJson = JSON.stringify(newVal)
+    if (oldJson !== newJson) {
+      result.push({ field, from: oldVal, to: newVal })
+    }
+  }
+  return result
+}
+
+function toSerializable(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(obj)) {
+    if (v instanceof Date) {
+      out[k] = v.toISOString()
+    } else {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+export async function recordItemCreated(
+  db: Database,
+  params: {
+    itemId: string
+    planId: string
+    snapshot: Record<string, unknown>
+    changedByUserId?: string | null
+    changedByParticipantId?: string | null
+  }
+): Promise<void> {
+  try {
+    await db.insert(itemChanges).values({
+      itemId: params.itemId,
+      planId: params.planId,
+      changeType: 'created',
+      changes: { snapshot: toSerializable(params.snapshot) },
+      changedByUserId: params.changedByUserId ?? null,
+      changedByParticipantId: params.changedByParticipantId ?? null,
+    })
+  } catch (err) {
+    console.error('[item-changes] Failed to record item created:', err)
+  }
+}
+
+export async function recordItemUpdated(
+  db: Database,
+  params: {
+    itemId: string
+    planId: string
+    existing: Pick<Item, (typeof TRACKED_FIELDS)[number]>
+    updates: Partial<Pick<Item, (typeof TRACKED_FIELDS)[number]>>
+    changedByUserId?: string | null
+    changedByParticipantId?: string | null
+  }
+): Promise<void> {
+  const diff = computeItemDiff(params.existing, params.updates)
+  if (diff.length === 0) return
+  try {
+    await db.insert(itemChanges).values({
+      itemId: params.itemId,
+      planId: params.planId,
+      changeType: 'updated',
+      changes: {
+        fields: diff.map((d) => ({
+          field: d.field,
+          from: d.from,
+          to: d.to,
+        })),
+      },
+      changedByUserId: params.changedByUserId ?? null,
+      changedByParticipantId: params.changedByParticipantId ?? null,
+    })
+  } catch (err) {
+    console.error('[item-changes] Failed to record item updated:', err)
+  }
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -39,6 +39,7 @@ export async function getTestDb(): Promise<Database> {
 export async function cleanupTestDatabase() {
   const testDb = await getTestDb()
 
+  await testDb.delete(schema.itemChanges)
   await testDb.delete(schema.items)
   await testDb.delete(schema.planInvites)
   await testDb.delete(schema.participantJoinRequests)

--- a/tests/integration/invite.test.ts
+++ b/tests/integration/invite.test.ts
@@ -10,7 +10,8 @@ import {
   seedTestItems,
   getTestDb,
 } from '../helpers/db.js'
-import { items } from '../../src/db/schema.js'
+import { items, itemChanges } from '../../src/db/schema.js'
+import { eq } from 'drizzle-orm'
 
 describe('Invite Route', () => {
   let app: FastifyInstance
@@ -1158,6 +1159,47 @@ describe('Invite Route', () => {
       })
 
       expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe('Item change tracking (invite)', () => {
+    it('records created row with changedByParticipantId when guest creates item', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participantList = await seedTestParticipants(plan.planId, 1)
+      const token = participantList[0].inviteToken!
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/invite/${token}/items`,
+        payload: {
+          name: 'Camp Chair',
+          category: 'equipment',
+          quantity: 2,
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const item = response.json()
+
+      const db = await getTestDb()
+      const changes = await db
+        .select()
+        .from(itemChanges)
+        .where(eq(itemChanges.itemId, item.itemId))
+
+      expect(changes).toHaveLength(1)
+      expect(changes[0].changeType).toBe('created')
+      expect(changes[0].changedByUserId).toBeNull()
+      expect(changes[0].changedByParticipantId).toBe(
+        participantList[0].participantId
+      )
+      expect(changes[0].changes).toMatchObject({
+        snapshot: expect.objectContaining({
+          name: 'Camp Chair',
+          category: 'equipment',
+          quantity: 2,
+        }),
+      })
     })
   })
 })

--- a/tests/integration/items.test.ts
+++ b/tests/integration/items.test.ts
@@ -4,11 +4,14 @@ import { FastifyInstance } from 'fastify'
 import {
   cleanupTestDatabase,
   closeTestDatabase,
+  getTestDb,
   seedTestItems,
   seedTestParticipants,
   seedTestPlans,
   setupTestDatabase,
 } from '../helpers/db.js'
+import { itemChanges } from '../../src/db/schema.js'
+import { eq } from 'drizzle-orm'
 import {
   setupTestKeys,
   getTestJWKS,
@@ -1043,6 +1046,168 @@ describe('Items Route', () => {
       })
 
       expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe('Item change tracking', () => {
+    it('records created row when creating item', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Tent',
+          category: 'equipment',
+          quantity: 2,
+          status: 'pending',
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const item = response.json()
+
+      const db = await getTestDb()
+      const changes = await db
+        .select()
+        .from(itemChanges)
+        .where(eq(itemChanges.itemId, item.itemId))
+
+      expect(changes).toHaveLength(1)
+      expect(changes[0].changeType).toBe('created')
+      expect(changes[0].changedByUserId).toBe(TEST_USER_ID)
+      expect(changes[0].changedByParticipantId).toBeNull()
+      expect(changes[0].changes).toMatchObject({
+        snapshot: expect.objectContaining({
+          name: 'Tent',
+          category: 'equipment',
+          quantity: 2,
+          status: 'pending',
+        }),
+      })
+    })
+
+    it('records updated row when changing item status', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { status: 'purchased' },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const db = await getTestDb()
+      const changes = await db
+        .select()
+        .from(itemChanges)
+        .where(eq(itemChanges.itemId, item.itemId))
+
+      expect(changes).toHaveLength(1)
+      expect(changes[0].changeType).toBe('updated')
+      expect(changes[0].changes).toMatchObject({
+        fields: [{ field: 'status', from: 'pending', to: 'purchased' }],
+      })
+    })
+
+    it('records multiple field changes in single updated row', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: {
+          status: 'packed',
+          quantity: 3,
+          notes: 'Ready to go',
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const db = await getTestDb()
+      const changes = await db
+        .select()
+        .from(itemChanges)
+        .where(eq(itemChanges.itemId, item.itemId))
+
+      expect(changes).toHaveLength(1)
+      const fields = (
+        changes[0].changes as { fields: Array<{ field: string }> }
+      ).fields
+      expect(fields).toHaveLength(3)
+      expect(fields.map((f) => f.field).sort()).toEqual(
+        ['notes', 'quantity', 'status'].sort()
+      )
+    })
+
+    it('does not record change when update has no actual diff', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { status: item.status },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const db = await getTestDb()
+      const changes = await db
+        .select()
+        .from(itemChanges)
+        .where(eq(itemChanges.itemId, item.itemId))
+
+      expect(changes).toHaveLength(0)
+    })
+
+    it('records one row per item on bulk create', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Item A',
+              category: 'equipment',
+              quantity: 1,
+              status: 'pending',
+            },
+            {
+              name: 'Item B',
+              category: 'equipment',
+              quantity: 1,
+              status: 'pending',
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items).toHaveLength(2)
+
+      const db = await getTestDb()
+      const changes = await db
+        .select()
+        .from(itemChanges)
+        .where(eq(itemChanges.planId, plan.planId))
+
+      expect(changes).toHaveLength(2)
+      expect(changes.every((c) => c.changeType === 'created')).toBe(true)
     })
   })
 })

--- a/tests/unit/item-changes.test.ts
+++ b/tests/unit/item-changes.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { computeItemDiff } from '../../src/utils/item-changes.js'
+import type { Item } from '../../src/db/schema.js'
+
+describe('computeItemDiff', () => {
+  const baseItem: Pick<
+    Item,
+    | 'name'
+    | 'category'
+    | 'quantity'
+    | 'unit'
+    | 'status'
+    | 'subcategory'
+    | 'notes'
+    | 'assignedParticipantId'
+  > = {
+    name: 'Tent',
+    category: 'equipment',
+    quantity: 2,
+    unit: 'pcs',
+    status: 'pending',
+    subcategory: null,
+    notes: null,
+    assignedParticipantId: null,
+  }
+
+  it('returns diff for single field change', () => {
+    const diff = computeItemDiff(baseItem, { status: 'purchased' })
+    expect(diff).toHaveLength(1)
+    expect(diff[0]).toEqual({
+      field: 'status',
+      from: 'pending',
+      to: 'purchased',
+    })
+  })
+
+  it('returns diff for multiple field changes', () => {
+    const diff = computeItemDiff(baseItem, {
+      status: 'packed',
+      quantity: 3,
+      notes: 'Ready',
+    })
+    expect(diff).toHaveLength(3)
+    expect(diff).toContainEqual({
+      field: 'status',
+      from: 'pending',
+      to: 'packed',
+    })
+    expect(diff).toContainEqual({ field: 'quantity', from: 2, to: 3 })
+    expect(diff).toContainEqual({
+      field: 'notes',
+      from: null,
+      to: 'Ready',
+    })
+  })
+
+  it('returns empty array when values are unchanged', () => {
+    const diff = computeItemDiff(baseItem, {
+      status: 'pending',
+      quantity: 2,
+    })
+    expect(diff).toHaveLength(0)
+  })
+
+  it('ignores fields not in updates', () => {
+    const diff = computeItemDiff(baseItem, {})
+    expect(diff).toHaveLength(0)
+  })
+
+  it('tracks null to value change', () => {
+    const diff = computeItemDiff(baseItem, { notes: 'Bring extra' })
+    expect(diff).toHaveLength(1)
+    expect(diff[0]).toEqual({
+      field: 'notes',
+      from: null,
+      to: 'Bring extra',
+    })
+  })
+
+  it('tracks value to null change', () => {
+    const withNotes = { ...baseItem, notes: 'Something' }
+    const diff = computeItemDiff(withNotes, { notes: null })
+    expect(diff).toHaveLength(1)
+    expect(diff[0]).toEqual({
+      field: 'notes',
+      from: 'Something',
+      to: null,
+    })
+  })
+})


### PR DESCRIPTION
Adds internal audit tracking for all item creates and updates.

## Summary
- `item_changes` table + `src/utils/item-changes.ts` records every item create/update
- Integrates into all 8 mutation endpoints (items + invite routes)
- Fire-and-forget recording; no API changes

## Changes
- Schema: `item_change_type` enum, `item_changes` table, migration
- Utility: `recordItemCreated`, `recordItemUpdated`, `computeItemDiff`
- Routes: items.route.ts, invite.route.ts (4 handlers each)
- Tests: unit (computeItemDiff), integration (create/update/bulk, owner + guest)

Relates to #121 (expose API) and chillist-fe#151 (UI component).

Made with [Cursor](https://cursor.com)