### PR TITLE
feat: add optional estimatedAdults and estimatedKids fields to plans

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -209,6 +209,16 @@
             "description": "ISO 4217 currency code (e.g. USD, EUR, ILS)",
             "nullable": true
           },
+          "estimatedAdults": {
+            "type": "integer",
+            "description": "Estimated number of adult participants for this plan",
+            "nullable": true
+          },
+          "estimatedKids": {
+            "type": "integer",
+            "description": "Estimated number of child participants for this plan",
+            "nullable": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -374,6 +384,16 @@
             "maxLength": 10,
             "description": "ISO 4217 currency code (e.g. USD, EUR, ILS)"
           },
+          "estimatedAdults": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Estimated number of adult participants for this plan"
+          },
+          "estimatedKids": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Estimated number of child participants for this plan"
+          },
           "owner": {
             "$ref": "#/components/schemas/def-9"
           },
@@ -456,6 +476,18 @@
             "maxLength": 10,
             "nullable": true,
             "description": "ISO 4217 currency code (e.g. USD, EUR, ILS). Send null to clear."
+          },
+          "estimatedAdults": {
+            "type": "integer",
+            "minimum": 0,
+            "nullable": true,
+            "description": "Estimated number of adult participants. Send null to clear."
+          },
+          "estimatedKids": {
+            "type": "integer",
+            "minimum": 0,
+            "nullable": true,
+            "description": "Estimated number of child participants. Send null to clear."
           }
         },
         "title": "UpdatePlanBody"
@@ -1125,6 +1157,16 @@
           "currency": {
             "type": "string",
             "description": "ISO 4217 currency code (e.g. USD, EUR, ILS)",
+            "nullable": true
+          },
+          "estimatedAdults": {
+            "type": "integer",
+            "description": "Estimated number of adult participants for this plan",
+            "nullable": true
+          },
+          "estimatedKids": {
+            "type": "integer",
+            "description": "Estimated number of child participants for this plan",
             "nullable": true
           },
           "createdAt": {

--- a/drizzle/0019_harsh_imperial_guard.sql
+++ b/drizzle/0019_harsh_imperial_guard.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "plans" ADD COLUMN "estimated_adults" integer;--> statement-breakpoint
+ALTER TABLE "plans" ADD COLUMN "estimated_kids" integer;

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1102 @@
+{
+  "id": "73c5680c-b85e-4e23-9bec-4db7f1cf8eb2",
+  "prevId": "4deca033-4abd-4db9-8db2-25dae23a09a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignment_status_list": {
+          "name": "assignment_status_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_expenses": {
+      "name": "participant_expenses",
+      "schema": "",
+      "columns": {
+        "expense_id": {
+          "name": "expense_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_expenses_participant_id_participants_participant_id_fk": {
+          "name": "participant_expenses_participant_id_participants_participant_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_expenses_plan_id_plans_plan_id_fk": {
+          "name": "participant_expenses_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lang": {
+          "name": "default_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_adults": {
+          "name": "estimated_adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_kids": {
+          "name": "estimated_kids",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1772884024788,
       "tag": "0018_lush_lord_hawal",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1773066036677,
+      "tag": "0019_harsh_imperial_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -133,6 +133,8 @@ export const plans = pgTable('plans', {
   tags: text('tags').array(),
   defaultLang: varchar('default_lang', { length: 10 }),
   currency: varchar('currency', { length: 10 }),
+  estimatedAdults: integer('estimated_adults'),
+  estimatedKids: integer('estimated_kids'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()
     .notNull(),

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -79,6 +79,8 @@ async function seed() {
         startDate: new Date('2026-04-03T08:00:00+03:00'),
         endDate: new Date('2026-04-04T16:00:00+03:00'),
         tags: ['camping', 'desert', 'negev', 'family', 'toddlers'],
+        estimatedAdults: 7,
+        estimatedKids: 5,
         ...(seedOwnerUserId && { createdByUserId: seedOwnerUserId }),
       })
       .returning()
@@ -607,6 +609,8 @@ async function seed() {
         startDate: new Date('2026-04-10T17:00:00+03:00'),
         endDate: new Date('2026-04-10T22:00:00+03:00'),
         tags: ['bbq', 'beach', 'friday', 'sunset'],
+        estimatedAdults: 5,
+        estimatedKids: 1,
       })
       .returning()
 

--- a/src/routes/plans.route.ts
+++ b/src/routes/plans.route.ts
@@ -52,6 +52,8 @@ interface UpdatePlanBody {
   tags?: string[] | null
   defaultLang?: string | null
   currency?: string | null
+  estimatedAdults?: number | null
+  estimatedKids?: number | null
 }
 
 export async function plansRoutes(fastify: FastifyInstance) {

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -41,6 +41,16 @@ export const planSchema = {
       description: 'ISO 4217 currency code (e.g. USD, EUR, ILS)',
       nullable: true,
     },
+    estimatedAdults: {
+      type: 'integer',
+      description: 'Estimated number of adult participants for this plan',
+      nullable: true,
+    },
+    estimatedKids: {
+      type: 'integer',
+      description: 'Estimated number of child participants for this plan',
+      nullable: true,
+    },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
   },
@@ -118,6 +128,16 @@ export const createPlanBodySchema = {
       maxLength: 10,
       description: 'ISO 4217 currency code (e.g. USD, EUR, ILS)',
     },
+    estimatedAdults: {
+      type: 'integer',
+      minimum: 0,
+      description: 'Estimated number of adult participants for this plan',
+    },
+    estimatedKids: {
+      type: 'integer',
+      minimum: 0,
+      description: 'Estimated number of child participants for this plan',
+    },
     owner: { $ref: 'OwnerBody#' },
     participants: {
       type: 'array',
@@ -153,6 +173,20 @@ export const updatePlanBodySchema = {
       nullable: true,
       description:
         'ISO 4217 currency code (e.g. USD, EUR, ILS). Send null to clear.',
+    },
+    estimatedAdults: {
+      type: 'integer',
+      minimum: 0,
+      nullable: true,
+      description:
+        'Estimated number of adult participants. Send null to clear.',
+    },
+    estimatedKids: {
+      type: 'integer',
+      minimum: 0,
+      nullable: true,
+      description:
+        'Estimated number of child participants. Send null to clear.',
     },
   },
 } as const
@@ -200,6 +234,16 @@ export const planWithDetailsSchema = {
     currency: {
       type: 'string',
       description: 'ISO 4217 currency code (e.g. USD, EUR, ILS)',
+      nullable: true,
+    },
+    estimatedAdults: {
+      type: 'integer',
+      description: 'Estimated number of adult participants for this plan',
+      nullable: true,
+    },
+    estimatedKids: {
+      type: 'integer',
+      description: 'Estimated number of child participants for this plan',
       nullable: true,
     },
     createdAt: { type: 'string', format: 'date-time' },

--- a/tests/integration/plans.test.ts
+++ b/tests/integration/plans.test.ts
@@ -492,6 +492,42 @@ describe('Plans Route', () => {
       expect(ownerParticipant.contactEmail).toBe('alex@example.com')
     })
 
+    it('creates plan with estimatedAdults and estimatedKids', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans',
+        headers: authHeaders(),
+        payload: {
+          title: 'Estimated Group Plan',
+          owner: validOwner,
+          estimatedAdults: 8,
+          estimatedKids: 3,
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const plan = response.json()
+      expect(plan.estimatedAdults).toBe(8)
+      expect(plan.estimatedKids).toBe(3)
+    })
+
+    it('creates plan without estimation fields (defaults to null)', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/plans',
+        headers: authHeaders(),
+        payload: {
+          title: 'No Estimation Plan',
+          owner: validOwner,
+        },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const plan = response.json()
+      expect(plan.estimatedAdults).toBeNull()
+      expect(plan.estimatedKids).toBeNull()
+    })
+
     it('creates plan with owner and participants', async () => {
       const response = await app.inject({
         method: 'POST',
@@ -1432,6 +1468,55 @@ describe('Plans Route', () => {
         expect(updated[_field]).toBeNull()
       }
     )
+
+    it('updates estimatedAdults and estimatedKids', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/plans',
+        headers: authHeaders(),
+        payload: { title: 'Estimate Plan', owner: validOwner },
+      })
+      const { planId } = createRes.json()
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${planId}`,
+        headers: authHeaders(),
+        payload: { estimatedAdults: 10, estimatedKids: 4 },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.estimatedAdults).toBe(10)
+      expect(updated.estimatedKids).toBe(4)
+    })
+
+    it('clears estimatedAdults and estimatedKids by setting to null', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/plans',
+        headers: authHeaders(),
+        payload: {
+          title: 'Clear Estimate Plan',
+          owner: validOwner,
+          estimatedAdults: 5,
+          estimatedKids: 2,
+        },
+      })
+      const { planId } = createRes.json()
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${planId}`,
+        headers: authHeaders(),
+        payload: { estimatedAdults: null, estimatedKids: null },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.estimatedAdults).toBeNull()
+      expect(updated.estimatedKids).toBeNull()
+    })
 
     it('returns 400 when body is empty', async () => {
       const [plan] = await seedTestPlans(1)


### PR DESCRIPTION
## Summary
- Add optional `estimatedAdults` and `estimatedKids` nullable integer columns to the `plans` table for plan-level headcount estimates (distinct from per-participant `adultsCount`/`kidsCount`)
- Supported in create (`POST /plans`), update (`PATCH /plans/:planId`), and all read responses
- Includes migration, 4 new integration tests, seed data updates, and OpenAPI spec regeneration

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 475 integration tests pass (including 4 new: create with values, create without (null default), PATCH update, PATCH clear to null)
- [x] OpenAPI spec regenerated and validated


Made with [Cursor](https://cursor.com)