### PR TITLE
feat: add itemIds association to participant expenses

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2261,6 +2261,14 @@
             "nullable": true,
             "description": "Optional description of what the expense was for"
           },
+          "itemIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "List of item IDs associated with this expense. Empty array if no items linked."
+          },
           "createdByUserId": {
             "type": "string",
             "format": "uuid",
@@ -2280,6 +2288,7 @@
           "participantId",
           "planId",
           "amount",
+          "itemIds",
           "createdAt",
           "updatedAt"
         ],
@@ -2351,6 +2360,14 @@
             "type": "string",
             "maxLength": 500,
             "description": "Optional description of what the expense was for"
+          },
+          "itemIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional list of item IDs this expense is for. All items must belong to the same plan."
           }
         },
         "required": [
@@ -2372,6 +2389,14 @@
             "maxLength": 500,
             "nullable": true,
             "description": "Updated description (send null to clear)"
+          },
+          "itemIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Updated list of item IDs. Replaces the existing list entirely. All items must belong to the same plan."
           }
         },
         "title": "UpdateExpenseBody"

--- a/drizzle/0018_lush_lord_hawal.sql
+++ b/drizzle/0018_lush_lord_hawal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "participant_expenses" ADD COLUMN "item_ids" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1090 @@
+{
+  "id": "4deca033-4abd-4db9-8db2-25dae23a09a7",
+  "prevId": "7aad50aa-6a8e-4e96-8954-d5cda26edb9b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignment_status_list": {
+          "name": "assignment_status_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_expenses": {
+      "name": "participant_expenses",
+      "schema": "",
+      "columns": {
+        "expense_id": {
+          "name": "expense_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_expenses_participant_id_participants_participant_id_fk": {
+          "name": "participant_expenses_participant_id_participants_participant_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_expenses_plan_id_plans_plan_id_fk": {
+          "name": "participant_expenses_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lang": {
+          "name": "default_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1772870400002,
       "tag": "0017_previous_red_hulk",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1772884024788,
+      "tag": "0018_lush_lord_hawal",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -284,6 +284,7 @@ export const participantExpenses = pgTable('participant_expenses', {
     .references(() => plans.planId, { onDelete: 'cascade' }),
   amount: numeric('amount', { precision: 10, scale: 2 }).notNull(),
   description: text('description'),
+  itemIds: jsonb('item_ids').$type<string[]>().notNull().default([]),
   createdByUserId: uuid('created_by_user_id'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()

--- a/src/routes/expenses.route.ts
+++ b/src/routes/expenses.route.ts
@@ -1,18 +1,43 @@
 import { FastifyInstance } from 'fastify'
-import { eq, sql } from 'drizzle-orm'
-import { participantExpenses, participants } from '../db/schema.js'
+import { eq, sql, and, inArray } from 'drizzle-orm'
+import { participantExpenses, participants, items } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { isAdmin } from '../utils/admin.js'
+import type { Database } from '../db/index.js'
 
 interface CreateExpenseBody {
   participantId: string
   amount: number
   description?: string
+  itemIds?: string[]
 }
 
 interface UpdateExpenseBody {
   amount?: number
   description?: string | null
+  itemIds?: string[]
+}
+
+async function validateItemIds(
+  db: Database,
+  itemIds: string[],
+  planId: string
+): Promise<string | null> {
+  if (itemIds.length === 0) return null
+
+  const uniqueIds = [...new Set(itemIds)]
+  const found = await db
+    .select({ itemId: items.itemId })
+    .from(items)
+    .where(and(inArray(items.itemId, uniqueIds), eq(items.planId, planId)))
+
+  if (found.length !== uniqueIds.length) {
+    const foundIds = new Set(found.map((r) => r.itemId))
+    const missing = uniqueIds.filter((id) => !foundIds.has(id))
+    return `Items not found in this plan: ${missing.join(', ')}`
+  }
+
+  return null
 }
 
 export async function expensesRoutes(fastify: FastifyInstance) {
@@ -171,7 +196,7 @@ export async function expensesRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { planId } = request.params
-      const { participantId, amount, description } = request.body
+      const { participantId, amount, description, itemIds } = request.body
       const userId = request.user!.id
 
       try {
@@ -212,6 +237,17 @@ export async function expensesRoutes(fastify: FastifyInstance) {
             .send({ message: 'You can only add expenses for yourself' })
         }
 
+        if (itemIds && itemIds.length > 0) {
+          const validationError = await validateItemIds(
+            fastify.db,
+            itemIds,
+            planId
+          )
+          if (validationError) {
+            return reply.status(400).send({ message: validationError })
+          }
+        }
+
         const [created] = await fastify.db
           .insert(participantExpenses)
           .values({
@@ -219,6 +255,7 @@ export async function expensesRoutes(fastify: FastifyInstance) {
             planId,
             amount: String(amount),
             description: description ?? null,
+            itemIds: itemIds ?? [],
             createdByUserId: userId,
           })
           .returning()
@@ -345,12 +382,26 @@ export async function expensesRoutes(fastify: FastifyInstance) {
           }
         }
 
+        if (updates.itemIds !== undefined && updates.itemIds.length > 0) {
+          const validationError = await validateItemIds(
+            fastify.db,
+            updates.itemIds,
+            existing.planId
+          )
+          if (validationError) {
+            return reply.status(400).send({ message: validationError })
+          }
+        }
+
         const setValues: Record<string, unknown> = { updatedAt: new Date() }
         if (updates.amount !== undefined) {
           setValues.amount = String(updates.amount)
         }
         if (updates.description !== undefined) {
           setValues.description = updates.description
+        }
+        if (updates.itemIds !== undefined) {
+          setValues.itemIds = updates.itemIds
         }
 
         const [updated] = await fastify.db

--- a/src/schemas/expense.schema.ts
+++ b/src/schemas/expense.schema.ts
@@ -19,6 +19,12 @@ export const expenseSchema = {
       nullable: true,
       description: 'Optional description of what the expense was for',
     },
+    itemIds: {
+      type: 'array',
+      items: { type: 'string', format: 'uuid' },
+      description:
+        'List of item IDs associated with this expense. Empty array if no items linked.',
+    },
     createdByUserId: { type: 'string', format: 'uuid', nullable: true },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
@@ -28,6 +34,7 @@ export const expenseSchema = {
     'participantId',
     'planId',
     'amount',
+    'itemIds',
     'createdAt',
     'updatedAt',
   ],
@@ -89,6 +96,12 @@ export const createExpenseBodySchema = {
       maxLength: 500,
       description: 'Optional description of what the expense was for',
     },
+    itemIds: {
+      type: 'array',
+      items: { type: 'string', format: 'uuid' },
+      description:
+        'Optional list of item IDs this expense is for. All items must belong to the same plan.',
+    },
   },
   required: ['participantId', 'amount'],
 } as const
@@ -107,6 +120,12 @@ export const updateExpenseBodySchema = {
       maxLength: 500,
       nullable: true,
       description: 'Updated description (send null to clear)',
+    },
+    itemIds: {
+      type: 'array',
+      items: { type: 'string', format: 'uuid' },
+      description:
+        'Updated list of item IDs. Replaces the existing list entirely. All items must belong to the same plan.',
     },
   },
 } as const

--- a/tests/integration/expenses.test.ts
+++ b/tests/integration/expenses.test.ts
@@ -5,6 +5,7 @@ import {
   cleanupTestDatabase,
   closeTestDatabase,
   seedTestExpenses,
+  seedTestItems,
   seedTestParticipants,
   seedTestParticipantWithUser,
   seedTestPlans,
@@ -151,6 +152,7 @@ describe('Expenses Route', () => {
       expect(expense.planId).toBe(plan.planId)
       expect(expense.amount).toBe('42.50')
       expect(expense.description).toBe('Firewood')
+      expect(expense.itemIds).toEqual([])
       expect(expense.createdByUserId).toBe(TEST_USER_ID)
     })
 
@@ -355,6 +357,104 @@ describe('Expenses Route', () => {
       })
 
       expect(response.statusCode).toBe(400)
+    })
+
+    it('creates an expense with itemIds', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const items = await seedTestItems(plan.planId, 2)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: participants[0].participantId,
+          amount: 50,
+          description: 'Bought items',
+          itemIds: items.map((i) => i.itemId),
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const expense = response.json()
+      expect(expense.itemIds).toHaveLength(2)
+      expect(expense.itemIds).toContain(items[0].itemId)
+      expect(expense.itemIds).toContain(items[1].itemId)
+    })
+
+    it('returns 400 when itemIds reference items from a different plan', async () => {
+      const [plan1, plan2] = await seedTestPlans(2, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan1.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const otherPlanItems = await seedTestItems(plan2.planId, 1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan1.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: participants[0].participantId,
+          amount: 25,
+          itemIds: [otherPlanItems[0].itemId],
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json().message).toMatch(/Items not found in this plan/)
+    })
+
+    it('returns 400 when itemIds reference non-existent items', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: participants[0].participantId,
+          amount: 25,
+          itemIds: ['00000000-0000-0000-0000-000000000000'],
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json().message).toMatch(/Items not found in this plan/)
+    })
+
+    it('creates an expense with empty itemIds', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: participants[0].participantId,
+          amount: 10,
+          itemIds: [],
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(response.json().itemIds).toEqual([])
     })
   })
 
@@ -576,6 +676,94 @@ describe('Expenses Route', () => {
 
       expect(response.statusCode).toBe(200)
       expect(response.json().amount).toBe('500.00')
+    })
+
+    it('updates itemIds on an expense', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const [expense] = await seedTestExpenses(
+        plan.planId,
+        participants[0].participantId,
+        1,
+        { createdByUserId: TEST_USER_ID }
+      )
+      const items = await seedTestItems(plan.planId, 3)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/expenses/${expense.expenseId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { itemIds: [items[0].itemId, items[2].itemId] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.itemIds).toHaveLength(2)
+      expect(updated.itemIds).toContain(items[0].itemId)
+      expect(updated.itemIds).toContain(items[2].itemId)
+    })
+
+    it('clears itemIds by sending empty array', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const items = await seedTestItems(plan.planId, 1)
+      const [expense] = await seedTestExpenses(
+        plan.planId,
+        participants[0].participantId,
+        1,
+        { createdByUserId: TEST_USER_ID }
+      )
+
+      await app.inject({
+        method: 'PATCH',
+        url: `/expenses/${expense.expenseId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { itemIds: [items[0].itemId] },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/expenses/${expense.expenseId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { itemIds: [] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().itemIds).toEqual([])
+    })
+
+    it('returns 400 when updating itemIds with items from a different plan', async () => {
+      const [plan1, plan2] = await seedTestPlans(2, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan1.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const [expense] = await seedTestExpenses(
+        plan1.planId,
+        participants[0].participantId,
+        1,
+        { createdByUserId: TEST_USER_ID }
+      )
+      const otherPlanItems = await seedTestItems(plan2.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/expenses/${expense.expenseId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { itemIds: [otherPlanItems[0].itemId] },
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json().message).toMatch(/Items not found in this plan/)
     })
   })
 


### PR DESCRIPTION
## Summary
- Expenses can now optionally link to plan items via an `itemIds` JSONB array (default `[]`)
- All item IDs are validated to belong to the same plan on both `POST` and `PATCH`
- Adds migration `0018` for the new `item_ids` column on `participant_expenses`
- 7 new integration tests (37 total) covering item linking, clearing, and cross-plan validation

## Test plan
- [x] `POST /plans/:planId/expenses` with `itemIds` creates expense with linked items
- [x] `POST` with items from a different plan returns 400
- [x] `POST` with non-existent item IDs returns 400
- [x] `POST` with empty `itemIds` works (defaults to `[]`)
- [x] `PATCH /expenses/:expenseId` with `itemIds` replaces the list
- [x] `PATCH` with empty array clears item associations
- [x] `PATCH` with wrong-plan items returns 400
- [x] Existing expenses without `itemIds` return `[]` (backward compatible)


Made with [Cursor](https://cursor.com)