### PR TITLE
fix: include participant plans in GET /plans list, not just creator-o…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2293,11 +2293,11 @@
         }
       },
       "get": {
-        "summary": "List plans owned by user",
+        "summary": "List plans the user participates in",
         "tags": [
           "plans"
         ],
-        "description": "Retrieve plans created by the authenticated user, ordered by creation date",
+        "description": "Retrieve plans where the authenticated user is a participant (owner or member), ordered by creation date",
         "responses": {
           "200": {
             "description": "List of plans owned by the authenticated user",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chillist-be",
-  "version": "1.5.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chillist-be",
-      "version": "1.5.0",
+      "version": "1.20.1",
       "dependencies": {
         "@fastify/cors": "11.0.0",
         "@fastify/helmet": "13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/routes/plans.route.ts
+++ b/src/routes/plans.route.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { FastifyInstance } from 'fastify'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, getTableColumns } from 'drizzle-orm'
 import {
   plans,
   participants,
@@ -214,9 +214,9 @@ export async function plansRoutes(fastify: FastifyInstance) {
     {
       schema: {
         tags: ['plans'],
-        summary: 'List plans owned by user',
+        summary: 'List plans the user participates in',
         description:
-          'Retrieve plans created by the authenticated user, ordered by creation date',
+          'Retrieve plans where the authenticated user is a participant (owner or member), ordered by creation date',
         response: {
           200: {
             description: 'List of plans owned by the authenticated user',
@@ -243,9 +243,10 @@ export async function plansRoutes(fastify: FastifyInstance) {
         const userId = request.user!.id
 
         const filteredPlans = await fastify.db
-          .select()
+          .select(getTableColumns(plans))
           .from(plans)
-          .where(eq(plans.createdByUserId, userId))
+          .innerJoin(participants, eq(participants.planId, plans.planId))
+          .where(eq(participants.userId, userId))
           .orderBy(plans.createdAt)
 
         request.log.info(

--- a/tests/integration/plan-access.test.ts
+++ b/tests/integration/plan-access.test.ts
@@ -615,7 +615,7 @@ describe('Plan Access Control', () => {
       expect(result[0].createdByUserId).toBe(OWNER_USER_ID)
     })
 
-    it('does not include plans where user is only a participant (not owner)', async () => {
+    it('includes plans where user is a participant but not the creator', async () => {
       const { plan } = await createPlanDirectly(db, {
         visibility: 'invite_only',
         createdByUserId: OWNER_USER_ID,
@@ -635,7 +635,7 @@ describe('Plan Access Control', () => {
       const result = response.json()
       expect(
         result.some((p: { planId: string }) => p.planId === plan.planId)
-      ).toBe(false)
+      ).toBe(true)
     })
 
     it('does not include other users invite_only plans', async () => {

--- a/tests/integration/plans.test.ts
+++ b/tests/integration/plans.test.ts
@@ -114,7 +114,10 @@ describe('Plans Route', () => {
     })
 
     it('returns all plans when plans exist', async () => {
-      await seedTestPlans(3, { createdByUserId: TEST_USER_ID })
+      const seeded = await seedTestPlans(3, { createdByUserId: TEST_USER_ID })
+      for (const p of seeded) {
+        await seedTestParticipantWithUser(p.planId, TEST_USER_ID)
+      }
 
       const response = await app.inject({
         method: 'GET',
@@ -139,8 +142,36 @@ describe('Plans Route', () => {
       expect(plans[0].updatedAt).toBeDefined()
     })
 
+    it('returns plans where user is a participant but not the creator', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/plans',
+        headers: authHeaders(),
+        payload: { title: 'Someone Else Plan', owner: validOwner },
+      })
+      expect(createRes.statusCode).toBe(201)
+      const { planId } = createRes.json()
+
+      await seedTestParticipantWithUser(planId, REQUESTER_USER_ID)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/plans',
+        headers: { authorization: `Bearer ${requesterToken}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const plans = response.json()
+      expect(plans.some((p: { planId: string }) => p.planId === planId)).toBe(
+        true
+      )
+    })
+
     it('returns plans ordered by createdAt', async () => {
-      await seedTestPlans(3, { createdByUserId: TEST_USER_ID })
+      const seeded = await seedTestPlans(3, { createdByUserId: TEST_USER_ID })
+      for (const p of seeded) {
+        await seedTestParticipantWithUser(p.planId, TEST_USER_ID)
+      }
 
       const response = await app.inject({
         method: 'GET',
@@ -159,7 +190,10 @@ describe('Plans Route', () => {
     })
 
     it('returns plans with correct structure', async () => {
-      await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      const [seededPlan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      await seedTestParticipantWithUser(seededPlan.planId, TEST_USER_ID)
 
       const response = await app.inject({
         method: 'GET',
@@ -1554,6 +1588,8 @@ describe('Plans Route', () => {
       const [plan1, plan2] = await seedTestPlans(2, {
         createdByUserId: TEST_USER_ID,
       })
+      await seedTestParticipantWithUser(plan1.planId, TEST_USER_ID)
+      await seedTestParticipantWithUser(plan2.planId, TEST_USER_ID)
       const adminToken = await signAdminJwt()
 
       await app.inject({

--- a/tests/unit/plans.route.test.ts
+++ b/tests/unit/plans.route.test.ts
@@ -50,8 +50,10 @@ describe('Plans Route - Error Scenarios', () => {
     function mockListChainError(error: unknown) {
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockRejectedValue(error),
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockRejectedValue(error),
+            }),
           }),
         }),
       })


### PR DESCRIPTION
…wned

The GET /plans query only filtered by createdByUserId, so plans where the user joined as a participant were missing from their list. Replaced with an innerJoin on participants table filtered by userId, which covers both owned and joined plans since the creator is always a participant.

Made-with: Cursor