### PR TITLE
feat: auto-advance item status to purchased on expense creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/routes/expenses.route.ts
+++ b/src/routes/expenses.route.ts
@@ -5,6 +5,8 @@ import { checkPlanAccess } from '../utils/plan-access.js'
 import { isAdmin } from '../utils/admin.js'
 import type { Database } from '../db/index.js'
 
+type TransactionClient = Parameters<Parameters<Database['transaction']>[0]>[0]
+
 interface CreateExpenseBody {
   participantId: string
   amount: number
@@ -38,6 +40,38 @@ async function validateItemIds(
   }
 
   return null
+}
+
+async function advanceItemStatusOnExpense(
+  db: Database | TransactionClient,
+  itemIds: string[],
+  planId: string,
+  participantId: string
+): Promise<void> {
+  if (itemIds.length === 0) return
+
+  const linkedItems = await db
+    .select()
+    .from(items)
+    .where(and(inArray(items.itemId, itemIds), eq(items.planId, planId)))
+
+  for (const item of linkedItems) {
+    const updatedList = item.assignmentStatusList.map((entry) =>
+      entry.participantId === participantId && entry.status === 'pending'
+        ? { ...entry, status: 'purchased' as const }
+        : entry
+    )
+
+    const changed =
+      JSON.stringify(updatedList) !== JSON.stringify(item.assignmentStatusList)
+
+    if (changed) {
+      await db
+        .update(items)
+        .set({ assignmentStatusList: updatedList, updatedAt: new Date() })
+        .where(eq(items.itemId, item.itemId))
+    }
+  }
 }
 
 export async function expensesRoutes(fastify: FastifyInstance) {
@@ -248,17 +282,25 @@ export async function expensesRoutes(fastify: FastifyInstance) {
           }
         }
 
-        const [created] = await fastify.db
-          .insert(participantExpenses)
-          .values({
-            participantId,
-            planId,
-            amount: String(amount),
-            description: description ?? null,
-            itemIds: itemIds ?? [],
-            createdByUserId: userId,
-          })
-          .returning()
+        const created = await fastify.db.transaction(async (tx) => {
+          const [expense] = await tx
+            .insert(participantExpenses)
+            .values({
+              participantId,
+              planId,
+              amount: String(amount),
+              description: description ?? null,
+              itemIds: itemIds ?? [],
+              createdByUserId: userId,
+            })
+            .returning()
+
+          if (itemIds && itemIds.length > 0) {
+            await advanceItemStatusOnExpense(tx, itemIds, planId, participantId)
+          }
+
+          return expense
+        })
 
         request.log.info(
           { expenseId: created.expenseId, planId, participantId },
@@ -404,11 +446,28 @@ export async function expensesRoutes(fastify: FastifyInstance) {
           setValues.itemIds = updates.itemIds
         }
 
-        const [updated] = await fastify.db
-          .update(participantExpenses)
-          .set(setValues)
-          .where(eq(participantExpenses.expenseId, expenseId))
-          .returning()
+        const updated = await fastify.db.transaction(async (tx) => {
+          const [expense] = await tx
+            .update(participantExpenses)
+            .set(setValues)
+            .where(eq(participantExpenses.expenseId, expenseId))
+            .returning()
+
+          if (updates.itemIds !== undefined) {
+            const oldIds = new Set(existing.itemIds)
+            const newlyAdded = updates.itemIds.filter((id) => !oldIds.has(id))
+            if (newlyAdded.length > 0) {
+              await advanceItemStatusOnExpense(
+                tx,
+                newlyAdded,
+                existing.planId,
+                existing.participantId
+              )
+            }
+          }
+
+          return expense
+        })
 
         request.log.info(
           { expenseId, changes: Object.keys(updates) },

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -180,6 +180,27 @@ export async function seedTestJoinRequests(
   return inserted
 }
 
+export async function seedTestItemWithAssignment(
+  planId: string,
+  assignmentStatusList: Array<{ participantId: string; status: string }>,
+  overrides?: Partial<schema.NewItem>
+): Promise<schema.Item> {
+  const testDb = await getTestDb()
+  const [inserted] = await testDb
+    .insert(schema.items)
+    .values({
+      planId,
+      name: 'Assigned Item',
+      category: 'equipment',
+      quantity: 1,
+      unit: 'pcs',
+      assignmentStatusList,
+      ...overrides,
+    })
+    .returning()
+  return inserted
+}
+
 export async function seedTestExpenses(
   planId: string,
   participantId: string,

--- a/tests/integration/expenses.test.ts
+++ b/tests/integration/expenses.test.ts
@@ -4,13 +4,17 @@ import { FastifyInstance } from 'fastify'
 import {
   cleanupTestDatabase,
   closeTestDatabase,
+  getTestDb,
   seedTestExpenses,
   seedTestItems,
+  seedTestItemWithAssignment,
   seedTestParticipants,
   seedTestParticipantWithUser,
   seedTestPlans,
   setupTestDatabase,
 } from '../helpers/db.js'
+import { eq } from 'drizzle-orm'
+import { items as itemsTable } from '../../src/db/schema.js'
 import {
   setupTestKeys,
   getTestJWKS,
@@ -912,6 +916,236 @@ describe('Expenses Route', () => {
 
       expect(response.statusCode).toBe(200)
       expect(response.json()).toEqual({ ok: true })
+    })
+  })
+
+  describe('item status advancement on expense creation', () => {
+    it('advances pending items to purchased when expense is created with itemIds', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 2, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const p1 = participants[0]
+      const p2 = participants[1]
+
+      const item1 = await seedTestItemWithAssignment(
+        plan.planId,
+        [
+          { participantId: p1.participantId, status: 'pending' },
+          { participantId: p2.participantId, status: 'pending' },
+        ],
+        { name: 'Item A' }
+      )
+      const item2 = await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: p1.participantId, status: 'pending' }],
+        { name: 'Item B' }
+      )
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: p1.participantId,
+          amount: 100,
+          itemIds: [item1.itemId, item2.itemId],
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const db = await getTestDb()
+      const [updatedItem1] = await db
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.itemId, item1.itemId))
+      const [updatedItem2] = await db
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.itemId, item2.itemId))
+
+      expect(
+        updatedItem1.assignmentStatusList.find(
+          (e) => e.participantId === p1.participantId
+        )?.status
+      ).toBe('purchased')
+      expect(
+        updatedItem1.assignmentStatusList.find(
+          (e) => e.participantId === p2.participantId
+        )?.status
+      ).toBe('pending')
+      expect(
+        updatedItem2.assignmentStatusList.find(
+          (e) => e.participantId === p1.participantId
+        )?.status
+      ).toBe('purchased')
+    })
+
+    it('does not change packed items when expense is created', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const p1 = participants[0]
+
+      const item = await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: p1.participantId, status: 'packed' }],
+        { name: 'Packed Item' }
+      )
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: p1.participantId,
+          amount: 50,
+          itemIds: [item.itemId],
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const db = await getTestDb()
+      const [updatedItem] = await db
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.itemId, item.itemId))
+
+      expect(
+        updatedItem.assignmentStatusList.find(
+          (e) => e.participantId === p1.participantId
+        )?.status
+      ).toBe('packed')
+    })
+
+    it('does not change canceled items when expense is created', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const p1 = participants[0]
+
+      const item = await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: p1.participantId, status: 'canceled' }],
+        { name: 'Canceled Item' }
+      )
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: p1.participantId,
+          amount: 30,
+          itemIds: [item.itemId],
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const db = await getTestDb()
+      const [updatedItem] = await db
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.itemId, item.itemId))
+
+      expect(
+        updatedItem.assignmentStatusList.find(
+          (e) => e.participantId === p1.participantId
+        )?.status
+      ).toBe('canceled')
+    })
+
+    it('does not change items when participant is not in assignmentStatusList', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 2, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const p1 = participants[0]
+      const p2 = participants[1]
+
+      const item = await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: p2.participantId, status: 'pending' }],
+        { name: 'Not Assigned to P1' }
+      )
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: p1.participantId,
+          amount: 20,
+          itemIds: [item.itemId],
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const db = await getTestDb()
+      const [updatedItem] = await db
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.itemId, item.itemId))
+
+      expect(
+        updatedItem.assignmentStatusList.find(
+          (e) => e.participantId === p2.participantId
+        )?.status
+      ).toBe('pending')
+    })
+
+    it('does not change items when expense has no itemIds', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const participants = await seedTestParticipants(plan.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const p1 = participants[0]
+
+      const item = await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: p1.participantId, status: 'pending' }],
+        { name: 'Untouched Item' }
+      )
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/expenses`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          participantId: p1.participantId,
+          amount: 15,
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+
+      const db = await getTestDb()
+      const [updatedItem] = await db
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.itemId, item.itemId))
+
+      expect(
+        updatedItem.assignmentStatusList.find(
+          (e) => e.participantId === p1.participantId
+        )?.status
+      ).toBe('pending')
     })
   })
 })


### PR DESCRIPTION
## Summary

- When an expense is created or updated with `itemIds`, automatically advance linked items' per-participant status from `pending` to `purchased` for the expense's participant
- Items already `packed` or `canceled` are not touched; participants not in `assignmentStatusList` are skipped
- Both POST and PATCH expense handlers now use transactions for atomicity (expense insert/update + item status updates)

## Changes

- `src/routes/expenses.route.ts` — added `advanceItemStatusOnExpense()` helper, wrapped POST and PATCH handlers in `db.transaction()`
- `tests/helpers/db.ts` — added `seedTestItemWithAssignment()` test helper
- `tests/integration/expenses.test.ts` — 5 new integration tests covering pending→purchased, packed unchanged, canceled unchanged, unassigned participant, and no itemIds
- `package.json` — version bump 1.22.0 → 1.23.0

## Test plan

- [x] Pending items advance to purchased when expense links them
- [x] Packed items stay packed
- [x] Canceled items stay canceled
- [x] Items where participant has no assignmentStatusList entry are unchanged
- [x] No items affected when expense has no itemIds
- [x] All 42 expense integration tests pass
- [x] Typecheck and lint pass


Made with [Cursor](https://cursor.com)