### PR TITLE
refactor: extract item route helpers and wire assignedToAll into bulk create

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -516,12 +516,14 @@
             "nullable": true
           },
           "isAllParticipants": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when this item is part of an all-participants group (one copy per participant)."
           },
           "allParticipantsGroupId": {
             "type": "string",
             "format": "uuid",
-            "nullable": true
+            "nullable": true,
+            "description": "Shared UUID linking all copies in an all-participants group. Null for regular items."
           },
           "createdAt": {
             "type": "string",
@@ -612,7 +614,8 @@
             "nullable": true
           },
           "assignedToAll": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Set true to assign this item to all participants (creates one copy per participant). Ignored if assignedParticipantId is also set."
           }
         },
         "required": [
@@ -682,7 +685,8 @@
             "nullable": true
           },
           "assignedToAll": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Set true to assign to all participants. Set false (or send assignedParticipantId/null) to switch from all to specific/unassigned."
           }
         },
         "title": "UpdateItemBody"
@@ -1837,6 +1841,10 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "assignedToAll": {
+            "type": "boolean",
+            "description": "Set true to assign to all participants. Set false (or send assignedParticipantId/null) to switch from all to specific/unassigned."
           }
         },
         "required": [
@@ -3065,7 +3073,7 @@
         "tags": [
           "items"
         ],
-        "description": "Create a new item in the specified plan. Equipment items always use pcs as the unit. Food items require a unit.",
+        "description": "Create a new item in the specified plan. Equipment items always use pcs as the unit. Food items require a unit. Send assignedToAll=true to assign to every participant.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3206,7 +3214,7 @@
         "tags": [
           "items"
         ],
-        "description": "Update an existing item by its ID",
+        "description": "Update an existing item by its ID. Supports all-participants assignment: send assignedToAll=true to assign to all, assignedParticipantId=<uuid> to reassign from all to one, assignedParticipantId=null or assignedToAll=false to unassign all. Core field changes on all-participants items cascade to every copy; status changes apply only to the target item.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3287,7 +3295,7 @@
         "tags": [
           "items"
         ],
-        "description": "Create multiple items at once. Each item is validated independently — valid items are created, invalid items are reported in the errors array with their name.",
+        "description": "Create multiple items at once. Each item is validated independently — valid items are created, invalid items are reported in the errors array. Supports assignedToAll per item (same logic as single-item POST).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3366,7 +3374,7 @@
         "tags": [
           "items"
         ],
-        "description": "Update multiple items at once. Each item is validated independently — valid items are updated, invalid items are reported in the errors array with their name.",
+        "description": "Update multiple items at once. Each item is validated independently — valid items are updated, invalid items are reported in the errors array. Supports assignedToAll per item (same logic as single-item PATCH).",
         "requestBody": {
           "content": {
             "application/json": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/routes/items.route.ts
+++ b/src/routes/items.route.ts
@@ -1,15 +1,17 @@
 import { FastifyInstance } from 'fastify'
 import { eq, inArray } from 'drizzle-orm'
-import {
-  items,
-  plans,
-  participants,
-  Unit,
-  ItemCategory,
-  ItemStatus,
-} from '../db/schema.js'
+import { items, ItemCategory, Unit, ItemStatus, Item } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { recordItemCreated, recordItemUpdated } from '../utils/item-changes.js'
+import { resolveItemUnit, classifyDbError } from '../utils/item-helpers.js'
+import {
+  checkPlanExists,
+  validateParticipant,
+  batchValidateParticipants,
+  applyAllParticipantsUpdate,
+  createItemAssignedToAll,
+} from '../services/item.service.js'
+import { NotOwnerError } from '../services/all-participants-items.service.js'
 
 interface CreateItemBody {
   name: string
@@ -20,6 +22,7 @@ interface CreateItemBody {
   subcategory?: string | null
   notes?: string | null
   assignedParticipantId?: string | null
+  assignedToAll?: boolean
 }
 
 interface UpdateItemBody {
@@ -31,6 +34,7 @@ interface UpdateItemBody {
   subcategory?: string | null
   notes?: string | null
   assignedParticipantId?: string | null
+  assignedToAll?: boolean
 }
 
 interface BulkItemError {
@@ -59,7 +63,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         tags: ['items'],
         summary: 'Add an item to a plan',
         description:
-          'Create a new item in the specified plan. Equipment items always use pcs as the unit. Food items require a unit.',
+          'Create a new item in the specified plan. Equipment items always use pcs as the unit. Food items require a unit. Send assignedToAll=true to assign to every participant.',
         params: { $ref: 'PlanIdParam#' },
         body: { $ref: 'CreateItemBody#' },
         response: {
@@ -73,47 +77,29 @@ export async function itemsRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { planId } = request.params
-      const { category, unit, assignedParticipantId, ...rest } = request.body
+      const { category, unit, assignedParticipantId, assignedToAll, ...rest } =
+        request.body
 
-      if (category === 'food' && !unit) {
-        return reply.status(400).send({
-          message: 'Unit is required for food items',
-        })
+      const unitResult = resolveItemUnit(category, unit)
+      if ('error' in unitResult) {
+        return reply.status(400).send({ message: unitResult.error })
       }
 
-      const resolvedUnit = category === 'equipment' ? 'pcs' : unit!
-
       try {
-        const [existingPlan] = await fastify.db
-          .select({ planId: plans.planId })
-          .from(plans)
-          .where(eq(plans.planId, planId))
-
-        if (!existingPlan) {
-          return reply.status(404).send({
-            message: 'Plan not found',
-          })
+        if (!(await checkPlanExists(fastify.db, planId))) {
+          return reply.status(404).send({ message: 'Plan not found' })
         }
 
         if (assignedParticipantId) {
-          const [participant] = await fastify.db
-            .select({
-              participantId: participants.participantId,
-              planId: participants.planId,
-            })
-            .from(participants)
-            .where(eq(participants.participantId, assignedParticipantId))
-
-          if (!participant) {
-            return reply.status(400).send({
-              message: 'Participant not found',
-            })
-          }
-
-          if (participant.planId !== planId) {
-            return reply.status(400).send({
-              message: 'Participant does not belong to this plan',
-            })
+          const check = await validateParticipant(
+            fastify.db,
+            assignedParticipantId,
+            planId
+          )
+          if (!check.valid) {
+            return reply
+              .status(400)
+              .send({ message: check.message ?? 'Invalid participant' })
           }
         }
 
@@ -122,7 +108,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           .values({
             planId,
             category,
-            unit: resolvedUnit,
+            unit: unitResult.unit,
             assignedParticipantId: assignedParticipantId ?? null,
             ...rest,
           })
@@ -138,24 +124,26 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           snapshot: createdItem as unknown as Record<string, unknown>,
           changedByUserId: request.user?.id ?? null,
         })
+
+        if (assignedToAll) {
+          const group = await createItemAssignedToAll(
+            fastify.db,
+            createdItem.itemId,
+            planId
+          )
+          if (group) {
+            const refreshed = group.find((g) => g.itemId === createdItem.itemId)
+            return reply.status(201).send(refreshed ?? group[0])
+          }
+        }
+
         return reply.status(201).send(createdItem)
       } catch (error) {
         request.log.error({ err: error, planId }, 'Failed to create item')
-
-        const isConnectionError =
-          error instanceof Error &&
-          (error.message.includes('connect') ||
-            error.message.includes('timeout'))
-
-        if (isConnectionError) {
-          return reply.status(503).send({
-            message: 'Database connection error',
-          })
-        }
-
-        return reply.status(500).send({
-          message: 'Failed to create item',
-        })
+        const classified = classifyDbError(error, 'Failed to create item')
+        return reply
+          .status(classified.statusCode)
+          .send({ message: classified.message })
       }
     }
   )
@@ -187,9 +175,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         )
 
         if (!allowed) {
-          return reply.status(404).send({
-            message: 'Plan not found',
-          })
+          return reply.status(404).send({ message: 'Plan not found' })
         }
 
         const planItems = await fastify.db
@@ -208,21 +194,13 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           { err: error, planId },
           'Failed to retrieve plan items'
         )
-
-        const isConnectionError =
-          error instanceof Error &&
-          (error.message.includes('connect') ||
-            error.message.includes('timeout'))
-
-        if (isConnectionError) {
-          return reply.status(503).send({
-            message: 'Database connection error',
-          })
-        }
-
-        return reply.status(500).send({
-          message: 'Failed to retrieve plan items',
-        })
+        const classified = classifyDbError(
+          error,
+          'Failed to retrieve plan items'
+        )
+        return reply
+          .status(classified.statusCode)
+          .send({ message: classified.message })
       }
     }
   )
@@ -233,7 +211,8 @@ export async function itemsRoutes(fastify: FastifyInstance) {
       schema: {
         tags: ['items'],
         summary: 'Update an item',
-        description: 'Update an existing item by its ID',
+        description:
+          'Update an existing item by its ID. Supports all-participants assignment: send assignedToAll=true to assign to all, assignedParticipantId=<uuid> to reassign from all to one, assignedParticipantId=null or assignedToAll=false to unassign all. Core field changes on all-participants items cascade to every copy; status changes apply only to the target item.',
         params: { $ref: 'ItemIdParam#' },
         body: { $ref: 'UpdateItemBody#' },
         response: {
@@ -247,12 +226,13 @@ export async function itemsRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { itemId } = request.params
-      const updates = request.body
+      const { assignedToAll, ...fieldUpdates } = request.body
 
-      if (Object.keys(updates).length === 0) {
-        return reply.status(400).send({
-          message: 'No fields to update',
-        })
+      if (
+        Object.keys(fieldUpdates).length === 0 &&
+        assignedToAll === undefined
+      ) {
+        return reply.status(400).send({ message: 'No fields to update' })
       }
 
       try {
@@ -262,73 +242,71 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           .where(eq(items.itemId, itemId))
 
         if (!existingItem) {
-          return reply.status(404).send({
-            message: 'Item not found',
-          })
+          return reply.status(404).send({ message: 'Item not found' })
+        }
+
+        const participantValidator = (pid: string) =>
+          validateParticipant(fastify.db, pid, existingItem.planId)
+
+        const allResult = await applyAllParticipantsUpdate(
+          fastify.db,
+          itemId,
+          existingItem,
+          assignedToAll,
+          fieldUpdates,
+          participantValidator
+        )
+
+        if (allResult) {
+          request.log.info(
+            { itemId, changes: Object.keys(fieldUpdates) },
+            'Item updated (all-participants)'
+          )
+          return allResult.item
         }
 
         if (
-          updates.assignedParticipantId !== undefined &&
-          updates.assignedParticipantId !== null
+          fieldUpdates.assignedParticipantId !== undefined &&
+          fieldUpdates.assignedParticipantId !== null
         ) {
-          const [participant] = await fastify.db
-            .select({
-              participantId: participants.participantId,
-              planId: participants.planId,
-            })
-            .from(participants)
-            .where(
-              eq(participants.participantId, updates.assignedParticipantId)
-            )
-
-          if (!participant) {
-            return reply.status(400).send({
-              message: 'Participant not found',
-            })
-          }
-
-          if (participant.planId !== existingItem.planId) {
-            return reply.status(400).send({
-              message: 'Participant does not belong to this plan',
-            })
+          const check = await validateParticipant(
+            fastify.db,
+            fieldUpdates.assignedParticipantId,
+            existingItem.planId
+          )
+          if (!check.valid) {
+            return reply.status(400).send({ message: check.message })
           }
         }
 
         const [updatedItem] = await fastify.db
           .update(items)
-          .set({ ...updates, updatedAt: new Date() })
+          .set({ ...fieldUpdates, updatedAt: new Date() })
           .where(eq(items.itemId, itemId))
           .returning()
 
         request.log.info(
-          { itemId, changes: Object.keys(updates) },
+          { itemId, changes: Object.keys(fieldUpdates) },
           'Item updated'
         )
         recordItemUpdated(fastify.db, {
           itemId,
           planId: existingItem.planId,
           existing: existingItem,
-          updates,
+          updates: fieldUpdates,
           changedByUserId: request.user?.id ?? null,
         })
         return updatedItem
       } catch (error) {
-        request.log.error({ err: error, itemId }, 'Failed to update item')
-
-        const isConnectionError =
-          error instanceof Error &&
-          (error.message.includes('connect') ||
-            error.message.includes('timeout'))
-
-        if (isConnectionError) {
-          return reply.status(503).send({
-            message: 'Database connection error',
-          })
+        if (error instanceof NotOwnerError) {
+          return reply.status(403).send({ message: error.message })
         }
 
-        return reply.status(500).send({
-          message: 'Failed to update item',
-        })
+        request.log.error({ err: error, itemId }, 'Failed to update item')
+        const classified = classifyDbError(error, 'Failed to update item')
+        return reply
+          .status(classified.statusCode)
+          .send({ message: classified.message })
       }
     }
   )
@@ -343,7 +321,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         tags: ['items'],
         summary: 'Bulk create items in a plan',
         description:
-          'Create multiple items at once. Each item is validated independently — valid items are created, invalid items are reported in the errors array with their name.',
+          'Create multiple items at once. Each item is validated independently — valid items are created, invalid items are reported in the errors array. Supports assignedToAll per item (same logic as single-item POST).',
         params: { $ref: 'PlanIdParam#' },
         body: { $ref: 'BulkCreateItemBody#' },
         response: {
@@ -360,12 +338,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
       const { items: itemsToCreate } = request.body
 
       try {
-        const [existingPlan] = await fastify.db
-          .select({ planId: plans.planId })
-          .from(plans)
-          .where(eq(plans.planId, planId))
-
-        if (!existingPlan) {
+        if (!(await checkPlanExists(fastify.db, planId))) {
           return reply.status(404).send({ message: 'Plan not found' })
         }
 
@@ -376,20 +349,10 @@ export async function itemsRoutes(fastify: FastifyInstance) {
               .filter((id): id is string => !!id)
           ),
         ]
-
-        const participantMap = new Map<string, string>()
-        if (participantIds.length > 0) {
-          const found = await fastify.db
-            .select({
-              participantId: participants.participantId,
-              planId: participants.planId,
-            })
-            .from(participants)
-            .where(inArray(participants.participantId, participantIds))
-          for (const p of found) {
-            participantMap.set(p.participantId, p.planId)
-          }
-        }
+        const participantMap = await batchValidateParticipants(
+          fastify.db,
+          participantIds
+        )
 
         const validValues: Array<{
           planId: string
@@ -402,16 +365,21 @@ export async function itemsRoutes(fastify: FastifyInstance) {
           notes?: string | null
           assignedParticipantId: string | null
         }> = []
+        const assignToAllIndices = new Set<number>()
         const errors: BulkItemError[] = []
 
         for (const item of itemsToCreate) {
-          const { category, unit, assignedParticipantId, ...rest } = item
+          const {
+            category,
+            unit,
+            assignedParticipantId,
+            assignedToAll,
+            ...rest
+          } = item
 
-          if (category === 'food' && !unit) {
-            errors.push({
-              name: item.name,
-              message: 'Unit is required for food items',
-            })
+          const unitResult = resolveItemUnit(category, unit)
+          if ('error' in unitResult) {
+            errors.push({ name: item.name, message: unitResult.error })
             continue
           }
 
@@ -433,17 +401,20 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             }
           }
 
-          const resolvedUnit = category === 'equipment' ? 'pcs' : unit!
+          if (assignedToAll) {
+            assignToAllIndices.add(validValues.length)
+          }
+
           validValues.push({
             planId,
             category,
-            unit: resolvedUnit,
+            unit: unitResult.unit,
             assignedParticipantId: assignedParticipantId ?? null,
             ...rest,
           })
         }
 
-        let createdItems: (typeof items.$inferSelect)[] = []
+        let createdItems: Item[] = []
         if (validValues.length > 0) {
           createdItems = await fastify.db
             .insert(items)
@@ -451,37 +422,57 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             .returning()
         }
 
-        for (const created of createdItems) {
+        const finalItems: Item[] = []
+        for (let i = 0; i < createdItems.length; i++) {
+          const created = createdItems[i]
+
           recordItemCreated(fastify.db, {
             itemId: created.itemId,
             planId,
             snapshot: created as unknown as Record<string, unknown>,
             changedByUserId: request.user?.id ?? null,
           })
+
+          if (assignToAllIndices.has(i)) {
+            try {
+              const group = await createItemAssignedToAll(
+                fastify.db,
+                created.itemId,
+                planId
+              )
+              if (group) {
+                const refreshed = group.find((g) => g.itemId === created.itemId)
+                finalItems.push(refreshed ?? group[0])
+              } else {
+                finalItems.push(created)
+              }
+            } catch (err) {
+              errors.push({
+                name: created.name,
+                message:
+                  err instanceof Error
+                    ? err.message
+                    : 'Failed to assign to all',
+              })
+              finalItems.push(created)
+            }
+          } else {
+            finalItems.push(created)
+          }
         }
+
         const statusCode = errors.length === 0 ? 200 : 207
         request.log.info(
-          { planId, created: createdItems.length, failed: errors.length },
+          { planId, created: finalItems.length, failed: errors.length },
           'Bulk items created'
         )
-        return reply.status(statusCode).send({ items: createdItems, errors })
+        return reply.status(statusCode).send({ items: finalItems, errors })
       } catch (error) {
         request.log.error({ err: error, planId }, 'Failed to bulk create items')
-
-        const isConnectionError =
-          error instanceof Error &&
-          (error.message.includes('connect') ||
-            error.message.includes('timeout'))
-
-        if (isConnectionError) {
-          return reply
-            .status(503)
-            .send({ message: 'Database connection error' })
-        }
-
+        const classified = classifyDbError(error, 'Failed to bulk create items')
         return reply
-          .status(500)
-          .send({ message: 'Failed to bulk create items' })
+          .status(classified.statusCode)
+          .send({ message: classified.message })
       }
     }
   )
@@ -496,7 +487,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         tags: ['items'],
         summary: 'Bulk update items in a plan',
         description:
-          'Update multiple items at once. Each item is validated independently — valid items are updated, invalid items are reported in the errors array with their name.',
+          'Update multiple items at once. Each item is validated independently — valid items are updated, invalid items are reported in the errors array. Supports assignedToAll per item (same logic as single-item PATCH).',
         params: { $ref: 'PlanIdParam#' },
         body: { $ref: 'BulkUpdateItemBody#' },
         response: {
@@ -527,26 +518,16 @@ export async function itemsRoutes(fastify: FastifyInstance) {
               .filter((id): id is string => id !== undefined && id !== null)
           ),
         ]
+        const participantMap = await batchValidateParticipants(
+          fastify.db,
+          participantIds
+        )
 
-        const participantMap = new Map<string, string>()
-        if (participantIds.length > 0) {
-          const found = await fastify.db
-            .select({
-              participantId: participants.participantId,
-              planId: participants.planId,
-            })
-            .from(participants)
-            .where(inArray(participants.participantId, participantIds))
-          for (const p of found) {
-            participantMap.set(p.participantId, p.planId)
-          }
-        }
-
-        const updatedItems: (typeof items.$inferSelect)[] = []
+        const updatedItems: Item[] = []
         const errors: BulkItemError[] = []
 
         for (const entry of itemUpdates) {
-          const { itemId, ...updates } = entry
+          const { itemId, assignedToAll, ...fieldUpdates } = entry
           const existing = itemMap.get(itemId)
 
           if (!existing) {
@@ -565,7 +546,10 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             continue
           }
 
-          if (Object.keys(updates).length === 0) {
+          if (
+            Object.keys(fieldUpdates).length === 0 &&
+            assignedToAll === undefined
+          ) {
             errors.push({
               name: existing.name,
               message: 'No fields to update',
@@ -573,11 +557,50 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             continue
           }
 
+          const participantValidator = async (
+            pid: string
+          ): Promise<{ valid: boolean; message?: string }> => {
+            const pPlanId = participantMap.get(pid)
+            if (!pPlanId)
+              return { valid: false, message: 'Participant not found' }
+            if (pPlanId !== planId)
+              return {
+                valid: false,
+                message: 'Participant does not belong to this plan',
+              }
+            return { valid: true }
+          }
+
+          try {
+            const allResult = await applyAllParticipantsUpdate(
+              fastify.db,
+              itemId,
+              existing,
+              assignedToAll,
+              fieldUpdates,
+              participantValidator
+            )
+
+            if (allResult) {
+              updatedItems.push(allResult.item)
+              continue
+            }
+          } catch (err) {
+            errors.push({
+              name: existing.name,
+              message:
+                err instanceof Error ? err.message : 'Failed to update item',
+            })
+            continue
+          }
+
           if (
-            updates.assignedParticipantId !== undefined &&
-            updates.assignedParticipantId !== null
+            fieldUpdates.assignedParticipantId !== undefined &&
+            fieldUpdates.assignedParticipantId !== null
           ) {
-            const pPlanId = participantMap.get(updates.assignedParticipantId)
+            const pPlanId = participantMap.get(
+              fieldUpdates.assignedParticipantId
+            )
             if (!pPlanId) {
               errors.push({
                 name: existing.name,
@@ -596,7 +619,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
 
           const [updatedItem] = await fastify.db
             .update(items)
-            .set({ ...updates, updatedAt: new Date() })
+            .set({ ...fieldUpdates, updatedAt: new Date() })
             .where(eq(items.itemId, itemId))
             .returning()
 
@@ -605,7 +628,7 @@ export async function itemsRoutes(fastify: FastifyInstance) {
             itemId,
             planId: existing.planId,
             existing,
-            updates,
+            updates: fieldUpdates,
             changedByUserId: request.user?.id ?? null,
           })
         }
@@ -618,21 +641,10 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         return reply.status(statusCode).send({ items: updatedItems, errors })
       } catch (error) {
         request.log.error({ err: error, planId }, 'Failed to bulk update items')
-
-        const isConnectionError =
-          error instanceof Error &&
-          (error.message.includes('connect') ||
-            error.message.includes('timeout'))
-
-        if (isConnectionError) {
-          return reply
-            .status(503)
-            .send({ message: 'Database connection error' })
-        }
-
+        const classified = classifyDbError(error, 'Failed to bulk update items')
         return reply
-          .status(500)
-          .send({ message: 'Failed to bulk update items' })
+          .status(classified.statusCode)
+          .send({ message: classified.message })
       }
     }
   )

--- a/src/schemas/item.schema.ts
+++ b/src/schemas/item.schema.ts
@@ -24,11 +24,17 @@ export const itemSchema = {
     subcategory: { type: 'string', nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
-    isAllParticipants: { type: 'boolean' },
+    isAllParticipants: {
+      type: 'boolean',
+      description:
+        'True when this item is part of an all-participants group (one copy per participant).',
+    },
     allParticipantsGroupId: {
       type: 'string',
       format: 'uuid',
       nullable: true,
+      description:
+        'Shared UUID linking all copies in an all-participants group. Null for regular items.',
     },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
@@ -71,7 +77,11 @@ export const createItemBodySchema = {
     subcategory: { type: 'string', maxLength: 255, nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
-    assignedToAll: { type: 'boolean' },
+    assignedToAll: {
+      type: 'boolean',
+      description:
+        'Set true to assign this item to all participants (creates one copy per participant). Ignored if assignedParticipantId is also set.',
+    },
   },
   required: ['name', 'category', 'quantity', 'status'],
 } as const
@@ -94,7 +104,11 @@ export const updateItemBodySchema = {
     subcategory: { type: 'string', maxLength: 255, nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
-    assignedToAll: { type: 'boolean' },
+    assignedToAll: {
+      type: 'boolean',
+      description:
+        'Set true to assign to all participants. Set false (or send assignedParticipantId/null) to switch from all to specific/unassigned.',
+    },
   },
 } as const
 
@@ -139,6 +153,11 @@ export const bulkUpdateItemEntrySchema = {
     subcategory: { type: 'string', maxLength: 255, nullable: true },
     notes: { type: 'string', nullable: true },
     assignedParticipantId: { type: 'string', format: 'uuid', nullable: true },
+    assignedToAll: {
+      type: 'boolean',
+      description:
+        'Set true to assign to all participants. Set false (or send assignedParticipantId/null) to switch from all to specific/unassigned.',
+    },
   },
   required: ['itemId'],
 } as const

--- a/src/services/item.service.ts
+++ b/src/services/item.service.ts
@@ -1,0 +1,178 @@
+import { eq, and, inArray } from 'drizzle-orm'
+import type { Database } from '../db/index.js'
+import { items, plans, participants } from '../db/schema.js'
+import type { Item, ItemCategory, Unit, ItemStatus } from '../db/schema.js'
+import {
+  assignItemToAllParticipants,
+  reassignGroupToParticipant,
+  unassignGroup,
+  updateGroupCoreFields,
+} from './all-participants-items.service.js'
+
+export interface ValidationResult {
+  valid: boolean
+  message?: string
+}
+
+export interface ItemUpdateResult {
+  item: Item
+  handled: true
+}
+
+export interface UpdateItemFields {
+  name?: string
+  category?: ItemCategory
+  quantity?: number
+  unit?: Unit
+  status?: ItemStatus
+  subcategory?: string | null
+  notes?: string | null
+  assignedParticipantId?: string | null
+}
+
+export async function checkPlanExists(
+  db: Database,
+  planId: string
+): Promise<boolean> {
+  const [existing] = await db
+    .select({ planId: plans.planId })
+    .from(plans)
+    .where(eq(plans.planId, planId))
+  return !!existing
+}
+
+export async function validateParticipant(
+  db: Database,
+  participantId: string,
+  planId: string
+): Promise<ValidationResult> {
+  const [p] = await db
+    .select({
+      participantId: participants.participantId,
+      planId: participants.planId,
+    })
+    .from(participants)
+    .where(eq(participants.participantId, participantId))
+
+  if (!p) return { valid: false, message: 'Participant not found' }
+  if (p.planId !== planId)
+    return {
+      valid: false,
+      message: 'Participant does not belong to this plan',
+    }
+  return { valid: true }
+}
+
+export async function batchValidateParticipants(
+  db: Database,
+  participantIds: string[]
+): Promise<Map<string, string>> {
+  if (participantIds.length === 0) return new Map()
+
+  const found = await db
+    .select({
+      participantId: participants.participantId,
+      planId: participants.planId,
+    })
+    .from(participants)
+    .where(inArray(participants.participantId, participantIds))
+
+  const map = new Map<string, string>()
+  for (const p of found) {
+    map.set(p.participantId, p.planId)
+  }
+  return map
+}
+
+export async function findPlanOwner(
+  db: Database,
+  planId: string
+): Promise<string | null> {
+  const [owner] = await db
+    .select({ participantId: participants.participantId })
+    .from(participants)
+    .where(and(eq(participants.planId, planId), eq(participants.role, 'owner')))
+  return owner?.participantId ?? null
+}
+
+export async function applyAllParticipantsUpdate(
+  db: Database,
+  itemId: string,
+  existing: Item,
+  assignedToAll: boolean | undefined,
+  fieldUpdates: UpdateItemFields,
+  participantValidator: (pid: string) => Promise<ValidationResult>
+): Promise<ItemUpdateResult | null> {
+  if (assignedToAll === true) {
+    const ownerPid = await findPlanOwner(db, existing.planId)
+    if (!ownerPid) {
+      throw new Error('Plan has no owner participant')
+    }
+
+    const group = await assignItemToAllParticipants(db, itemId, ownerPid)
+    const updated = group.find((g) => g.itemId === itemId) ?? group[0]
+    return { item: updated, handled: true }
+  }
+
+  if (!existing.isAllParticipants || !existing.allParticipantsGroupId) {
+    return null
+  }
+
+  if (
+    fieldUpdates.assignedParticipantId !== undefined &&
+    fieldUpdates.assignedParticipantId !== null
+  ) {
+    const check = await participantValidator(fieldUpdates.assignedParticipantId)
+    if (!check.valid) {
+      throw new Error(check.message ?? 'Participant not found')
+    }
+
+    const result = await reassignGroupToParticipant(
+      db,
+      itemId,
+      fieldUpdates.assignedParticipantId
+    )
+    return { item: result, handled: true }
+  }
+
+  if (fieldUpdates.assignedParticipantId === null || assignedToAll === false) {
+    await unassignGroup(db, itemId)
+    const [updated] = await db
+      .select()
+      .from(items)
+      .where(eq(items.itemId, itemId))
+    return { item: updated, handled: true }
+  }
+
+  if (Object.keys(fieldUpdates).length > 0) {
+    await updateGroupCoreFields(
+      db,
+      itemId,
+      fieldUpdates as Record<string, unknown>
+    )
+  }
+
+  if (fieldUpdates.status) {
+    await db
+      .update(items)
+      .set({ status: fieldUpdates.status, updatedAt: new Date() })
+      .where(eq(items.itemId, itemId))
+  }
+
+  const [refreshed] = await db
+    .select()
+    .from(items)
+    .where(eq(items.itemId, itemId))
+  return { item: refreshed, handled: true }
+}
+
+export async function createItemAssignedToAll(
+  db: Database,
+  createdItemId: string,
+  planId: string
+): Promise<Item[] | null> {
+  const ownerPid = await findPlanOwner(db, planId)
+  if (!ownerPid) return null
+
+  return await assignItemToAllParticipants(db, createdItemId, ownerPid)
+}

--- a/src/utils/item-helpers.ts
+++ b/src/utils/item-helpers.ts
@@ -1,0 +1,28 @@
+import type { ItemCategory, Unit } from '../db/schema.js'
+
+export type UnitResult = { unit: Unit } | { error: string }
+
+export function resolveItemUnit(
+  category: ItemCategory,
+  unit?: Unit
+): UnitResult {
+  if (category === 'food' && !unit) {
+    return { error: 'Unit is required for food items' }
+  }
+  return { unit: category === 'equipment' ? 'pcs' : unit! }
+}
+
+export function classifyDbError(
+  error: unknown,
+  fallbackMessage: string
+): { statusCode: number; message: string } {
+  const isConnectionError =
+    error instanceof Error &&
+    (error.message.includes('connect') || error.message.includes('timeout'))
+
+  if (isConnectionError) {
+    return { statusCode: 503, message: 'Database connection error' }
+  }
+
+  return { statusCode: 500, message: fallbackMessage }
+}

--- a/tests/integration/all-participants-items.test.ts
+++ b/tests/integration/all-participants-items.test.ts
@@ -474,6 +474,580 @@ describe('All Participants Items — Integration', () => {
     })
   })
 
+  describe('PATCH /items/:itemId with assignedToAll', () => {
+    it('assignedToAll: true creates copies for all participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { assignedToAll: true },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.isAllParticipants).toBe(true)
+      expect(updated.allParticipantsGroupId).toBeTruthy()
+
+      const allItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, updated.allParticipantsGroupId))
+      expect(allItems).toHaveLength(3)
+      expect(allItems.every((i) => i.isAllParticipants)).toBe(true)
+
+      const assignedIds = allItems.map((i) => i.assignedParticipantId).sort()
+      const expectedIds = planParticipants.map((p) => p.participantId).sort()
+      expect(assignedIds).toEqual(expectedIds)
+    })
+
+    it('changing assignedParticipantId on "all" item reassigns to one and cancels siblings', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const target = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { assignedParticipantId: target.participantId },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.isAllParticipants).toBe(false)
+      expect(updated.assignedParticipantId).toBe(target.participantId)
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, updated.allParticipantsGroupId))
+      const canceled = allGroupItems.filter((i) => i.status === 'canceled')
+      expect(canceled).toHaveLength(2)
+    })
+
+    it('setting assignedParticipantId to null on "all" item unassigns the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { assignedParticipantId: null },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.isAllParticipants).toBe(false)
+      expect(updated.status).toBe('canceled')
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      expect(allGroupItems.every((i) => i.status === 'canceled')).toBe(true)
+      expect(allGroupItems.every((i) => !i.isAllParticipants)).toBe(true)
+    })
+
+    it('assignedToAll: false on "all" item unassigns the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { assignedToAll: true },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { assignedToAll: false },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.isAllParticipants).toBe(false)
+      expect(updated.status).toBe('canceled')
+    })
+
+    it('updating core fields on "all" item cascades to all copies', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { name: 'Big Tent', quantity: 5 },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().name).toBe('Big Tent')
+      expect(response.json().quantity).toBe(5)
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      for (const gi of allGroupItems) {
+        expect(gi.name).toBe('Big Tent')
+        expect(gi.quantity).toBe(5)
+      }
+    })
+
+    it('status update on "all" item applies only to that copy', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const siblingCopy = group.find((g) => g.itemId !== item.itemId)!
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { status: 'purchased' },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().status).toBe('purchased')
+
+      const [sibling] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, siblingCopy.itemId))
+      expect(sibling.status).toBe('pending')
+    })
+
+    it('re-toggle via assignedToAll: true after unassign revives the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+      await unassignGroup(db, item.itemId)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/items/${item.itemId}`,
+        payload: { assignedToAll: true },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.isAllParticipants).toBe(true)
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, updated.allParticipantsGroupId))
+      const active = allGroupItems.filter(
+        (i) => i.isAllParticipants && i.status !== 'canceled'
+      )
+      expect(active).toHaveLength(3)
+    })
+  })
+
+  describe('POST /plans/:planId/items with assignedToAll', () => {
+    it('creates item and assigns to all participants in one request', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Shared Tent',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+          assignedToAll: true,
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const created = response.json()
+      expect(created.isAllParticipants).toBe(true)
+      expect(created.allParticipantsGroupId).toBeTruthy()
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, created.allParticipantsGroupId))
+      expect(allGroupItems).toHaveLength(3)
+      expect(allGroupItems.every((i) => i.name === 'Shared Tent')).toBe(true)
+
+      const assignedIds = allGroupItems
+        .map((i) => i.assignedParticipantId)
+        .sort()
+      const expectedIds = planParticipants.map((p) => p.participantId).sort()
+      expect(assignedIds).toEqual(expectedIds)
+    })
+
+    it('creates item without assignedToAll as a normal item', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 2)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items`,
+        payload: {
+          name: 'Regular Item',
+          category: 'equipment',
+          quantity: 1,
+          status: 'pending',
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const created = response.json()
+      expect(created.isAllParticipants).toBe(false)
+      expect(created.allParticipantsGroupId).toBeNull()
+    })
+  })
+
+  describe('PATCH /plans/:planId/items/bulk with assignedToAll', () => {
+    it('bulk update with assignedToAll: true creates copies for all participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+      const planItems = await seedTestItems(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [{ itemId: planItems[0].itemId, assignedToAll: true }],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items).toHaveLength(1)
+      expect(body.errors).toHaveLength(0)
+      expect(body.items[0].isAllParticipants).toBe(true)
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, body.items[0].allParticipantsGroupId)
+        )
+      expect(allGroupItems).toHaveLength(3)
+    })
+
+    it('bulk update reassigning "all" item to specific participant cancels siblings', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const target = planParticipants.find((p) => p.role === 'participant')!
+      const planItems = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              itemId: planItems[0].itemId,
+              assignedParticipantId: target.participantId,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items[0].isAllParticipants).toBe(false)
+      expect(body.items[0].assignedParticipantId).toBe(target.participantId)
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, body.items[0].allParticipantsGroupId)
+        )
+      const canceled = allGroupItems.filter((i) => i.status === 'canceled')
+      expect(canceled).toHaveLength(2)
+    })
+
+    it('bulk update mixing normal and assignedToAll items in one request', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+      const planItems = await seedTestItems(plan.planId, 2)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            { itemId: planItems[0].itemId, assignedToAll: true },
+            { itemId: planItems[1].itemId, name: 'Updated Normal' },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items).toHaveLength(2)
+      expect(body.errors).toHaveLength(0)
+
+      const allItem = body.items.find(
+        (i: { itemId: string }) => i.itemId === planItems[0].itemId
+      )
+      expect(allItem.isAllParticipants).toBe(true)
+
+      const normalItem = body.items.find(
+        (i: { itemId: string }) => i.itemId === planItems[1].itemId
+      )
+      expect(normalItem.name).toBe('Updated Normal')
+      expect(normalItem.isAllParticipants).toBe(false)
+    })
+
+    it('bulk update with assignedToAll: false unassigns the group', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [{ itemId: planItems[0].itemId, assignedToAll: false }],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items[0].isAllParticipants).toBe(false)
+      expect(body.items[0].status).toBe('canceled')
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      expect(allGroupItems.every((i) => i.status === 'canceled')).toBe(true)
+    })
+
+    it('bulk update core fields on "all" item cascades to all copies', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const planItems = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        planItems[0].itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              itemId: planItems[0].itemId,
+              name: 'Bulk Renamed',
+              quantity: 10,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().items[0].name).toBe('Bulk Renamed')
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      for (const gi of allGroupItems) {
+        expect(gi.name).toBe('Bulk Renamed')
+        expect(gi.quantity).toBe(10)
+      }
+    })
+  })
+
+  describe('POST /plans/:planId/items/bulk with assignedToAll', () => {
+    it('bulk create with assignedToAll: true creates copies for all participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Shared Lantern',
+              category: 'equipment',
+              quantity: 1,
+              status: 'pending',
+              assignedToAll: true,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.errors).toHaveLength(0)
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].isAllParticipants).toBe(true)
+      expect(body.items[0].allParticipantsGroupId).toBeTruthy()
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, body.items[0].allParticipantsGroupId)
+        )
+      expect(allGroupItems).toHaveLength(3)
+      expect(allGroupItems.every((i) => i.name === 'Shared Lantern')).toBe(true)
+    })
+
+    it('bulk create mixing assignedToAll and normal items', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Shared Rope',
+              category: 'equipment',
+              quantity: 2,
+              status: 'pending',
+              assignedToAll: true,
+            },
+            {
+              name: 'My Snack',
+              category: 'food',
+              quantity: 1,
+              unit: 'pcs',
+              status: 'pending',
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items).toHaveLength(2)
+      expect(body.errors).toHaveLength(0)
+
+      const sharedItem = body.items.find(
+        (i: { name: string }) => i.name === 'Shared Rope'
+      )
+      expect(sharedItem.isAllParticipants).toBe(true)
+
+      const normalItem = body.items.find(
+        (i: { name: string }) => i.name === 'My Snack'
+      )
+      expect(normalItem.isAllParticipants).toBe(false)
+      expect(normalItem.allParticipantsGroupId).toBeNull()
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, sharedItem.allParticipantsGroupId)
+        )
+      expect(allGroupItems).toHaveLength(3)
+    })
+
+    it('bulk create without assignedToAll creates normal items', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 2)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Regular Item',
+              category: 'equipment',
+              quantity: 1,
+              status: 'pending',
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].isAllParticipants).toBe(false)
+      expect(body.items[0].allParticipantsGroupId).toBeNull()
+    })
+  })
+
   describe('createItemsForNewParticipant handles mixed group states', () => {
     it('only creates copies for active groups, not canceled ones', async () => {
       const [plan] = await seedTestPlans(1)

--- a/tests/unit/item-helpers.test.ts
+++ b/tests/unit/item-helpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveItemUnit,
+  classifyDbError,
+} from '../../src/utils/item-helpers.js'
+
+describe('resolveItemUnit', () => {
+  it('returns pcs for equipment regardless of unit', () => {
+    const result = resolveItemUnit('equipment')
+    expect(result).toEqual({ unit: 'pcs' })
+  })
+
+  it('returns pcs for equipment even when a different unit is supplied', () => {
+    const result = resolveItemUnit('equipment', 'kg')
+    expect(result).toEqual({ unit: 'pcs' })
+  })
+
+  it('returns the given unit for food', () => {
+    const result = resolveItemUnit('food', 'kg')
+    expect(result).toEqual({ unit: 'kg' })
+  })
+
+  it.each(['kg', 'g', 'l', 'ml', 'pcs'] as const)(
+    'returns %s for food when supplied',
+    (unit) => {
+      const result = resolveItemUnit('food', unit)
+      expect(result).toEqual({ unit })
+    }
+  )
+
+  it('returns error when food has no unit', () => {
+    const result = resolveItemUnit('food')
+    expect(result).toEqual({ error: 'Unit is required for food items' })
+  })
+
+  it('returns error when food unit is undefined', () => {
+    const result = resolveItemUnit('food', undefined)
+    expect(result).toEqual({ error: 'Unit is required for food items' })
+  })
+})
+
+describe('classifyDbError', () => {
+  it.each([
+    ['connect ECONNREFUSED', 503, 'Database connection error'],
+    ['connection timeout', 503, 'Database connection error'],
+    ['socket connection failed', 503, 'Database connection error'],
+    ['request timeout exceeded', 503, 'Database connection error'],
+  ])(
+    'classifies "%s" as %d',
+    (errorMessage, expectedStatus, expectedMessage) => {
+      const result = classifyDbError(
+        new Error(errorMessage),
+        'Fallback message'
+      )
+      expect(result).toEqual({
+        statusCode: expectedStatus,
+        message: expectedMessage,
+      })
+    }
+  )
+
+  it('returns 500 with fallback message for generic errors', () => {
+    const result = classifyDbError(
+      new Error('unique constraint violation'),
+      'Failed to create item'
+    )
+    expect(result).toEqual({
+      statusCode: 500,
+      message: 'Failed to create item',
+    })
+  })
+
+  it('returns 500 with fallback message for non-Error thrown values', () => {
+    const result = classifyDbError('string error', 'Failed to update item')
+    expect(result).toEqual({
+      statusCode: 500,
+      message: 'Failed to update item',
+    })
+  })
+
+  it('returns 500 with fallback message for null', () => {
+    const result = classifyDbError(null, 'Operation failed')
+    expect(result).toEqual({ statusCode: 500, message: 'Operation failed' })
+  })
+
+  it('returns 500 with fallback message for undefined', () => {
+    const result = classifyDbError(undefined, 'Operation failed')
+    expect(result).toEqual({ statusCode: 500, message: 'Operation failed' })
+  })
+})

--- a/tests/unit/item-service.test.ts
+++ b/tests/unit/item-service.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  setupTestDatabase,
+  closeTestDatabase,
+  cleanupTestDatabase,
+  seedTestPlans,
+  seedTestParticipants,
+  seedTestItems,
+  getTestDb,
+} from '../helpers/db.js'
+import { items, participants } from '../../src/db/schema.js'
+import { Database } from '../../src/db/index.js'
+import {
+  checkPlanExists,
+  validateParticipant,
+  batchValidateParticipants,
+  findPlanOwner,
+  applyAllParticipantsUpdate,
+  createItemAssignedToAll,
+} from '../../src/services/item.service.js'
+import {
+  assignItemToAllParticipants,
+  unassignGroup,
+} from '../../src/services/all-participants-items.service.js'
+
+describe('Item Service', () => {
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('checkPlanExists', () => {
+    it('returns true for existing plan', async () => {
+      const [plan] = await seedTestPlans(1)
+      expect(await checkPlanExists(db, plan.planId)).toBe(true)
+    })
+
+    it('returns false for non-existent plan', async () => {
+      expect(
+        await checkPlanExists(db, '00000000-0000-0000-0000-000000000099')
+      ).toBe(false)
+    })
+  })
+
+  describe('validateParticipant', () => {
+    it('returns valid for participant belonging to the plan', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 2)
+
+      const result = await validateParticipant(
+        db,
+        planParticipants[0].participantId,
+        plan.planId
+      )
+      expect(result).toEqual({ valid: true })
+    })
+
+    it('returns invalid for non-existent participant', async () => {
+      const [plan] = await seedTestPlans(1)
+      const result = await validateParticipant(
+        db,
+        '00000000-0000-0000-0000-000000000099',
+        plan.planId
+      )
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('Participant not found')
+    })
+
+    it('returns invalid when participant belongs to a different plan', async () => {
+      const [planA, planB] = await seedTestPlans(2)
+      const participantsA = await seedTestParticipants(planA.planId, 2)
+
+      const result = await validateParticipant(
+        db,
+        participantsA[0].participantId,
+        planB.planId
+      )
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('Participant does not belong to this plan')
+    })
+  })
+
+  describe('batchValidateParticipants', () => {
+    it('returns map of participantId to planId for found participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+
+      const ids = planParticipants.map((p) => p.participantId)
+      const map = await batchValidateParticipants(db, ids)
+
+      expect(map.size).toBe(3)
+      for (const p of planParticipants) {
+        expect(map.get(p.participantId)).toBe(plan.planId)
+      }
+    })
+
+    it('returns empty map for empty input', async () => {
+      const map = await batchValidateParticipants(db, [])
+      expect(map.size).toBe(0)
+    })
+
+    it('omits non-existent participants from the map', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 2)
+
+      const ids = [
+        planParticipants[0].participantId,
+        '00000000-0000-0000-0000-000000000099',
+      ]
+      const map = await batchValidateParticipants(db, ids)
+
+      expect(map.size).toBe(1)
+      expect(map.has(planParticipants[0].participantId)).toBe(true)
+      expect(map.has('00000000-0000-0000-0000-000000000099')).toBe(false)
+    })
+
+    it('includes participants from different plans', async () => {
+      const [planA, planB] = await seedTestPlans(2)
+      const pA = await seedTestParticipants(planA.planId, 1)
+      const pB = await seedTestParticipants(planB.planId, 1)
+
+      const ids = [pA[0].participantId, pB[0].participantId]
+      const map = await batchValidateParticipants(db, ids)
+
+      expect(map.get(pA[0].participantId)).toBe(planA.planId)
+      expect(map.get(pB[0].participantId)).toBe(planB.planId)
+    })
+  })
+
+  describe('findPlanOwner', () => {
+    it('returns owner participantId when plan has an owner', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+
+      const result = await findPlanOwner(db, plan.planId)
+      expect(result).toBe(owner.participantId)
+    })
+
+    it('returns null when plan has no participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      const result = await findPlanOwner(db, plan.planId)
+      expect(result).toBeNull()
+    })
+
+    it('returns null for non-existent plan', async () => {
+      const result = await findPlanOwner(
+        db,
+        '00000000-0000-0000-0000-000000000099'
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('applyAllParticipantsUpdate', () => {
+    it('assigns to all when assignedToAll=true', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const result = await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        item,
+        true,
+        {},
+        async () => ({ valid: true })
+      )
+
+      expect(result).not.toBeNull()
+      expect(result!.item.isAllParticipants).toBe(true)
+      expect(result!.item.allParticipantsGroupId).toBeTruthy()
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(
+          eq(items.allParticipantsGroupId, result!.item.allParticipantsGroupId!)
+        )
+      expect(allGroupItems).toHaveLength(3)
+    })
+
+    it('reassigns group to specific participant', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const target = planParticipants.find((p) => p.role === 'participant')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      const [existing] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+
+      const result = await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        existing,
+        undefined,
+        { assignedParticipantId: target.participantId },
+        async () => ({ valid: true })
+      )
+
+      expect(result).not.toBeNull()
+      expect(result!.item.isAllParticipants).toBe(false)
+      expect(result!.item.assignedParticipantId).toBe(target.participantId)
+    })
+
+    it('unassigns group when assignedParticipantId is null', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const [existing] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+
+      const result = await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        existing,
+        undefined,
+        { assignedParticipantId: null },
+        async () => ({ valid: true })
+      )
+
+      expect(result).not.toBeNull()
+      expect(result!.item.status).toBe('canceled')
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      expect(allGroupItems.every((i) => i.status === 'canceled')).toBe(true)
+    })
+
+    it('unassigns group when assignedToAll=false', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        item,
+        true,
+        {},
+        async () => ({ valid: true })
+      )
+
+      const [existing] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+
+      const result = await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        existing,
+        false,
+        {},
+        async () => ({ valid: true })
+      )
+
+      expect(result).not.toBeNull()
+      expect(result!.item.status).toBe('canceled')
+      expect(result!.item.isAllParticipants).toBe(false)
+    })
+
+    it('cascades core field updates to all copies', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const groupId = group[0].allParticipantsGroupId!
+
+      const [existing] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+
+      await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        existing,
+        undefined,
+        { name: 'Renamed Item', quantity: 10 },
+        async () => ({ valid: true })
+      )
+
+      const allGroupItems = await db
+        .select()
+        .from(items)
+        .where(eq(items.allParticipantsGroupId, groupId))
+      for (const gi of allGroupItems) {
+        expect(gi.name).toBe('Renamed Item')
+        expect(gi.quantity).toBe(10)
+      }
+    })
+
+    it('applies status update only to the target item', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await assignItemToAllParticipants(
+        db,
+        item.itemId,
+        owner.participantId
+      )
+      const sibling = group.find((g) => g.itemId !== item.itemId)!
+
+      const [existing] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+
+      await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        existing,
+        undefined,
+        { status: 'purchased' },
+        async () => ({ valid: true })
+      )
+
+      const [refreshedTarget] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+      expect(refreshedTarget.status).toBe('purchased')
+
+      const [refreshedSibling] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, sibling.itemId))
+      expect(refreshedSibling.status).toBe('pending')
+    })
+
+    it('returns null for normal (non-all-participants) item with no assignedToAll flag', async () => {
+      const [plan] = await seedTestPlans(1)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const result = await applyAllParticipantsUpdate(
+        db,
+        item.itemId,
+        item,
+        undefined,
+        { name: 'Updated' },
+        async () => ({ valid: true })
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('throws when participant validator fails during reassignment', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const owner = planParticipants.find((p) => p.role === 'owner')!
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      await assignItemToAllParticipants(db, item.itemId, owner.participantId)
+
+      const [existing] = await db
+        .select()
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+
+      await expect(
+        applyAllParticipantsUpdate(
+          db,
+          item.itemId,
+          existing,
+          undefined,
+          { assignedParticipantId: '00000000-0000-0000-0000-000000000099' },
+          async () => ({ valid: false, message: 'Participant not found' })
+        )
+      ).rejects.toThrow('Participant not found')
+    })
+  })
+
+  describe('createItemAssignedToAll', () => {
+    it('creates copies for all participants', async () => {
+      const [plan] = await seedTestPlans(1)
+      const planParticipants = await seedTestParticipants(plan.planId, 3)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const group = await createItemAssignedToAll(db, item.itemId, plan.planId)
+
+      expect(group).not.toBeNull()
+      expect(group!).toHaveLength(3)
+
+      const assignedIds = group!.map((g) => g.assignedParticipantId).sort()
+      const expectedIds = planParticipants.map((p) => p.participantId).sort()
+      expect(assignedIds).toEqual(expectedIds)
+    })
+
+    it('returns null when plan has no owner', async () => {
+      const [plan] = await seedTestPlans(1)
+      const testDb = await getTestDb()
+      await testDb.insert(participants).values({
+        planId: plan.planId,
+        name: 'Non',
+        lastName: 'Owner',
+        contactPhone: '+1-555-000-0001',
+        role: 'participant',
+      })
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const result = await createItemAssignedToAll(db, item.itemId, plan.planId)
+      expect(result).toBeNull()
+    })
+
+    it('works after unassign and re-create', async () => {
+      const [plan] = await seedTestPlans(1)
+      await seedTestParticipants(plan.planId, 3)
+      const [item] = await seedTestItems(plan.planId, 1)
+
+      const first = await createItemAssignedToAll(db, item.itemId, plan.planId)
+      expect(first).toHaveLength(3)
+
+      await unassignGroup(db, item.itemId)
+
+      const second = await createItemAssignedToAll(db, item.itemId, plan.planId)
+      expect(second).not.toBeNull()
+      expect(second!).toHaveLength(3)
+      expect(second!.every((g) => g.isAllParticipants)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Extract duplicated logic from items.route.ts into testable helpers:
- src/utils/item-helpers.ts (resolveItemUnit, classifyDbError)
- src/services/item.service.ts (validateParticipant, checkPlanExists, batchValidateParticipants, findPlanOwner, applyAllParticipantsUpdate, createItemAssignedToAll)
Wire assignedToAll into POST /plans/:planId/items/bulk.
Add 44 new tests (18 pure unit + 23 service unit + 3 integration).

Closes #116

Made with [Cursor](https://cursor.com)