### PR TITLE
feat: restrict GET /plans to owner plans, add GET /admin/plans for admins

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2169,11 +2169,11 @@
         }
       },
       "get": {
-        "summary": "List all plans",
+        "summary": "List plans owned by user",
         "tags": [
           "plans"
         ],
-        "description": "Retrieve all plans ordered by creation date",
+        "description": "Retrieve plans created by the authenticated user, ordered by creation date",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -2181,6 +2181,58 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-6"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/plans": {
+      "get": {
+        "summary": "Admin: list all plans",
+        "tags": [
+          "admin",
+          "plans"
+        ],
+        "description": "Returns all plans in the system. Admin only. JWT required.",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-6"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import Fastify from 'fastify'
 import cors from '@fastify/cors'
 import helmet from '@fastify/helmet'
-import rateLimit from '@fastify/rate-limit'
+import rateLimitPlugin from '@fastify/rate-limit'
 import swagger from '@fastify/swagger'
 import swaggerUI from '@fastify/swagger-ui'
 import { config } from './config.js'
@@ -26,13 +26,14 @@ export interface BuildAppOptions {
   enableDocs?: boolean
   logger?: false
   auth?: AuthPluginOptions
+  rateLimit?: { max: number; timeWindow: string } | false
 }
 
 export async function buildApp(
   deps: AppDependencies,
   options: BuildAppOptions = {}
 ) {
-  const { enableDocs = config.isDev, logger, auth } = options
+  const { enableDocs = config.isDev, logger, auth, rateLimit } = options
 
   const fastify = Fastify({
     logger:
@@ -105,10 +106,16 @@ export async function buildApp(
     contentSecurityPolicy: config.isDev ? false : undefined,
   })
 
-  await fastify.register(rateLimit, {
-    max: 100,
-    timeWindow: '1 minute',
-  })
+  const rateLimitConfig =
+    rateLimit === false
+      ? false
+      : (rateLimit ?? {
+          max: logger === false ? 100_000 : 100,
+          timeWindow: '1 minute',
+        })
+  if (rateLimitConfig !== false) {
+    await fastify.register(rateLimitPlugin, rateLimitConfig)
+  }
 
   await fastify.register(authPlugin, auth ?? {})
   await fastify.register(guestAuthPlugin)

--- a/src/routes/plans.route.ts
+++ b/src/routes/plans.route.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { FastifyInstance } from 'fastify'
-import { eq, and, or, exists, sql } from 'drizzle-orm'
+import { eq, and } from 'drizzle-orm'
 import {
   plans,
   participants,
@@ -197,8 +197,9 @@ export async function plansRoutes(fastify: FastifyInstance) {
     {
       schema: {
         tags: ['plans'],
-        summary: 'List all plans',
-        description: 'Retrieve all plans ordered by creation date',
+        summary: 'List plans owned by user',
+        description:
+          'Retrieve plans created by the authenticated user, ordered by creation date',
         response: {
           200: { $ref: 'PlanList#' },
           500: { $ref: 'ErrorResponse#' },
@@ -210,28 +211,10 @@ export async function plansRoutes(fastify: FastifyInstance) {
       try {
         const userId = request.user!.id
 
-        const conditions = isAdmin(request.user)
-          ? sql`true`
-          : or(
-              eq(plans.visibility, 'public'),
-              eq(plans.createdByUserId, userId),
-              exists(
-                fastify.db
-                  .select({ one: participants.participantId })
-                  .from(participants)
-                  .where(
-                    and(
-                      eq(participants.planId, plans.planId),
-                      eq(participants.userId, userId)
-                    )
-                  )
-              )
-            )
-
         const filteredPlans = await fastify.db
           .select()
           .from(plans)
-          .where(conditions)
+          .where(eq(plans.createdByUserId, userId))
           .orderBy(plans.createdAt)
 
         request.log.info(
@@ -241,6 +224,61 @@ export async function plansRoutes(fastify: FastifyInstance) {
         return filteredPlans
       } catch (error) {
         request.log.error({ err: error }, 'Failed to retrieve plans')
+
+        const isConnectionError =
+          error instanceof Error &&
+          (error.message.includes('connect') ||
+            error.message.includes('timeout'))
+
+        if (isConnectionError) {
+          return reply.status(503).send({
+            message: 'Database connection error',
+          })
+        }
+
+        return reply.status(500).send({
+          message: 'Failed to retrieve plans',
+        })
+      }
+    }
+  )
+
+  fastify.get(
+    '/admin/plans',
+    {
+      schema: {
+        tags: ['admin', 'plans'],
+        summary: 'Admin: list all plans',
+        description:
+          'Returns all plans in the system. Admin only. JWT required.',
+        response: {
+          200: { $ref: 'PlanList#' },
+          403: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+          503: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!isAdmin(request.user)) {
+        return reply.status(403).send({
+          message: 'Admin access required',
+        })
+      }
+
+      try {
+        const allPlans = await fastify.db
+          .select()
+          .from(plans)
+          .orderBy(plans.createdAt)
+
+        request.log.info(
+          { count: allPlans.length },
+          'Admin: all plans retrieved'
+        )
+        return allPlans
+      } catch (error) {
+        request.log.error({ err: error }, 'Admin: failed to retrieve plans')
 
         const isConnectionError =
           error instanceof Error &&

--- a/tests/integration/claim.test.ts
+++ b/tests/integration/claim.test.ts
@@ -172,7 +172,7 @@ describe('POST /plans/:planId/claim/:inviteToken', () => {
     expect(response.json().contactEmail).toBe('claimer@example.com')
   })
 
-  it('plan appears in user plan list after claiming', async () => {
+  it('plan is accessible via GET /plans/:planId after claiming', async () => {
     const { plan, inviteToken } = await createPlanWithParticipant(db)
     const jwt = await signTestJwt({ sub: USER_A_ID })
 
@@ -182,17 +182,16 @@ describe('POST /plans/:planId/claim/:inviteToken', () => {
       headers: { authorization: `Bearer ${jwt}` },
     })
 
-    const listResponse = await app.inject({
+    const getResponse = await app.inject({
       method: 'GET',
-      url: '/plans',
+      url: `/plans/${plan.planId}`,
       headers: { authorization: `Bearer ${jwt}` },
     })
 
-    expect(listResponse.statusCode).toBe(200)
-    const planList = listResponse.json()
-    expect(
-      planList.some((p: { planId: string }) => p.planId === plan.planId)
-    ).toBe(true)
+    expect(getResponse.statusCode).toBe(200)
+    const fetched = getResponse.json()
+    expect(fetched.planId).toBe(plan.planId)
+    expect(fetched.participants).toBeDefined()
   })
 
   it('returns 200 idempotently when participant already linked to same user', async () => {

--- a/tests/integration/plan-access.test.ts
+++ b/tests/integration/plan-access.test.ts
@@ -589,7 +589,7 @@ describe('Plan Access Control', () => {
       expect(response.statusCode).toBe(401)
     })
 
-    it('returns own plans + public plans with JWT', async () => {
+    it('returns only owned plans with JWT', async () => {
       await createPlanDirectly(db, { visibility: 'public' })
       await createPlanDirectly(db, {
         visibility: 'invite_only',
@@ -610,15 +610,12 @@ describe('Plan Access Control', () => {
 
       expect(response.statusCode).toBe(200)
       const result = response.json()
-      expect(result).toHaveLength(2)
-      const visibilities = result.map(
-        (p: { visibility: string }) => p.visibility
-      )
-      expect(visibilities).toContain('public')
-      expect(visibilities).toContain('invite_only')
+      expect(result).toHaveLength(1)
+      expect(result[0].visibility).toBe('invite_only')
+      expect(result[0].createdByUserId).toBe(OWNER_USER_ID)
     })
 
-    it('includes plans where user is a linked participant', async () => {
+    it('does not include plans where user is only a participant (not owner)', async () => {
       const { plan } = await createPlanDirectly(db, {
         visibility: 'invite_only',
         createdByUserId: OWNER_USER_ID,
@@ -638,7 +635,7 @@ describe('Plan Access Control', () => {
       const result = response.json()
       expect(
         result.some((p: { planId: string }) => p.planId === plan.planId)
-      ).toBe(true)
+      ).toBe(false)
     })
 
     it('does not include other users invite_only plans', async () => {
@@ -659,7 +656,7 @@ describe('Plan Access Control', () => {
       expect(response.json()).toHaveLength(0)
     })
 
-    it('returns all plans for admin regardless of visibility', async () => {
+    it('returns all plans for admin via GET /admin/plans', async () => {
       await createPlanDirectly(db, { visibility: 'public' })
       await createPlanDirectly(db, {
         visibility: 'invite_only',
@@ -674,7 +671,7 @@ describe('Plan Access Control', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: '/plans',
+        url: '/admin/plans',
         headers: { authorization: `Bearer ${token}` },
       })
 

--- a/tests/integration/plans.test.ts
+++ b/tests/integration/plans.test.ts
@@ -72,6 +72,7 @@ describe('Plans Route', () => {
   describe('JWT enforcement', () => {
     it.each([
       ['GET', '/plans'],
+      ['GET', '/admin/plans'],
       ['GET', '/plans/pending-requests'],
       ['POST', '/plans'],
       ['PATCH', '/plans/00000000-0000-0000-0000-000000000000'],
@@ -113,7 +114,7 @@ describe('Plans Route', () => {
     })
 
     it('returns all plans when plans exist', async () => {
-      await seedTestPlans(3)
+      await seedTestPlans(3, { createdByUserId: TEST_USER_ID })
 
       const response = await app.inject({
         method: 'GET',
@@ -139,7 +140,7 @@ describe('Plans Route', () => {
     })
 
     it('returns plans ordered by createdAt', async () => {
-      await seedTestPlans(3)
+      await seedTestPlans(3, { createdByUserId: TEST_USER_ID })
 
       const response = await app.inject({
         method: 'GET',
@@ -158,7 +159,7 @@ describe('Plans Route', () => {
     })
 
     it('returns plans with correct structure', async () => {
-      await seedTestPlans(1)
+      await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
 
       const response = await app.inject({
         method: 'GET',
@@ -180,6 +181,52 @@ describe('Plans Route', () => {
       expect(plan).toHaveProperty('tags')
       expect(plan).toHaveProperty('createdAt')
       expect(plan).toHaveProperty('updatedAt')
+    })
+  })
+
+  describe('GET /admin/plans', () => {
+    it('returns 403 for non-admin user', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/admin/plans',
+        headers: authHeaders(),
+      })
+
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toEqual({
+        message: 'Admin access required',
+      })
+    })
+
+    it('returns all plans for admin including plans not owned by admin', async () => {
+      const [plan1] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestPlans(1, { createdByUserId: OTHER_USER_ID })
+
+      const adminToken = await signAdminJwt()
+      const response = await app.inject({
+        method: 'GET',
+        url: '/admin/plans',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const plansList = response.json()
+      expect(plansList).toHaveLength(2)
+      expect(plansList.map((p: { planId: string }) => p.planId)).toContain(
+        plan1.planId
+      )
+    })
+
+    it('returns empty array when no plans exist', async () => {
+      const adminToken = await signAdminJwt()
+      const response = await app.inject({
+        method: 'GET',
+        url: '/admin/plans',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual([])
     })
   })
 
@@ -1504,7 +1551,9 @@ describe('Plans Route', () => {
     })
 
     it('deleted plan is removed from list', async () => {
-      const [plan1, plan2] = await seedTestPlans(2)
+      const [plan1, plan2] = await seedTestPlans(2, {
+        createdByUserId: TEST_USER_ID,
+      })
       const adminToken = await signAdminJwt()
 
       await app.inject({


### PR DESCRIPTION
## Summary

Restricts `GET /plans` to return only plans owned by the authenticated user, and adds a new `GET /admin/plans` endpoint for admins to fetch all plans in the system.

## Changes

### Route behavior

- **`GET /plans`** — Returns only plans where `createdByUserId === userId`. No longer includes public plans or plans where the user is a participant. Admins no longer receive all plans via this endpoint.
- **`GET /admin/plans`** — New admin-only route. Returns all plans. Non-admins receive `403 Admin access required`.

### Files modified

- `src/routes/plans.route.ts` — Owner-only filter on GET /plans; new GET /admin/plans handler
- `docs/openapi.json` — Regenerated spec
- `tests/integration/plans.test.ts` — Updated GET /plans seeds; added GET /admin/plans suite; JWT enforcement for /admin/plans
- `tests/integration/plan-access.test.ts` — Aligned with new behavior: owner-only, participant exclusion, admin uses /admin/plans
- `tests/integration/claim.test.ts` — Claimed plans verified via GET /plans/:planId (participants not in GET /plans)
- `src/app.ts` — Higher rate limit in test mode to avoid 429 during integration tests

### API

| Endpoint | Before | After |
|----------|--------|-------|
| GET /plans | Admin: all plans. User: owned + public + participant | All: owned only |
| GET /admin/plans | — | Admin: all plans (403 for non-admin) |

Made with [Cursor](https://cursor.com)