### PR TITLE
feat: add all-participants item assignment model (#116)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -515,6 +515,14 @@
             "format": "uuid",
             "nullable": true
           },
+          "isAllParticipants": {
+            "type": "boolean"
+          },
+          "allParticipantsGroupId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -532,6 +540,7 @@
           "quantity",
           "unit",
           "status",
+          "isAllParticipants",
           "createdAt",
           "updatedAt"
         ],
@@ -601,6 +610,9 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "assignedToAll": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -668,6 +680,9 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "assignedToAll": {
+            "type": "boolean"
           }
         },
         "title": "UpdateItemBody"

--- a/drizzle/0012_kind_jack_power.sql
+++ b/drizzle/0012_kind_jack_power.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "items" ADD COLUMN "is_all_participants" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "items" ADD COLUMN "all_participants_group_id" uuid;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1006 @@
+{
+  "id": "274bba7f-ec42-4c45-ba1c-733f90d21804",
+  "prevId": "31905b84-d8bb-45c0-8eb1-32a2aa28b7f4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_participant_id": {
+          "name": "assigned_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "all_participants_group_id": {
+          "name": "all_participants_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "items_assigned_participant_id_participants_participant_id_fk": {
+          "name": "items_assigned_participant_id_participants_participant_id_fk",
+          "tableFrom": "items",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "assigned_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1772486237567,
       "tag": "0011_cynical_daredevil",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1772554579831,
+      "tag": "0012_kind_jack_power",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   pgEnum,
   unique,
+  boolean,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 
@@ -187,6 +188,8 @@ export const items = pgTable('items', {
     () => participants.participantId,
     { onDelete: 'set null' }
   ),
+  isAllParticipants: boolean('is_all_participants').default(false).notNull(),
+  allParticipantsGroupId: uuid('all_participants_group_id'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()
     .notNull(),

--- a/src/routes/participants.route.ts
+++ b/src/routes/participants.route.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm'
 import { participants, plans } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { isAdmin } from '../utils/admin.js'
+import { removeParticipantFromAllGroups } from '../services/all-participants-items.service.js'
 
 function generateInviteToken(): string {
   return randomBytes(32).toString('hex')
@@ -426,6 +427,17 @@ export async function participantsRoutes(fastify: FastifyInstance) {
           return reply.status(400).send({
             message: 'Cannot delete participant with owner role',
           })
+        }
+
+        const deletedAllItems = await removeParticipantFromAllGroups(
+          fastify.db,
+          participantId
+        )
+        if (deletedAllItems > 0) {
+          request.log.info(
+            { participantId, deletedAllItems },
+            'Removed participant all-participants item copies'
+          )
         }
 
         await fastify.db

--- a/src/schemas/item.schema.ts
+++ b/src/schemas/item.schema.ts
@@ -24,6 +24,12 @@ export const itemSchema = {
     subcategory: { type: 'string', nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
+    isAllParticipants: { type: 'boolean' },
+    allParticipantsGroupId: {
+      type: 'string',
+      format: 'uuid',
+      nullable: true,
+    },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
   },
@@ -35,6 +41,7 @@ export const itemSchema = {
     'quantity',
     'unit',
     'status',
+    'isAllParticipants',
     'createdAt',
     'updatedAt',
   ],
@@ -64,6 +71,7 @@ export const createItemBodySchema = {
     subcategory: { type: 'string', maxLength: 255, nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
+    assignedToAll: { type: 'boolean' },
   },
   required: ['name', 'category', 'quantity', 'status'],
 } as const
@@ -86,6 +94,7 @@ export const updateItemBodySchema = {
     subcategory: { type: 'string', maxLength: 255, nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
+    assignedToAll: { type: 'boolean' },
   },
 } as const
 

--- a/src/services/all-participants-items.service.ts
+++ b/src/services/all-participants-items.service.ts
@@ -1,0 +1,385 @@
+import { eq, and, ne } from 'drizzle-orm'
+import { randomUUID } from 'crypto'
+import type { Database } from '../db/index.js'
+import { items, participants, Item, ItemCategory, Unit } from '../db/schema.js'
+
+export class NotOwnerError extends Error {
+  constructor() {
+    super('Only the plan owner can assign items to all participants')
+    this.name = 'NotOwnerError'
+  }
+}
+
+export class ItemNotFoundError extends Error {
+  constructor(itemId: string) {
+    super(`Item not found: ${itemId}`)
+    this.name = 'ItemNotFoundError'
+  }
+}
+
+export class NoGroupError extends Error {
+  constructor(itemId: string) {
+    super(`Item is not part of an all-participants group: ${itemId}`)
+    this.name = 'NoGroupError'
+  }
+}
+
+interface CoreFieldUpdates {
+  name?: string
+  quantity?: number
+  unit?: Unit
+  category?: ItemCategory
+  subcategory?: string | null
+  notes?: string | null
+}
+
+const CORE_FIELD_KEYS: (keyof CoreFieldUpdates)[] = [
+  'name',
+  'quantity',
+  'unit',
+  'category',
+  'subcategory',
+  'notes',
+]
+
+function pickCoreFields(
+  updates: Record<string, unknown>
+): CoreFieldUpdates | null {
+  const picked: Record<string, unknown> = {}
+  let hasFields = false
+  for (const key of CORE_FIELD_KEYS) {
+    if (key in updates) {
+      picked[key] = updates[key]
+      hasFields = true
+    }
+  }
+  return hasFields ? (picked as CoreFieldUpdates) : null
+}
+
+export async function assignItemToAllParticipants(
+  db: Database,
+  itemId: string,
+  ownerParticipantId: string
+): Promise<Item[]> {
+  return await db.transaction(async (tx) => {
+    const [item] = await tx.select().from(items).where(eq(items.itemId, itemId))
+
+    if (!item) throw new ItemNotFoundError(itemId)
+
+    const [owner] = await tx
+      .select({
+        participantId: participants.participantId,
+        role: participants.role,
+        planId: participants.planId,
+      })
+      .from(participants)
+      .where(eq(participants.participantId, ownerParticipantId))
+
+    if (!owner || owner.role !== 'owner') throw new NotOwnerError()
+
+    const allParticipants = await tx
+      .select({
+        participantId: participants.participantId,
+      })
+      .from(participants)
+      .where(eq(participants.planId, item.planId))
+
+    if (item.allParticipantsGroupId) {
+      return await reconcileGroup(
+        tx,
+        item.allParticipantsGroupId,
+        item.planId,
+        allParticipants.map((p) => p.participantId)
+      )
+    }
+
+    const groupId = randomUUID()
+    const now = new Date()
+
+    await tx
+      .update(items)
+      .set({
+        isAllParticipants: true,
+        allParticipantsGroupId: groupId,
+        assignedParticipantId: ownerParticipantId,
+        updatedAt: now,
+      })
+      .where(eq(items.itemId, itemId))
+
+    const otherParticipants = allParticipants.filter(
+      (p) => p.participantId !== ownerParticipantId
+    )
+
+    if (otherParticipants.length > 0) {
+      await tx.insert(items).values(
+        otherParticipants.map((p) => ({
+          planId: item.planId,
+          name: item.name,
+          category: item.category,
+          quantity: item.quantity,
+          unit: item.unit,
+          status: 'pending' as const,
+          subcategory: item.subcategory,
+          notes: item.notes,
+          assignedParticipantId: p.participantId,
+          isAllParticipants: true,
+          allParticipantsGroupId: groupId,
+        }))
+      )
+    }
+
+    return await tx
+      .select()
+      .from(items)
+      .where(eq(items.allParticipantsGroupId, groupId))
+  })
+}
+
+async function reconcileGroup(
+  tx: Parameters<Parameters<Database['transaction']>[0]>[0],
+  groupId: string,
+  planId: string,
+  currentParticipantIds: string[]
+): Promise<Item[]> {
+  const groupItems = await tx
+    .select()
+    .from(items)
+    .where(eq(items.allParticipantsGroupId, groupId))
+
+  const existingByParticipant = new Map<string, Item>()
+  for (const gi of groupItems) {
+    if (gi.assignedParticipantId) {
+      existingByParticipant.set(gi.assignedParticipantId, gi)
+    }
+  }
+
+  const template = groupItems[0]
+  const now = new Date()
+
+  for (const pid of currentParticipantIds) {
+    const existing = existingByParticipant.get(pid)
+    if (existing) {
+      if (existing.status === 'canceled') {
+        await tx
+          .update(items)
+          .set({
+            status: 'pending',
+            isAllParticipants: true,
+            updatedAt: now,
+          })
+          .where(eq(items.itemId, existing.itemId))
+      } else if (!existing.isAllParticipants) {
+        await tx
+          .update(items)
+          .set({ isAllParticipants: true, updatedAt: now })
+          .where(eq(items.itemId, existing.itemId))
+      }
+    } else {
+      await tx.insert(items).values({
+        planId,
+        name: template.name,
+        category: template.category,
+        quantity: template.quantity,
+        unit: template.unit,
+        status: 'pending',
+        subcategory: template.subcategory,
+        notes: template.notes,
+        assignedParticipantId: pid,
+        isAllParticipants: true,
+        allParticipantsGroupId: groupId,
+      })
+    }
+  }
+
+  return await tx
+    .select()
+    .from(items)
+    .where(
+      and(
+        eq(items.allParticipantsGroupId, groupId),
+        eq(items.isAllParticipants, true),
+        ne(items.status, 'canceled')
+      )
+    )
+}
+
+export async function reassignGroupToParticipant(
+  db: Database,
+  itemId: string,
+  newAssignedParticipantId: string
+): Promise<Item> {
+  return await db.transaction(async (tx) => {
+    const [item] = await tx.select().from(items).where(eq(items.itemId, itemId))
+
+    if (!item) throw new ItemNotFoundError(itemId)
+    if (!item.allParticipantsGroupId) throw new NoGroupError(itemId)
+
+    const now = new Date()
+
+    await tx
+      .update(items)
+      .set({
+        status: 'canceled',
+        isAllParticipants: false,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(items.allParticipantsGroupId, item.allParticipantsGroupId),
+          ne(items.itemId, itemId)
+        )
+      )
+
+    const [updated] = await tx
+      .update(items)
+      .set({
+        isAllParticipants: false,
+        assignedParticipantId: newAssignedParticipantId,
+        updatedAt: now,
+      })
+      .where(eq(items.itemId, itemId))
+      .returning()
+
+    return updated
+  })
+}
+
+export async function unassignGroup(
+  db: Database,
+  itemId: string
+): Promise<number> {
+  return await db.transaction(async (tx) => {
+    const [item] = await tx.select().from(items).where(eq(items.itemId, itemId))
+
+    if (!item) throw new ItemNotFoundError(itemId)
+    if (!item.allParticipantsGroupId) throw new NoGroupError(itemId)
+
+    const result = await tx
+      .update(items)
+      .set({
+        status: 'canceled',
+        isAllParticipants: false,
+        updatedAt: new Date(),
+      })
+      .where(eq(items.allParticipantsGroupId, item.allParticipantsGroupId))
+      .returning({ itemId: items.itemId })
+
+    return result.length
+  })
+}
+
+export async function updateGroupCoreFields(
+  db: Database,
+  itemId: string,
+  updates: Record<string, unknown>
+): Promise<number> {
+  const coreFields = pickCoreFields(updates)
+  if (!coreFields) return 0
+
+  return await db.transaction(async (tx) => {
+    const [item] = await tx.select().from(items).where(eq(items.itemId, itemId))
+
+    if (!item) throw new ItemNotFoundError(itemId)
+    if (!item.isAllParticipants || !item.allParticipantsGroupId) return 0
+
+    const result = await tx
+      .update(items)
+      .set({ ...coreFields, updatedAt: new Date() })
+      .where(eq(items.allParticipantsGroupId, item.allParticipantsGroupId))
+      .returning({ itemId: items.itemId })
+
+    return result.length
+  })
+}
+
+export async function createItemsForNewParticipant(
+  db: Database,
+  planId: string,
+  participantId: string
+): Promise<Item[]> {
+  return await db.transaction(async (tx) => {
+    const templates = await tx
+      .select()
+      .from(items)
+      .where(
+        and(
+          eq(items.planId, planId),
+          eq(items.isAllParticipants, true),
+          ne(items.status, 'canceled')
+        )
+      )
+
+    const groupsSeen = new Set<string>()
+    const uniqueTemplates: Item[] = []
+    for (const t of templates) {
+      if (
+        t.allParticipantsGroupId &&
+        !groupsSeen.has(t.allParticipantsGroupId)
+      ) {
+        groupsSeen.add(t.allParticipantsGroupId)
+        uniqueTemplates.push(t)
+      }
+    }
+
+    if (uniqueTemplates.length === 0) return []
+
+    const existingCopies = await tx
+      .select({ allParticipantsGroupId: items.allParticipantsGroupId })
+      .from(items)
+      .where(
+        and(
+          eq(items.assignedParticipantId, participantId),
+          eq(items.planId, planId),
+          eq(items.isAllParticipants, true)
+        )
+      )
+
+    const existingGroups = new Set(
+      existingCopies
+        .map((c) => c.allParticipantsGroupId)
+        .filter((id): id is string => !!id)
+    )
+
+    const toInsert = uniqueTemplates.filter(
+      (t) => !existingGroups.has(t.allParticipantsGroupId!)
+    )
+
+    if (toInsert.length === 0) return []
+
+    return await tx
+      .insert(items)
+      .values(
+        toInsert.map((t) => ({
+          planId,
+          name: t.name,
+          category: t.category,
+          quantity: t.quantity,
+          unit: t.unit,
+          status: 'pending' as const,
+          subcategory: t.subcategory,
+          notes: t.notes,
+          assignedParticipantId: participantId,
+          isAllParticipants: true,
+          allParticipantsGroupId: t.allParticipantsGroupId,
+        }))
+      )
+      .returning()
+  })
+}
+
+export async function removeParticipantFromAllGroups(
+  db: Database,
+  participantId: string
+): Promise<number> {
+  const result = await db
+    .delete(items)
+    .where(
+      and(
+        eq(items.assignedParticipantId, participantId),
+        eq(items.isAllParticipants, true)
+      )
+    )
+    .returning({ itemId: items.itemId })
+
+  return result.length
+}

--- a/src/services/participant.service.ts
+++ b/src/services/participant.service.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm'
 import type { Database } from '../db/index.js'
 import { participants, userDetails, Participant } from '../db/schema.js'
+import { createItemsForNewParticipant } from './all-participants-items.service.js'
 
 export interface AddParticipantData {
   planId: string
@@ -65,6 +66,8 @@ export async function addParticipantToPlan(
       rsvpStatus: data.rsvpStatus ?? 'confirmed',
     })
     .returning()
+
+  await createItemsForNewParticipant(db, data.planId, created.participantId)
 
   return created
 }

--- a/tests/integration/all-participants-items.test.ts
+++ b/tests/integration/all-participants-items.test.ts
@@ -1,0 +1,526 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import { eq } from 'drizzle-orm'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  seedTestItems,
+  seedTestParticipants,
+  seedTestPlans,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import { items, participants } from '../../src/db/schema.js'
+import { Database } from '../../src/db/index.js'
+import {
+  assignItemToAllParticipants,
+  reassignGroupToParticipant,
+  unassignGroup,
+  updateGroupCoreFields,
+  createItemsForNewParticipant,
+  removeParticipantFromAllGroups,
+} from '../../src/services/all-participants-items.service.js'
+import { addParticipantToPlan } from '../../src/services/participant.service.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+} from '../helpers/auth.js'
+
+const TEST_USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+
+describe('All Participants Items — Integration', () => {
+  let app: FastifyInstance
+  let db: Database
+  let token: string
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+    token = await signTestJwt({ sub: TEST_USER_ID })
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('Full lifecycle: assign all → status updates → reassign to one', () => {
+    it('participants update their own statuses independently, then owner reassigns to one', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 4)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const others = planParticipants.filter((p) => p.role !== 'owner')
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      expect(group).toHaveLength(4)
+
+      const ownerCopy = group.find(
+        (g) => g.assignedParticipantId === owner.participantId
+      )!
+      const p1Copy = group.find(
+        (g) => g.assignedParticipantId === others[0].participantId
+      )!
+      await db
+        .update(items)
+        .set({ status: 'purchased' })
+        .where(eq(items.itemId, ownerCopy.itemId))
+      await db
+        .update(items)
+        .set({ status: 'packed' })
+        .where(eq(items.itemId, p1Copy.itemId))
+
+      const reassigned = await reassignGroupToParticipant(
+        db,
+        item.itemId,
+        others[1].participantId
+      )
+
+      expect(reassigned.assignedParticipantId).toBe(others[1].participantId)
+      expect(reassigned.isAllParticipants).toBe(false)
+
+      const allItems = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, group[0].allParticipantsGroupId!)
+        )
+      const active = allItems.filter((i) => i.status !== 'canceled')
+      const canceled = allItems.filter((i) => i.status === 'canceled')
+
+      expect(active).toHaveLength(1)
+      expect(active[0].itemId).toBe(item.itemId)
+      expect(canceled).toHaveLength(3)
+    })
+  })
+
+  describe('Full lifecycle: assign all → unassign → re-toggle', () => {
+    it('unassign cancels all, re-toggle revives with correct statuses', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const nonOwner = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const nonOwnerCopy = group.find(
+        (g) => g.assignedParticipantId === nonOwner.participantId
+      )!
+      await db
+        .update(items)
+        .set({ status: 'purchased' })
+        .where(eq(items.itemId, nonOwnerCopy.itemId))
+
+      const canceledCount = await unassignGroup(db, item.itemId)
+      expect(canceledCount).toBe(3)
+
+      const afterUnassign = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      expect(afterUnassign.every((i) => i.status === 'canceled')).toBe(true)
+      expect(afterUnassign.every((i) => !i.isAllParticipants)).toBe(true)
+
+      const revived = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      expect(revived).toHaveLength(3)
+      expect(revived.every((r) => r.isAllParticipants)).toBe(true)
+
+      const revivedCanceled = revived.filter((r) => r.status === 'canceled')
+      expect(revivedCanceled).toHaveLength(0)
+    })
+  })
+
+  describe('New participant auto-assignment via addParticipantToPlan', () => {
+    it('addParticipantToPlan creates copies of all active "all" items for the new joiner', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      const existingParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = existingParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 3)
+
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      await assignItemToAllParticipants(
+        db,
+        planItems[1].itemId,
+        owner.participantId
+      )
+
+      const newParticipant = await addParticipantToPlan(db, {
+        planId: plan.planId,
+        userId: 'cccccccc-1111-2222-3333-444444444444',
+        name: 'New',
+        lastName: 'Joiner',
+        contactPhone: '+1-555-999-0000',
+      })
+
+      const newItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.assignedParticipantId, newParticipant.participantId))
+
+      const allCopies = newItems.filter((i) => i.isAllParticipants)
+      expect(allCopies).toHaveLength(2)
+
+      const names = allCopies.map((c) => c.name).sort()
+      expect(names).toEqual([planItems[0].name, planItems[1].name].sort())
+    })
+  })
+
+  describe('Participant deletion cleans up "all" copies', () => {
+    it('deleting participant via route removes their "all" copies but keeps regular items', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const target = planParticipants.find((p) => p.role === 'participant')!
+
+      const planItems = await seedTestItems(plan.planId, 2)
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+
+      await db
+        .update(items)
+        .set({ assignedParticipantId: target.participantId })
+        .where(eq(items.itemId, planItems[1].itemId))
+
+      const beforeDelete = await db
+        .select()
+        .from(items)
+        .where(eq(items.assignedParticipantId, target.participantId))
+      expect(beforeDelete).toHaveLength(2)
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/participants/${target.participantId}`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const afterDelete = await db
+        .select()
+        .from(items)
+        .where(eq(items.planId, plan.planId))
+
+      const targetItems = afterDelete.filter(
+        (i) => i.assignedParticipantId === target.participantId
+      )
+      expect(targetItems).toHaveLength(0)
+
+      const regularItem = afterDelete.find(
+        (i) => i.itemId === planItems[1].itemId
+      )
+      expect(regularItem).toBeDefined()
+      expect(regularItem!.assignedParticipantId).toBeNull()
+
+      const allGroupItems = afterDelete.filter((i) => i.isAllParticipants)
+      const allGroupParticipantIds = allGroupItems.map(
+        (i) => i.assignedParticipantId
+      )
+      expect(allGroupParticipantIds).not.toContain(target.participantId)
+    })
+  })
+
+  describe('Multiple "all" groups in same plan', () => {
+    it('two separate all-items groups coexist independently', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 2)
+
+      const group1 = await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      const group2 = await assignItemToAllParticipants(
+        db,
+        planItems[1].itemId,
+        owner.participantId
+      )
+
+      expect(group1[0].allParticipantsGroupId).not.toBe(
+        group2[0].allParticipantsGroupId
+      )
+      expect(group1).toHaveLength(3)
+      expect(group2).toHaveLength(3)
+
+      await unassignGroup(db, planItems[0].itemId)
+
+      const g1Items = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, group1[0].allParticipantsGroupId!)
+        )
+      expect(g1Items.every((i) => i.status === 'canceled')).toBe(true)
+
+      const g2Items = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, group2[0].allParticipantsGroupId!)
+        )
+      expect(g2Items.every((i) => i.status !== 'canceled')).toBe(true)
+      expect(g2Items.every((i) => i.isAllParticipants)).toBe(true)
+    })
+  })
+
+  describe('Cross-plan isolation', () => {
+    it('assign-all in plan A does not affect plan B items', async () => {
+      const [planA, planB] = await seedTestPlans(2)
+      const participantsA = await seedTestParticipants(planA.planId, 3)
+      await seedTestParticipants(planB.planId, 2)
+      const ownerA = participantsA.find((p) => p.role === 'owner')!
+
+      const itemsA = await seedTestItems(planA.planId, 1)
+      await seedTestItems(planB.planId, 2)
+
+      await assignItemToAllParticipants(
+        db,
+        itemsA[0].itemId,
+        ownerA.participantId
+      )
+
+      const planBItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.planId, planB.planId))
+
+      expect(planBItems).toHaveLength(2)
+      expect(planBItems.every((i) => !i.isAllParticipants)).toBe(true)
+      expect(planBItems.every((i) => i.allParticipantsGroupId === null)).toBe(
+        true
+      )
+    })
+  })
+
+  describe('Core field sync across group', () => {
+    it('owner updates name and quantity — all copies receive the change', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 4)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      await updateGroupCoreFields(db, item.itemId, {
+        name: 'Large Tent',
+        quantity: 3,
+        notes: 'Bring extra stakes',
+      })
+
+      const updated = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+
+      expect(updated).toHaveLength(4)
+      for (const u of updated) {
+        expect(u.name).toBe('Large Tent')
+        expect(u.quantity).toBe(3)
+        expect(u.notes).toBe('Bring extra stakes')
+      }
+    })
+
+    it('core field update does not touch individual statuses', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const nonOwner = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      const nonOwnerCopy = group.find(
+        (g) => g.assignedParticipantId === nonOwner.participantId
+      )!
+      await db
+        .update(items)
+        .set({ status: 'packed' })
+        .where(eq(items.itemId, nonOwnerCopy.itemId))
+
+      await updateGroupCoreFields(db, item.itemId, { name: 'Renamed' })
+
+      const [refreshed] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, nonOwnerCopy.itemId))
+
+      expect(refreshed.name).toBe('Renamed')
+      expect(refreshed.status).toBe('packed')
+    })
+  })
+
+  describe('GET /plans/:planId/items returns new fields', () => {
+    it('items response includes isAllParticipants and allParticipantsGroupId', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 2)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/items`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const responseItems = response.json()
+
+      expect(responseItems.length).toBeGreaterThanOrEqual(2)
+      const allCopies = responseItems.filter(
+        (i: { isAllParticipants: boolean }) => i.isAllParticipants
+      )
+      expect(allCopies.length).toBe(2)
+      expect(allCopies[0].allParticipantsGroupId).toBeTruthy()
+      expect(allCopies[0].allParticipantsGroupId).toBe(
+        allCopies[1].allParticipantsGroupId
+      )
+    })
+  })
+
+  describe('Complex re-toggle with participant roster changes', () => {
+    it('assign all → unassign → add participant → remove participant → re-toggle includes new, excludes removed', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const toRemove = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      await unassignGroup(db, item.itemId)
+
+      const [newParticipant] = await db
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'Late',
+          lastName: 'Joiner',
+          contactPhone: '+1-555-111-2222',
+          role: 'participant',
+        })
+        .returning()
+
+      await removeParticipantFromAllGroups(db, toRemove.participantId)
+      await db
+        .delete(participants)
+        .where(eq(participants.participantId, toRemove.participantId))
+
+      const revived = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      const revivedParticipantIds = revived.map((r) => r.assignedParticipantId)
+      expect(revivedParticipantIds).toContain(newParticipant.participantId)
+      expect(revivedParticipantIds).not.toContain(toRemove.participantId)
+
+      const currentParticipantList = await db
+        .select({ participantId: participants.participantId })
+        .from(participants)
+        .where(eq(participants.planId, plan.planId))
+      const currentIds = currentParticipantList
+        .map((p) => p.participantId)
+        .sort()
+
+      expect(revivedParticipantIds.sort()).toEqual(currentIds)
+    })
+  })
+
+  describe('createItemsForNewParticipant handles mixed group states', () => {
+    it('only creates copies for active groups, not canceled ones', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 3)
+
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      await assignItemToAllParticipants(
+        db,
+        planItems[1].itemId,
+        owner.participantId
+      )
+      await assignItemToAllParticipants(
+        db,
+        planItems[2].itemId,
+        owner.participantId
+      )
+
+      await unassignGroup(db, planItems[1].itemId)
+
+      const [newParticipant] = await db
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'Late',
+          lastName: 'Arrival',
+          contactPhone: '+1-555-333-4444',
+          role: 'participant',
+        })
+        .returning()
+
+      const created = await createItemsForNewParticipant(
+        db,
+        plan.planId,
+        newParticipant.participantId
+      )
+
+      expect(created).toHaveLength(2)
+      const createdNames = created.map((c) => c.name).sort()
+      expect(createdNames).toEqual(
+        [planItems[0].name, planItems[2].name].sort()
+      )
+    })
+  })
+})

--- a/tests/unit/all-participants-items.test.ts
+++ b/tests/unit/all-participants-items.test.ts
@@ -1,0 +1,512 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  setupTestDatabase,
+  closeTestDatabase,
+  cleanupTestDatabase,
+  seedTestPlans,
+  seedTestParticipants,
+  seedTestItems,
+  getTestDb,
+} from '../helpers/db.js'
+import { items, participants } from '../../src/db/schema.js'
+import { Database } from '../../src/db/index.js'
+import {
+  assignItemToAllParticipants,
+  reassignGroupToParticipant,
+  unassignGroup,
+  updateGroupCoreFields,
+  createItemsForNewParticipant,
+  removeParticipantFromAllGroups,
+  NotOwnerError,
+  ItemNotFoundError,
+  NoGroupError,
+} from '../../src/services/all-participants-items.service.js'
+
+describe('All Participants Items Service', () => {
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('assignItemToAllParticipants', () => {
+    it('flags original and creates N-1 copies on first assignment', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 4)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const result = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      expect(result).toHaveLength(4)
+      for (const r of result) {
+        expect(r.isAllParticipants).toBe(true)
+        expect(r.allParticipantsGroupId).toBe(result[0].allParticipantsGroupId)
+        expect(r.name).toBe(item.name)
+        expect(r.assignedParticipantId).toBeTruthy()
+      }
+
+      const assignedIds = result.map((r) => r.assignedParticipantId).sort()
+      const expectedIds = planParticipants.map((p) => p.participantId).sort()
+      expect(assignedIds).toEqual(expectedIds)
+
+      const ownerItem = result.find(
+        (r) => r.assignedParticipantId === owner.participantId
+      )!
+      expect(ownerItem.itemId).toBe(item.itemId)
+    })
+
+    it('throws NotOwnerError when called by non-owner', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const nonOwner = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await expect(
+        assignItemToAllParticipants(db, item.itemId, nonOwner.participantId)
+      ).rejects.toThrow(NotOwnerError)
+    })
+
+    it('throws ItemNotFoundError for non-existent item', async () => {
+      const fakeItemId = '00000000-0000-0000-0000-000000000001'
+      const fakeOwnerId = '00000000-0000-0000-0000-000000000002'
+
+      await expect(
+        assignItemToAllParticipants(db, fakeItemId, fakeOwnerId)
+      ).rejects.toThrow(ItemNotFoundError)
+    })
+
+    it('reconciles on re-toggle: revives canceled, creates for new participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      await unassignGroup(db, item.itemId)
+
+      const testDb = await getTestDb()
+      const [newParticipant] = await testDb
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'New',
+          lastName: 'Person',
+          contactPhone: '+1-555-999-9999',
+          role: 'participant',
+        })
+        .returning()
+
+      const result = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      expect(result).toHaveLength(4)
+      const assignedIds = new Set(result.map((r) => r.assignedParticipantId))
+      expect(assignedIds.has(newParticipant.participantId)).toBe(true)
+      for (const r of result) {
+        expect(r.isAllParticipants).toBe(true)
+        expect(r.status).not.toBe('canceled')
+      }
+    })
+
+    it('re-toggle preserves non-canceled statuses', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const nonOwner = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      const nonOwnerItem = group.find(
+        (g) => g.assignedParticipantId === nonOwner.participantId
+      )!
+
+      await reassignGroupToParticipant(db, item.itemId, owner.participantId)
+
+      const testDb = await getTestDb()
+      await testDb
+        .update(items)
+        .set({ status: 'purchased' })
+        .where(eq(items.itemId, nonOwnerItem.itemId))
+
+      const result = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      const revivedNonOwner = result.find(
+        (r) => r.assignedParticipantId === nonOwner.participantId
+      )!
+      expect(revivedNonOwner.status).toBe('purchased')
+      expect(revivedNonOwner.isAllParticipants).toBe(true)
+    })
+  })
+
+  describe('reassignGroupToParticipant', () => {
+    it('cancels all siblings and reassigns target item', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const target = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const updated = await reassignGroupToParticipant(
+        db,
+        item.itemId,
+        target.participantId
+      )
+
+      expect(updated.isAllParticipants).toBe(false)
+      expect(updated.assignedParticipantId).toBe(target.participantId)
+      expect(updated.allParticipantsGroupId).toBe(groupId)
+
+      const testDb = await getTestDb()
+      const allGroupItems = await testDb
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+
+      const siblings = allGroupItems.filter((i) => i.itemId !== item.itemId)
+      for (const s of siblings) {
+        expect(s.status).toBe('canceled')
+        expect(s.isAllParticipants).toBe(false)
+      }
+    })
+
+    it('throws NoGroupError for item without group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await expect(
+        reassignGroupToParticipant(
+          db,
+          item.itemId,
+          '00000000-0000-0000-0000-000000000001'
+        )
+      ).rejects.toThrow(NoGroupError)
+    })
+  })
+
+  describe('unassignGroup', () => {
+    it('cancels ALL items in the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 4)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const count = await unassignGroup(db, item.itemId)
+
+      expect(count).toBe(4)
+
+      const testDb = await getTestDb()
+      const allGroupItems = await testDb
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+
+      for (const i of allGroupItems) {
+        expect(i.status).toBe('canceled')
+        expect(i.isAllParticipants).toBe(false)
+      }
+    })
+
+    it('throws NoGroupError for item without group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await expect(unassignGroup(db, item.itemId)).rejects.toThrow(NoGroupError)
+    })
+  })
+
+  describe('updateGroupCoreFields', () => {
+    it('updates name/qty/unit across all copies in the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const updatedCount = await updateGroupCoreFields(db, item.itemId, {
+        name: 'Updated Tent',
+        quantity: 5,
+        unit: 'kg',
+      })
+
+      expect(updatedCount).toBe(3)
+
+      const testDb = await getTestDb()
+      const allGroupItems = await testDb
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+
+      for (const i of allGroupItems) {
+        expect(i.name).toBe('Updated Tent')
+        expect(i.quantity).toBe(5)
+        expect(i.unit).toBe('kg')
+      }
+    })
+
+    it('does NOT update status across the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const nonOwner = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+
+      const nonOwnerItem = group.find(
+        (g) => g.assignedParticipantId === nonOwner.participantId
+      )!
+      const testDb = await getTestDb()
+      await testDb
+        .update(items)
+        .set({ status: 'purchased' })
+        .where(eq(items.itemId, nonOwnerItem.itemId))
+
+      await updateGroupCoreFields(db, item.itemId, {
+        name: 'New Name',
+        status: 'packed',
+      })
+
+      const [refreshedNonOwner] = await testDb
+        .select()
+        .from(items)
+        .where(eq(items.itemId, nonOwnerItem.itemId))
+
+      expect(refreshedNonOwner.name).toBe('New Name')
+      expect(refreshedNonOwner.status).toBe('purchased')
+    })
+
+    it('returns 0 for non-all-participants item', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const count = await updateGroupCoreFields(db, item.itemId, {
+        name: 'New Name',
+      })
+
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('createItemsForNewParticipant', () => {
+    it('creates copies from active groups for a new participant', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 2)
+
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      await assignItemToAllParticipants(
+        db,
+        planItems[1].itemId,
+        owner.participantId
+      )
+
+      const testDb = await getTestDb()
+      const [newParticipant] = await testDb
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'New',
+          lastName: 'Person',
+          contactPhone: '+1-555-888-8888',
+          role: 'participant',
+        })
+        .returning()
+
+      const created = await createItemsForNewParticipant(
+        db,
+        plan.planId,
+        newParticipant.participantId
+      )
+
+      expect(created).toHaveLength(2)
+      for (const c of created) {
+        expect(c.assignedParticipantId).toBe(newParticipant.participantId)
+        expect(c.isAllParticipants).toBe(true)
+        expect(c.status).toBe('pending')
+      }
+    })
+
+    it('skips canceled groups', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 2)
+
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      await assignItemToAllParticipants(
+        db,
+        planItems[1].itemId,
+        owner.participantId
+      )
+
+      await unassignGroup(db, planItems[0].itemId)
+
+      const testDb = await getTestDb()
+      const [newParticipant] = await testDb
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'New',
+          lastName: 'Person',
+          contactPhone: '+1-555-777-7777',
+          role: 'participant',
+        })
+        .returning()
+
+      const created = await createItemsForNewParticipant(
+        db,
+        plan.planId,
+        newParticipant.participantId
+      )
+
+      expect(created).toHaveLength(1)
+      expect(created[0].name).toBe(planItems[1].name)
+    })
+
+    it('is idempotent — calling twice does not create duplicates', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      const testDb = await getTestDb()
+      const [newParticipant] = await testDb
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'New',
+          lastName: 'Person',
+          contactPhone: '+1-555-666-6666',
+          role: 'participant',
+        })
+        .returning()
+
+      const first = await createItemsForNewParticipant(
+        db,
+        plan.planId,
+        newParticipant.participantId
+      )
+      const second = await createItemsForNewParticipant(
+        db,
+        plan.planId,
+        newParticipant.participantId
+      )
+
+      expect(first).toHaveLength(1)
+      expect(second).toHaveLength(0)
+    })
+  })
+
+  describe('removeParticipantFromAllGroups', () => {
+    it('hard deletes only all-participants copies for the participant', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const target = planParticipants.find((p) => p.role === 'participant')!
+      const planItems = await seedTestItems(plan.planId, 2)
+
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+
+      const testDb = await getTestDb()
+      await testDb
+        .update(items)
+        .set({ assignedParticipantId: target.participantId })
+        .where(eq(items.itemId, planItems[1].itemId))
+
+      const deletedCount = await removeParticipantFromAllGroups(
+        db,
+        target.participantId
+      )
+
+      expect(deletedCount).toBe(1)
+
+      const remaining = await testDb
+        .select()
+        .from(items)
+        .where(eq(items.assignedParticipantId, target.participantId))
+
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0].itemId).toBe(planItems[1].itemId)
+      expect(remaining[0].isAllParticipants).toBe(false)
+    })
+
+    it('returns 0 when participant has no all-participants items', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 2)
+      const nonOwner = planParticipants.find((p) => p.role === 'participant')!
+
+      const count = await removeParticipantFromAllGroups(
+        db,
+        nonOwner.participantId
+      )
+
+      expect(count).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
Support assigning items to all participants via flat duplication with groupId linking. Includes assign/unassign/reassign/re-toggle logic, core field cascade, new participant auto-copy, participant deletion cleanup, and comprehensive unit + integration tests.

Made-with: Cursor