### PR TITLE
feat(whatsapp): unified send-list endpoint with item filtering and rejection notification

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2482,28 +2482,38 @@
       },
       "def-67": {
         "title": "SendListBody",
-        "description": "Request body for sending a plan item list via WhatsApp.",
+        "description": "Request body for sending a plan item list via WhatsApp. Use \"recipient\" to choose who receives the list and \"listType\" to filter items.",
         "type": "object",
         "properties": {
-          "phone": {
+          "recipient": {
             "type": "string",
-            "pattern": "^\\+[1-9]\\d{6,14}$",
-            "description": "Recipient phone number in E.164 format (e.g. +972501234567). The formatted item list for the plan will be sent to this number via WhatsApp.",
-            "example": "+972501234567"
+            "description": "Who should receive the list. \"self\" sends to the caller's own phone. \"all\" sends to every non-owner participant (owner-only). A specific participantId sends to that participant.",
+            "example": "self"
+          },
+          "listType": {
+            "type": "string",
+            "enum": [
+              "full",
+              "buying",
+              "packing",
+              "unassigned"
+            ],
+            "default": "full",
+            "description": "Which items to include. \"full\" = all items, \"buying\" = pending assignments, \"packing\" = purchased assignments, \"unassigned\" = no assignments."
           }
         },
         "required": [
-          "phone"
+          "recipient"
         ]
       },
       "def-68": {
-        "title": "SendListAllResponse",
-        "description": "Response after attempting to send an item list to all non-owner participants via WhatsApp.",
+        "title": "SendListResponse",
+        "description": "Unified response after attempting to send an item list via WhatsApp.",
         "type": "object",
         "properties": {
           "total": {
             "type": "number",
-            "description": "Total number of non-owner participants with phone numbers."
+            "description": "Total number of recipients targeted."
           },
           "sent": {
             "type": "number",
@@ -2515,7 +2525,7 @@
           },
           "results": {
             "type": "array",
-            "description": "Per-participant send result.",
+            "description": "Per-recipient send result.",
             "items": {
               "type": "object",
               "properties": {
@@ -2548,28 +2558,6 @@
           "sent",
           "failed",
           "results"
-        ]
-      },
-      "def-69": {
-        "title": "SendListResponse",
-        "description": "Response after attempting to send an item list via WhatsApp.",
-        "type": "object",
-        "properties": {
-          "sent": {
-            "type": "boolean",
-            "description": "Whether the WhatsApp message was successfully queued for delivery."
-          },
-          "messageId": {
-            "type": "string",
-            "description": "Unique message ID returned by the WhatsApp provider. Present only when sent is true."
-          },
-          "error": {
-            "type": "string",
-            "description": "Error description from the WhatsApp provider. Present only when sent is false."
-          }
-        },
-        "required": [
-          "sent"
         ]
       }
     }
@@ -5760,7 +5748,7 @@
         "tags": [
           "plans"
         ],
-        "description": "Sends a formatted item list for the specified plan to the given phone number via WhatsApp. Items are grouped by category and include name, quantity, and unit. The message language (English or Hebrew) is determined by the plan defaultLang setting. The phone number must be in E.164 format. Requires JWT authentication. Caller must be a participant of the plan.",
+        "description": "Sends a formatted item list for the specified plan via WhatsApp. Use \"recipient\" to control who receives the list: \"self\" sends to the caller, \"all\" sends to every non-owner participant (owner-only), or pass a specific participantId. Use \"listType\" to filter items: \"full\" (default), \"buying\", \"packing\", or \"unassigned\". When recipient is \"all\" with buying/packing, items are filtered per-participant. Requires JWT authentication.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5783,12 +5771,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Message sent successfully",
+            "description": "Send results",
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Message sent successfully",
-                  "$ref": "#/components/schemas/def-69"
+                  "description": "Send results",
+                  "$ref": "#/components/schemas/def-68"
                 }
               }
             }
@@ -5816,88 +5804,11 @@
             }
           },
           "403": {
-            "description": "Forbidden — not a participant of this plan",
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Forbidden — not a participant of this plan",
-                  "$ref": "#/components/schemas/def-0"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Plan not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Plan not found",
-                  "$ref": "#/components/schemas/def-0"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Internal server error",
-                  "$ref": "#/components/schemas/def-0"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/plans/{planId}/send-list-all": {
-      "post": {
-        "summary": "Send the item list to all non-owner participants via WhatsApp",
-        "tags": [
-          "plans"
-        ],
-        "description": "Sends the formatted item list for the specified plan to every non-owner participant who has a phone number. Messages are sent in parallel. The response includes per-participant results. Language is determined by plan defaultLang. Requires JWT authentication. Caller must be the plan owner or admin.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "in": "path",
-            "name": "planId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Bulk send results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Bulk send results",
-                  "$ref": "#/components/schemas/def-68"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Authentication required",
-                  "$ref": "#/components/schemas/def-0"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden — not the plan owner",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Forbidden — not the plan owner",
+                  "description": "Forbidden",
                   "$ref": "#/components/schemas/def-0"
                 }
               }

--- a/drizzle/0021_productive_zemo.sql
+++ b/drizzle/0021_productive_zemo.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."whatsapp_notification_type" ADD VALUE 'join_request_rejected';

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1218 @@
+{
+  "id": "b008fe13-542d-43dc-91bc-151d069f435a",
+  "prevId": "d46ee763-ab46-44c1-8ed8-3ba1dfa08377",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignment_status_list": {
+          "name": "assignment_status_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_expenses": {
+      "name": "participant_expenses",
+      "schema": "",
+      "columns": {
+        "expense_id": {
+          "name": "expense_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_expenses_participant_id_participants_participant_id_fk": {
+          "name": "participant_expenses_participant_id_participants_participant_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_expenses_plan_id_plans_plan_id_fk": {
+          "name": "participant_expenses_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lang": {
+          "name": "default_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_adults": {
+          "name": "estimated_adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_kids": {
+          "name": "estimated_kids",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_notifications": {
+      "name": "whatsapp_notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_phone": {
+          "name": "recipient_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_participant_id": {
+          "name": "recipient_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "whatsapp_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "whatsapp_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "whatsapp_notifications_plan_id_plans_plan_id_fk": {
+          "name": "whatsapp_notifications_plan_id_plans_plan_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk": {
+          "name": "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "recipient_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    },
+    "public.whatsapp_notification_status": {
+      "name": "whatsapp_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed"
+      ]
+    },
+    "public.whatsapp_notification_type": {
+      "name": "whatsapp_notification_type",
+      "schema": "public",
+      "values": [
+        "invitation_sent",
+        "join_request_pending",
+        "join_request_approved",
+        "join_request_rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1773390250979,
       "tag": "0020_medical_fixer",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1773584947760,
+      "tag": "0021_productive_zemo",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -278,7 +278,12 @@ export const participantJoinRequests = pgTable(
 
 export const whatsappNotificationTypeEnum = pgEnum(
   'whatsapp_notification_type',
-  ['invitation_sent', 'join_request_pending', 'join_request_approved']
+  [
+    'invitation_sent',
+    'join_request_pending',
+    'join_request_approved',
+    'join_request_rejected',
+  ]
 )
 
 export const whatsappNotificationStatusEnum = pgEnum(

--- a/src/routes/join-request.route.ts
+++ b/src/routes/join-request.route.ts
@@ -1,11 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { eq, and } from 'drizzle-orm'
-import {
-  plans,
-  participants,
-  participantJoinRequests,
-  whatsappNotifications,
-} from '../db/schema.js'
+import { plans, participants, participantJoinRequests } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { addParticipantToPlan } from '../services/participant.service.js'
 import { config } from '../config.js'
@@ -13,7 +8,9 @@ import {
   resolveLanguage,
   joinRequestMessage,
   joinRequestApprovedMessage,
+  joinRequestRejectedMessage,
 } from '../services/whatsapp/messages.js'
+import { fireAndForgetNotification } from '../services/whatsapp/notify.js'
 
 interface CreateJoinRequestBody {
   name: string
@@ -186,7 +183,7 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
             .where(eq(participants.participantId, plan.ownerParticipantId))
             .limit(1)
             .then(([owner]) => {
-              if (!owner?.contactPhone) return undefined
+              if (!owner?.contactPhone) return
               const lang = resolveLanguage(plan.defaultLang)
               const requesterName = `${created.name} ${created.lastName}`
               const planTitle =
@@ -200,38 +197,16 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
                 planTitle,
                 deepLink,
               })
-              return fastify.whatsapp
-                .sendMessage(owner.contactPhone, msg)
-                .then((result) => {
-                  fastify.db
-                    .insert(whatsappNotifications)
-                    .values({
-                      planId,
-                      recipientPhone: owner.contactPhone!,
-                      recipientParticipantId: plan.ownerParticipantId,
-                      type: 'join_request_pending',
-                      status: result.success ? 'sent' : 'failed',
-                      messageId: result.success ? result.messageId : null,
-                      error: result.success ? null : result.error,
-                    })
-                    .catch((dbErr) =>
-                      request.log.warn(
-                        { err: dbErr },
-                        'Failed to persist WhatsApp notification'
-                      )
-                    )
-                  if (result.success) {
-                    request.log.info(
-                      { requestId: created.requestId },
-                      'WhatsApp join-request notification sent to owner'
-                    )
-                  } else {
-                    request.log.warn(
-                      { requestId: created.requestId, error: result.error },
-                      'WhatsApp join-request notification failed'
-                    )
-                  }
-                })
+              fireAndForgetNotification({
+                whatsapp: fastify.whatsapp,
+                db: fastify.db,
+                log: request.log,
+                phone: owner.contactPhone,
+                message: msg,
+                planId,
+                recipientParticipantId: plan.ownerParticipantId,
+                type: 'join_request_pending',
+              })
             })
             .catch((err) => {
               request.log.warn(
@@ -422,44 +397,16 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
               planTitle,
               deepLink,
             })
-            fastify.whatsapp
-              .sendMessage(joinRequest.contactPhone, msg)
-              .then((waResult) => {
-                fastify.db
-                  .insert(whatsappNotifications)
-                  .values({
-                    planId,
-                    recipientPhone: joinRequest.contactPhone!,
-                    recipientParticipantId: result.participantId,
-                    type: 'join_request_approved',
-                    status: waResult.success ? 'sent' : 'failed',
-                    messageId: waResult.success ? waResult.messageId : null,
-                    error: waResult.success ? null : waResult.error,
-                  })
-                  .catch((dbErr) =>
-                    request.log.warn(
-                      { err: dbErr },
-                      'Failed to persist WhatsApp notification'
-                    )
-                  )
-                if (waResult.success) {
-                  request.log.info(
-                    { requestId },
-                    'WhatsApp join-request-approved notification sent'
-                  )
-                } else {
-                  request.log.warn(
-                    { requestId, error: waResult.error },
-                    'WhatsApp join-request-approved notification failed'
-                  )
-                }
-              })
-              .catch((err) => {
-                request.log.warn(
-                  { err, requestId },
-                  'WhatsApp join-request-approved notification error'
-                )
-              })
+            fireAndForgetNotification({
+              whatsapp: fastify.whatsapp,
+              db: fastify.db,
+              log: request.log,
+              phone: joinRequest.contactPhone,
+              message: msg,
+              planId,
+              recipientParticipantId: result.participantId,
+              type: 'join_request_approved',
+            })
           }
 
           return reply.status(200).send(result)
@@ -475,6 +422,23 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
           { planId, requestId, rejectedUserId: joinRequest.supabaseUserId },
           'Join request rejected'
         )
+
+        if (joinRequest.contactPhone) {
+          const lang = resolveLanguage(plan.defaultLang)
+          const planTitle =
+            plan.title ?? (lang === 'he' ? 'התוכנית' : 'the plan')
+          const msg = joinRequestRejectedMessage(lang, { planTitle })
+          fireAndForgetNotification({
+            whatsapp: fastify.whatsapp,
+            db: fastify.db,
+            log: request.log,
+            phone: joinRequest.contactPhone,
+            message: msg,
+            planId,
+            recipientParticipantId: null,
+            type: 'join_request_rejected',
+          })
+        }
 
         return reply.status(200).send({
           requestId: updated.requestId,

--- a/src/routes/participants.route.ts
+++ b/src/routes/participants.route.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import { FastifyInstance } from 'fastify'
 import { eq } from 'drizzle-orm'
-import { participants, plans, whatsappNotifications } from '../db/schema.js'
+import { participants, plans } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { removeParticipantFromAssignments } from '../services/item.service.js'
 import { config } from '../config.js'
@@ -9,6 +9,7 @@ import {
   resolveLanguage,
   inviteMessage,
 } from '../services/whatsapp/messages.js'
+import { fireAndForgetNotification } from '../services/whatsapp/notify.js'
 
 function generateInviteToken(): string {
   return randomBytes(32).toString('hex')
@@ -227,68 +228,36 @@ export async function participantsRoutes(fastify: FastifyInstance) {
           const planTitle =
             existingPlan.title ?? (lang === 'he' ? 'תוכנית' : 'a plan')
           const msg = inviteMessage(lang, { planTitle, deepLink })
-          fastify.whatsapp
-            .sendMessage(createdParticipant.contactPhone, msg)
-            .then((result) => {
+          fireAndForgetNotification({
+            whatsapp: fastify.whatsapp,
+            db: fastify.db,
+            log: request.log,
+            phone: createdParticipant.contactPhone,
+            message: msg,
+            planId,
+            recipientParticipantId: createdParticipant.participantId,
+            type: 'invitation_sent',
+            onSuccess: () => {
               fastify.db
-                .insert(whatsappNotifications)
-                .values({
-                  planId,
-                  recipientPhone: createdParticipant.contactPhone!,
-                  recipientParticipantId: createdParticipant.participantId,
-                  type: 'invitation_sent',
-                  status: result.success ? 'sent' : 'failed',
-                  messageId: result.success ? result.messageId : null,
-                  error: result.success ? null : result.error,
+                .update(participants)
+                .set({
+                  inviteStatus: 'invited',
+                  updatedAt: new Date(),
                 })
+                .where(
+                  eq(
+                    participants.participantId,
+                    createdParticipant.participantId
+                  )
+                )
                 .catch((dbErr) =>
                   request.log.warn(
                     { err: dbErr },
-                    'Failed to persist WhatsApp notification'
+                    'Failed to update inviteStatus'
                   )
                 )
-              if (result.success) {
-                fastify.db
-                  .update(participants)
-                  .set({
-                    inviteStatus: 'invited',
-                    updatedAt: new Date(),
-                  })
-                  .where(
-                    eq(
-                      participants.participantId,
-                      createdParticipant.participantId
-                    )
-                  )
-                  .catch((dbErr) =>
-                    request.log.warn(
-                      { err: dbErr },
-                      'Failed to update inviteStatus'
-                    )
-                  )
-                request.log.info(
-                  {
-                    participantId: createdParticipant.participantId,
-                    messageId: result.messageId,
-                  },
-                  'WhatsApp invitation sent'
-                )
-              } else {
-                request.log.warn(
-                  {
-                    participantId: createdParticipant.participantId,
-                    error: result.error,
-                  },
-                  'WhatsApp invitation failed'
-                )
-              }
-            })
-            .catch((err) => {
-              request.log.warn(
-                { err, participantId: createdParticipant.participantId },
-                'WhatsApp invitation error'
-              )
-            })
+            },
+          })
         }
 
         return reply.status(201).send(createdParticipant)

--- a/src/routes/send-list.route.ts
+++ b/src/routes/send-list.route.ts
@@ -1,16 +1,72 @@
 import { FastifyInstance } from 'fastify'
 import { eq } from 'drizzle-orm'
-import { plans, items, participants } from '../db/schema.js'
+import { items, participants } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import {
   resolveLanguage,
+  resolvePlanTitle,
+  formatItemList,
   sendListMessage,
-  translateCategory,
-  translateUnit,
 } from '../services/whatsapp/messages.js'
+import {
+  filterItemsForList,
+  type ListType,
+  type ItemWithAssignments,
+} from '../services/whatsapp/item-filters.js'
 
 interface SendListBody {
+  recipient: string
+  listType?: ListType
+}
+
+interface Recipient {
+  participantId: string
   phone: string
+}
+
+async function sendToRecipient(
+  fastify: FastifyInstance,
+  recipient: Recipient,
+  planItems: ItemWithAssignments[],
+  listType: ListType,
+  lang: 'en' | 'he',
+  planTitle: string
+) {
+  try {
+    const filtered = filterItemsForList(
+      planItems,
+      listType,
+      recipient.participantId
+    )
+    const categoryBlocks = formatItemList(filtered, lang)
+    const message = sendListMessage(lang, {
+      planTitle,
+      categoryBlocks,
+      emptyList: filtered.length === 0,
+    })
+    const result = await fastify.whatsapp.sendMessage(recipient.phone, message)
+    if (result.success) {
+      return {
+        participantId: recipient.participantId,
+        phone: recipient.phone,
+        sent: true as const,
+        messageId: result.messageId,
+      }
+    }
+    return {
+      participantId: recipient.participantId,
+      phone: recipient.phone,
+      sent: false as const,
+      error: result.error,
+    }
+  } catch {
+    return {
+      participantId: recipient.participantId,
+      phone: recipient.phone,
+      sent: false as const,
+      error: 'Unexpected send error',
+    }
+  }
 }
 
 export async function sendListRoutes(fastify: FastifyInstance) {
@@ -37,16 +93,18 @@ export async function sendListRoutes(fastify: FastifyInstance) {
         tags: ['plans'],
         summary: 'Send the item list for a plan via WhatsApp',
         description:
-          'Sends a formatted item list for the specified plan to the given phone number via WhatsApp. ' +
-          'Items are grouped by category and include name, quantity, and unit. ' +
-          'The message language (English or Hebrew) is determined by the plan defaultLang setting. ' +
-          'The phone number must be in E.164 format. ' +
-          'Requires JWT authentication. Caller must be a participant of the plan.',
+          'Sends a formatted item list for the specified plan via WhatsApp. ' +
+          'Use "recipient" to control who receives the list: ' +
+          '"self" sends to the caller, "all" sends to every non-owner participant (owner-only), ' +
+          'or pass a specific participantId. ' +
+          'Use "listType" to filter items: "full" (default), "buying", "packing", or "unassigned". ' +
+          'When recipient is "all" with buying/packing, items are filtered per-participant. ' +
+          'Requires JWT authentication.',
         params: { $ref: 'PlanIdParam#' },
         body: { $ref: 'SendListBody#' },
         response: {
           200: {
-            description: 'Message sent successfully',
+            description: 'Send results',
             $ref: 'SendListResponse#',
           },
           400: {
@@ -58,7 +116,7 @@ export async function sendListRoutes(fastify: FastifyInstance) {
             $ref: 'ErrorResponse#',
           },
           403: {
-            description: 'Forbidden — not a participant of this plan',
+            description: 'Forbidden',
             $ref: 'ErrorResponse#',
           },
           404: {
@@ -74,30 +132,26 @@ export async function sendListRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { planId } = request.params
-      const { phone } = request.body
+      const { recipient, listType = 'full' } = request.body
 
       try {
-        const { allowed } = await checkPlanAccess(
+        const { allowed, plan: accessPlan } = await checkPlanAccess(
           fastify.db,
           planId,
           request.user
         )
 
-        if (!allowed) {
+        if (!allowed || !accessPlan) {
+          if (!accessPlan) {
+            return reply.status(404).send({ message: 'Plan not found' })
+          }
           return reply
             .status(403)
             .send({ message: 'You are not a participant of this plan' })
         }
 
-        const [plan] = await fastify.db
-          .select({ title: plans.title, defaultLang: plans.defaultLang })
-          .from(plans)
-          .where(eq(plans.planId, planId))
-          .limit(1)
-
-        if (!plan) {
-          return reply.status(404).send({ message: 'Plan not found' })
-        }
+        const lang = resolveLanguage(accessPlan.defaultLang)
+        const planTitle = resolvePlanTitle(accessPlan.title, lang)
 
         const planItems = await fastify.db
           .select({
@@ -105,239 +159,155 @@ export async function sendListRoutes(fastify: FastifyInstance) {
             quantity: items.quantity,
             unit: items.unit,
             category: items.category,
+            isAllParticipants: items.isAllParticipants,
+            assignmentStatusList: items.assignmentStatusList,
           })
           .from(items)
           .where(eq(items.planId, planId))
 
-        const lang = resolveLanguage(plan.defaultLang)
-        const planTitle =
-          plan.title ?? (lang === 'he' ? 'תוכנית ללא שם' : 'Untitled Plan')
-
-        let categoryBlocks = ''
-        if (planItems.length > 0) {
-          const grouped: Record<string, string[]> = {}
-          for (const item of planItems) {
-            const cat = translateCategory(item.category ?? 'other', lang)
-            if (!grouped[cat]) grouped[cat] = []
-            const qty =
-              item.quantity > 1
-                ? `${item.quantity} ${item.unit ? translateUnit(item.unit, lang) : ''}`
-                : ''
-            grouped[cat].push(
-              qty ? `• ${item.name} (${qty.trim()})` : `• ${item.name}`
-            )
-          }
-
-          for (const [category, lines] of Object.entries(grouped)) {
-            categoryBlocks += `*${category}*\n${lines.join('\n')}\n\n`
-          }
-        }
-
-        const message = sendListMessage(lang, {
-          planTitle,
-          categoryBlocks,
-          emptyList: planItems.length === 0,
-        })
-
-        const result = await fastify.whatsapp.sendMessage(phone, message)
-
-        if (result.success) {
-          request.log.info(
-            { planId, phone, messageId: result.messageId },
-            'Item list sent via WhatsApp'
-          )
-          return reply.send({ sent: true, messageId: result.messageId })
-        }
-
-        request.log.warn(
-          { planId, phone, error: result.error },
-          'Failed to send item list via WhatsApp'
-        )
-        return reply.send({ sent: false, error: result.error })
-      } catch (error) {
-        request.log.error({ err: error, planId }, 'Failed to send item list')
-        return reply.status(500).send({ message: 'Failed to send item list' })
-      }
-    }
-  )
-
-  fastify.post<{
-    Params: { planId: string }
-  }>(
-    '/plans/:planId/send-list-all',
-    {
-      schema: {
-        tags: ['plans'],
-        summary:
-          'Send the item list to all non-owner participants via WhatsApp',
-        description:
-          'Sends the formatted item list for the specified plan to every non-owner participant who has a phone number. ' +
-          'Messages are sent in parallel. The response includes per-participant results. ' +
-          'Language is determined by plan defaultLang. ' +
-          'Requires JWT authentication. Caller must be the plan owner or admin.',
-        params: { $ref: 'PlanIdParam#' },
-        response: {
-          200: {
-            description: 'Bulk send results',
-            $ref: 'SendListAllResponse#',
-          },
-          401: {
-            description: 'Authentication required',
-            $ref: 'ErrorResponse#',
-          },
-          403: {
-            description: 'Forbidden — not the plan owner',
-            $ref: 'ErrorResponse#',
-          },
-          404: {
-            description: 'Plan not found',
-            $ref: 'ErrorResponse#',
-          },
-          500: {
-            description: 'Internal server error',
-            $ref: 'ErrorResponse#',
-          },
-        },
-      },
-    },
-    async (request, reply) => {
-      const { planId } = request.params
-
-      try {
-        const [plan] = await fastify.db
-          .select({
-            title: plans.title,
-            defaultLang: plans.defaultLang,
-            ownerParticipantId: plans.ownerParticipantId,
-            createdByUserId: plans.createdByUserId,
-          })
-          .from(plans)
-          .where(eq(plans.planId, planId))
-          .limit(1)
-
-        if (!plan) {
-          return reply.status(404).send({ message: 'Plan not found' })
-        }
-
-        if (plan.createdByUserId !== request.user!.id) {
-          return reply
-            .status(403)
-            .send({ message: 'Only the plan owner can send to all' })
-        }
-
-        const recipients = await fastify.db
+        const allParticipants = await fastify.db
           .select({
             participantId: participants.participantId,
             contactPhone: participants.contactPhone,
+            userId: participants.userId,
           })
           .from(participants)
           .where(eq(participants.planId, planId))
 
-        const nonOwnerRecipients = recipients.filter(
-          (p) => p.participantId !== plan.ownerParticipantId && p.contactPhone
-        )
+        let targets: Recipient[]
 
-        if (nonOwnerRecipients.length === 0) {
-          return reply.send({
-            total: 0,
-            sent: 0,
-            failed: 0,
-            results: [],
-          })
-        }
-
-        const planItems = await fastify.db
-          .select({
-            name: items.name,
-            quantity: items.quantity,
-            unit: items.unit,
-            category: items.category,
-          })
-          .from(items)
-          .where(eq(items.planId, planId))
-
-        const lang = resolveLanguage(plan.defaultLang)
-        const planTitle =
-          plan.title ?? (lang === 'he' ? 'תוכנית ללא שם' : 'Untitled Plan')
-
-        let categoryBlocks = ''
-        if (planItems.length > 0) {
-          const grouped: Record<string, string[]> = {}
-          for (const item of planItems) {
-            const cat = translateCategory(item.category ?? 'other', lang)
-            if (!grouped[cat]) grouped[cat] = []
-            const qty =
-              item.quantity > 1
-                ? `${item.quantity} ${item.unit ? translateUnit(item.unit, lang) : ''}`
-                : ''
-            grouped[cat].push(
-              qty ? `• ${item.name} (${qty.trim()})` : `• ${item.name}`
+        if (recipient === 'self') {
+          const callerParticipant = allParticipants.find(
+            (p) => p.userId === request.user!.id
+          )
+          if (!callerParticipant) {
+            return reply
+              .status(403)
+              .send({ message: 'You are not a participant of this plan' })
+          }
+          if (!callerParticipant.contactPhone) {
+            return reply
+              .status(400)
+              .send({ message: 'You do not have a phone number on file' })
+          }
+          targets = [
+            {
+              participantId: callerParticipant.participantId,
+              phone: callerParticipant.contactPhone,
+            },
+          ]
+        } else if (recipient === 'all') {
+          if (accessPlan.createdByUserId !== request.user!.id) {
+            return reply
+              .status(403)
+              .send({ message: 'Only the plan owner can send to all' })
+          }
+          targets = allParticipants
+            .filter(
+              (p) =>
+                p.participantId !== accessPlan.ownerParticipantId &&
+                p.contactPhone
             )
+            .map((p) => ({
+              participantId: p.participantId,
+              phone: p.contactPhone!,
+            }))
+        } else {
+          const targetParticipant = allParticipants.find(
+            (p) => p.participantId === recipient
+          )
+          if (!targetParticipant) {
+            return reply.status(404).send({ message: 'Participant not found' })
           }
-          for (const [category, lines] of Object.entries(grouped)) {
-            categoryBlocks += `*${category}*\n${lines.join('\n')}\n\n`
+          if (!targetParticipant.contactPhone) {
+            return reply
+              .status(400)
+              .send({ message: 'Participant does not have a phone number' })
           }
+          targets = [
+            {
+              participantId: targetParticipant.participantId,
+              phone: targetParticipant.contactPhone,
+            },
+          ]
         }
 
-        const message = sendListMessage(lang, {
-          planTitle,
-          categoryBlocks,
-          emptyList: planItems.length === 0,
-        })
+        if (targets.length === 0) {
+          return reply.send({ total: 0, sent: 0, failed: 0, results: [] })
+        }
+
+        const perParticipantFiltering =
+          recipient === 'all' &&
+          (listType === 'buying' || listType === 'packing')
 
         const sendResults = await Promise.all(
-          nonOwnerRecipients.map(async (recipient) => {
-            try {
-              const result = await fastify.whatsapp.sendMessage(
-                recipient.contactPhone,
-                message
+          targets.map((target) => {
+            if (perParticipantFiltering) {
+              return sendToRecipient(
+                fastify,
+                target,
+                planItems,
+                listType,
+                lang,
+                planTitle
               )
-              if (result.success) {
-                return {
-                  participantId: recipient.participantId,
-                  phone: recipient.contactPhone,
-                  sent: true,
-                  messageId: result.messageId,
-                }
-              }
-              return {
-                participantId: recipient.participantId,
-                phone: recipient.contactPhone,
-                sent: false,
-                error: result.error,
-              }
-            } catch {
-              return {
-                participantId: recipient.participantId,
-                phone: recipient.contactPhone,
-                sent: false,
-                error: 'Unexpected send error',
-              }
             }
+            const filtered = filterItemsForList(planItems, listType)
+            const categoryBlocks = formatItemList(filtered, lang)
+            const message = sendListMessage(lang, {
+              planTitle,
+              categoryBlocks,
+              emptyList: filtered.length === 0,
+            })
+            return fastify.whatsapp
+              .sendMessage(target.phone, message)
+              .then((result) => {
+                if (result.success) {
+                  return {
+                    participantId: target.participantId,
+                    phone: target.phone,
+                    sent: true as const,
+                    messageId: result.messageId,
+                  }
+                }
+                return {
+                  participantId: target.participantId,
+                  phone: target.phone,
+                  sent: false as const,
+                  error: result.error,
+                }
+              })
+              .catch(() => ({
+                participantId: target.participantId,
+                phone: target.phone,
+                sent: false as const,
+                error: 'Unexpected send error',
+              }))
           })
         )
 
         const sentCount = sendResults.filter((r) => r.sent).length
 
         request.log.info(
-          { planId, total: nonOwnerRecipients.length, sent: sentCount },
-          'Bulk item list sent via WhatsApp'
+          {
+            planId,
+            total: targets.length,
+            sent: sentCount,
+            listType,
+            recipient,
+          },
+          'Item list sent via WhatsApp'
         )
 
         return reply.send({
-          total: nonOwnerRecipients.length,
+          total: targets.length,
           sent: sentCount,
-          failed: nonOwnerRecipients.length - sentCount,
+          failed: targets.length - sentCount,
           results: sendResults,
         })
       } catch (error) {
-        request.log.error(
-          { err: error, planId },
-          'Failed to send item list to all'
-        )
-        return reply
-          .status(500)
-          .send({ message: 'Failed to send item list to all' })
+        request.log.error({ err: error, planId }, 'Failed to send item list')
+        return reply.status(500).send({ message: 'Failed to send item list' })
       }
     }
   )

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -84,7 +84,6 @@ import {
 } from './expense.schema.js'
 import {
   sendListBodySchema,
-  sendListAllResponseSchema,
   sendListResponseSchema,
 } from './send-list.schema.js'
 
@@ -157,7 +156,6 @@ const schemas = [
   expenseIdParamSchema,
   deleteExpenseResponseSchema,
   sendListBodySchema,
-  sendListAllResponseSchema,
   sendListResponseSchema,
 ]
 

--- a/src/schemas/send-list.schema.ts
+++ b/src/schemas/send-list.schema.ts
@@ -1,30 +1,43 @@
 export const sendListBodySchema = {
   $id: 'SendListBody',
   title: 'SendListBody',
-  description: 'Request body for sending a plan item list via WhatsApp.',
+  description:
+    'Request body for sending a plan item list via WhatsApp. ' +
+    'Use "recipient" to choose who receives the list and "listType" to filter items.',
   type: 'object',
   properties: {
-    phone: {
+    recipient: {
       type: 'string',
-      pattern: '^\\+[1-9]\\d{6,14}$',
       description:
-        'Recipient phone number in E.164 format (e.g. +972501234567). The formatted item list for the plan will be sent to this number via WhatsApp.',
-      examples: ['+972501234567', '+15551234567'],
+        'Who should receive the list. ' +
+        '"self" sends to the caller\'s own phone. ' +
+        '"all" sends to every non-owner participant (owner-only). ' +
+        'A specific participantId sends to that participant.',
+      examples: ['self', 'all', '550e8400-e29b-41d4-a716-446655440000'],
+    },
+    listType: {
+      type: 'string',
+      enum: ['full', 'buying', 'packing', 'unassigned'],
+      default: 'full',
+      description:
+        'Which items to include. ' +
+        '"full" = all items, "buying" = pending assignments, ' +
+        '"packing" = purchased assignments, "unassigned" = no assignments.',
     },
   },
-  required: ['phone'],
+  required: ['recipient'],
 } as const
 
-export const sendListAllResponseSchema = {
-  $id: 'SendListAllResponse',
-  title: 'SendListAllResponse',
+export const sendListResponseSchema = {
+  $id: 'SendListResponse',
+  title: 'SendListResponse',
   description:
-    'Response after attempting to send an item list to all non-owner participants via WhatsApp.',
+    'Unified response after attempting to send an item list via WhatsApp.',
   type: 'object',
   properties: {
     total: {
       type: 'number',
-      description: 'Total number of non-owner participants with phone numbers.',
+      description: 'Total number of recipients targeted.',
     },
     sent: {
       type: 'number',
@@ -36,7 +49,7 @@ export const sendListAllResponseSchema = {
     },
     results: {
       type: 'array',
-      description: 'Per-participant send result.',
+      description: 'Per-recipient send result.',
       items: {
         type: 'object',
         properties: {
@@ -51,29 +64,4 @@ export const sendListAllResponseSchema = {
     },
   },
   required: ['total', 'sent', 'failed', 'results'],
-} as const
-
-export const sendListResponseSchema = {
-  $id: 'SendListResponse',
-  title: 'SendListResponse',
-  description: 'Response after attempting to send an item list via WhatsApp.',
-  type: 'object',
-  properties: {
-    sent: {
-      type: 'boolean',
-      description:
-        'Whether the WhatsApp message was successfully queued for delivery.',
-    },
-    messageId: {
-      type: 'string',
-      description:
-        'Unique message ID returned by the WhatsApp provider. Present only when sent is true.',
-    },
-    error: {
-      type: 'string',
-      description:
-        'Error description from the WhatsApp provider. Present only when sent is false.',
-    },
-  },
-  required: ['sent'],
 } as const

--- a/src/services/whatsapp/item-filters.ts
+++ b/src/services/whatsapp/item-filters.ts
@@ -1,0 +1,49 @@
+import type { ItemStatus } from '../../db/schema.js'
+
+export type ListType = 'full' | 'buying' | 'packing' | 'unassigned'
+
+export interface ItemWithAssignments {
+  name: string
+  quantity: number
+  unit: string | null
+  category: string | null
+  isAllParticipants: boolean
+  assignmentStatusList: Array<{ participantId: string; status: ItemStatus }>
+}
+
+export function filterItemsForList(
+  items: ItemWithAssignments[],
+  listType: ListType,
+  participantId?: string
+): ItemWithAssignments[] {
+  switch (listType) {
+    case 'full':
+      return items
+
+    case 'buying':
+      return items.filter((item) => {
+        const assignments = participantId
+          ? item.assignmentStatusList.filter(
+              (a) => a.participantId === participantId
+            )
+          : item.assignmentStatusList
+        return assignments.some((a) => a.status === 'pending')
+      })
+
+    case 'packing':
+      return items.filter((item) => {
+        const assignments = participantId
+          ? item.assignmentStatusList.filter(
+              (a) => a.participantId === participantId
+            )
+          : item.assignmentStatusList
+        return assignments.some((a) => a.status === 'purchased')
+      })
+
+    case 'unassigned':
+      return items.filter(
+        (item) =>
+          item.assignmentStatusList.length === 0 && !item.isAllParticipants
+      )
+  }
+}

--- a/src/services/whatsapp/messages.ts
+++ b/src/services/whatsapp/messages.ts
@@ -35,10 +35,21 @@ interface JoinRequestApprovedMessageParams {
   deepLink: string
 }
 
+interface JoinRequestRejectedMessageParams {
+  planTitle: string
+}
+
 interface SendListMessageParams {
   planTitle: string
   categoryBlocks: string
   emptyList: boolean
+}
+
+export interface ItemForList {
+  name: string
+  quantity: number
+  unit: string | null
+  category: string | null
 }
 
 const templates = {
@@ -59,6 +70,12 @@ const templates = {
       `Great news! 🎉 Your request to join "${p.planTitle}" has been approved. View the plan: ${p.deepLink}`,
     he: (p: JoinRequestApprovedMessageParams) =>
       `חדשות טובות! 🎉 בקשתך להצטרף ל"${p.planTitle}" אושרה. לצפייה בתוכנית: ${p.deepLink}`,
+  },
+  joinRequestRejected: {
+    en: (p: JoinRequestRejectedMessageParams) =>
+      `Your request to join "${p.planTitle}" was not approved. If you think this is a mistake, please contact the plan organizer.`,
+    he: (p: JoinRequestRejectedMessageParams) =>
+      `בקשתך להצטרף ל"${p.planTitle}" לא אושרה. אם לדעתך מדובר בטעות, אנא צור/צרי קשר עם מארגן/ת התוכנית.`,
   },
   sendListHeader: {
     en: (planTitle: string) => `📋 *${planTitle}*\n\n`,
@@ -93,12 +110,45 @@ export function joinRequestApprovedMessage(
   return templates.joinRequestApproved[lang](params)
 }
 
+export function joinRequestRejectedMessage(
+  lang: Lang,
+  params: JoinRequestRejectedMessageParams
+): string {
+  return templates.joinRequestRejected[lang](params)
+}
+
 export function translateCategory(category: string, lang: Lang): string {
   return categoryTranslations[category]?.[lang] ?? category
 }
 
 export function translateUnit(unit: string, lang: Lang): string {
   return unitTranslations[unit]?.[lang] ?? unit
+}
+
+export function resolvePlanTitle(
+  title: string | null | undefined,
+  lang: Lang
+): string {
+  return title ?? (lang === 'he' ? 'תוכנית ללא שם' : 'Untitled Plan')
+}
+
+export function formatItemList(items: ItemForList[], lang: Lang): string {
+  if (items.length === 0) return ''
+  const grouped: Record<string, string[]> = {}
+  for (const item of items) {
+    const cat = translateCategory(item.category ?? 'other', lang)
+    if (!grouped[cat]) grouped[cat] = []
+    const qty =
+      item.quantity > 1
+        ? `${item.quantity} ${item.unit ? translateUnit(item.unit, lang) : ''}`
+        : ''
+    grouped[cat].push(qty ? `• ${item.name} (${qty.trim()})` : `• ${item.name}`)
+  }
+  let categoryBlocks = ''
+  for (const [category, lines] of Object.entries(grouped)) {
+    categoryBlocks += `*${category}*\n${lines.join('\n')}\n\n`
+  }
+  return categoryBlocks
 }
 
 export function sendListMessage(

--- a/src/services/whatsapp/notify.ts
+++ b/src/services/whatsapp/notify.ts
@@ -1,0 +1,72 @@
+import type { FastifyBaseLogger } from 'fastify'
+import type { IWhatsAppService } from './types.js'
+import type { Database } from '../../db/index.js'
+import { whatsappNotifications } from '../../db/schema.js'
+
+type NotificationType =
+  | 'invitation_sent'
+  | 'join_request_pending'
+  | 'join_request_approved'
+  | 'join_request_rejected'
+
+export interface FireAndForgetNotificationOpts {
+  whatsapp: IWhatsAppService
+  db: Database
+  log: FastifyBaseLogger
+  phone: string
+  message: string
+  planId: string
+  recipientParticipantId: string | null
+  type: NotificationType
+  onSuccess?: () => void
+}
+
+export function fireAndForgetNotification(
+  opts: FireAndForgetNotificationOpts
+): void {
+  const {
+    whatsapp,
+    db,
+    log,
+    phone,
+    message,
+    planId,
+    recipientParticipantId,
+    type,
+    onSuccess,
+  } = opts
+
+  whatsapp
+    .sendMessage(phone, message)
+    .then((result) => {
+      db.insert(whatsappNotifications)
+        .values({
+          planId,
+          recipientPhone: phone,
+          recipientParticipantId,
+          type,
+          status: result.success ? 'sent' : 'failed',
+          messageId: result.success ? result.messageId : null,
+          error: result.success ? null : result.error,
+        })
+        .catch((dbErr) =>
+          log.warn({ err: dbErr }, 'Failed to persist WhatsApp notification')
+        )
+
+      if (result.success) {
+        log.info(
+          { planId, type, recipientParticipantId },
+          'WhatsApp notification sent'
+        )
+        onSuccess?.()
+      } else {
+        log.warn(
+          { planId, type, error: result.error },
+          'WhatsApp notification failed'
+        )
+      }
+    })
+    .catch((err) => {
+      log.warn({ err, planId, type }, 'WhatsApp notification error')
+    })
+}

--- a/tests/integration/whatsapp.test.ts
+++ b/tests/integration/whatsapp.test.ts
@@ -7,6 +7,7 @@ import {
   getTestDb,
   seedTestPlans,
   seedTestParticipants,
+  seedTestItemWithAssignment,
   setupTestDatabase,
 } from '../helpers/db.js'
 import {
@@ -166,35 +167,79 @@ describe('WhatsApp Integration', () => {
       expect(messages[0].message).toContain('Requester Smith')
       expect(messages[0].message).toContain('join')
     })
+
+    it('sends WhatsApp rejection message to requester when join request is rejected', async () => {
+      const { plan } = await createPlanWithOwner()
+
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/join-requests`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+        payload: {
+          name: 'Requester',
+          lastName: 'Jones',
+          contactPhone: '+972502222222',
+        },
+      })
+      expect(createRes.statusCode).toBe(201)
+      const { requestId } = createRes.json()
+
+      await new Promise((r) => setTimeout(r, 100))
+      fakeGreenApi.clear()
+
+      const rejectRes = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'rejected' },
+      })
+      expect(rejectRes.statusCode).toBe(200)
+
+      await new Promise((r) => setTimeout(r, 100))
+
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0].chatId).toBe(phoneToChatId('+972502222222'))
+      expect(messages[0].message).toContain('not approved')
+    })
   })
 
   describe('Send-list endpoint', () => {
-    it('sends formatted item list via WhatsApp', async () => {
+    async function createPlanWithParticipants() {
       const [plan] = await seedTestPlans(1, {
         createdByUserId: OWNER_USER_ID,
       })
-      await seedTestParticipants(plan.planId, 1, {
+      const allParticipants = await seedTestParticipants(plan.planId, 3, {
         ownerUserId: OWNER_USER_ID,
       })
-
+      const owner = allParticipants[0]
       await db
         .update(plans)
-        .set({ title: 'Camping Trip' })
+        .set({
+          title: 'Camping Trip',
+          ownerParticipantId: owner.participantId,
+        })
         .where(eq(plans.planId, plan.planId))
+
+      return { plan, owner, participants: allParticipants }
+    }
+
+    it('recipient: "self" sends to caller\'s own phone', async () => {
+      const { plan } = await createPlanWithParticipants()
 
       await db.insert(items).values([
         {
           planId: plan.planId,
           name: 'Tent',
           quantity: 1,
-          unit: 'pcs',
+          unit: 'pcs' as const,
           category: 'equipment' as const,
         },
         {
           planId: plan.planId,
           name: 'Burgers',
           quantity: 10,
-          unit: 'pcs',
+          unit: 'pcs' as const,
           category: 'food' as const,
         },
       ])
@@ -203,25 +248,218 @@ describe('WhatsApp Integration', () => {
         method: 'POST',
         url: `/plans/${plan.planId}/send-list`,
         headers: { authorization: `Bearer ${ownerToken}` },
-        payload: {
-          phone: '+972503333333',
-        },
+        payload: { recipient: 'self' },
       })
 
       expect(response.statusCode).toBe(200)
       const body = response.json()
-      expect(body.sent).toBe(true)
-      expect(body.messageId).toBeDefined()
+      expect(body.total).toBe(1)
+      expect(body.sent).toBe(1)
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0].sent).toBe(true)
 
       const messages = fakeGreenApi.getSentMessages()
       expect(messages).toHaveLength(1)
-      expect(messages[0].chatId).toBe(phoneToChatId('+972503333333'))
       expect(messages[0].message).toContain('Camping Trip')
       expect(messages[0].message).toContain('Tent')
       expect(messages[0].message).toContain('Burgers')
     })
 
-    it('returns 403 when user is not a participant', async () => {
+    it('recipient: "self" with listType: "full" sends all items', async () => {
+      const { plan } = await createPlanWithParticipants()
+
+      await db.insert(items).values([
+        {
+          planId: plan.planId,
+          name: 'Tent',
+          quantity: 1,
+          unit: 'pcs' as const,
+          category: 'equipment' as const,
+        },
+      ])
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { recipient: 'self', listType: 'full' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toContain('Tent')
+    })
+
+    it('recipient: "self" with listType: "buying" filters to pending items', async () => {
+      const { plan, owner } = await createPlanWithParticipants()
+
+      await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: owner.participantId, status: 'pending' }],
+        { name: 'Pending Item', category: 'food' }
+      )
+      await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: owner.participantId, status: 'purchased' }],
+        { name: 'Purchased Item', category: 'food' }
+      )
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { recipient: 'self', listType: 'buying' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toContain('Pending Item')
+      expect(messages[0].message).not.toContain('Purchased Item')
+    })
+
+    it('recipient: "all" sends to all non-owner participants', async () => {
+      const { plan, participants: allP } = await createPlanWithParticipants()
+
+      await db.insert(items).values([
+        {
+          planId: plan.planId,
+          name: 'Tent',
+          quantity: 1,
+          unit: 'pcs' as const,
+          category: 'equipment' as const,
+        },
+      ])
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { recipient: 'all' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.total).toBe(2)
+      expect(body.sent).toBe(2)
+      expect(body.results).toHaveLength(2)
+
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(2)
+      const chatIds = messages.map((m: { chatId: string }) => m.chatId)
+      expect(chatIds).toContain(phoneToChatId(allP[1].contactPhone!))
+      expect(chatIds).toContain(phoneToChatId(allP[2].contactPhone!))
+    })
+
+    it('recipient: "all" returns 403 for non-owner', async () => {
+      const { plan } = await createPlanWithParticipants()
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${requesterToken}` },
+        payload: { recipient: 'all' },
+      })
+
+      expect(response.statusCode).toBe(403)
+    })
+
+    it('recipient: "<participantId>" sends to specific participant', async () => {
+      const { plan, participants: allP } = await createPlanWithParticipants()
+
+      await db.insert(items).values([
+        {
+          planId: plan.planId,
+          name: 'Tent',
+          quantity: 1,
+          unit: 'pcs' as const,
+          category: 'equipment' as const,
+        },
+      ])
+
+      const targetP = allP[1]
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { recipient: targetP.participantId },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.total).toBe(1)
+      expect(body.sent).toBe(1)
+      expect(body.results[0].participantId).toBe(targetP.participantId)
+
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0].chatId).toBe(phoneToChatId(targetP.contactPhone!))
+    })
+
+    it('listType: "unassigned" filters to unassigned items', async () => {
+      const { plan, owner } = await createPlanWithParticipants()
+
+      await seedTestItemWithAssignment(plan.planId, [], {
+        name: 'Unassigned Item',
+        category: 'equipment',
+        isAllParticipants: false,
+      })
+      await seedTestItemWithAssignment(
+        plan.planId,
+        [{ participantId: owner.participantId, status: 'pending' }],
+        { name: 'Assigned Item', category: 'equipment' }
+      )
+      await seedTestItemWithAssignment(plan.planId, [], {
+        name: 'AllParticipants Item',
+        category: 'equipment',
+        isAllParticipants: true,
+      })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { recipient: 'self', listType: 'unassigned' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toContain('Unassigned Item')
+      expect(messages[0].message).not.toContain('Assigned Item')
+      expect(messages[0].message).not.toContain('AllParticipants Item')
+    })
+
+    it('sends empty list message when plan has no items', async () => {
+      const { plan } = await createPlanWithParticipants()
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { recipient: 'self' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const messages = fakeGreenApi.getSentMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toContain('No items yet')
+    })
+
+    it('returns 401 without auth', async () => {
+      const [plan] = await seedTestPlans(1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/send-list`,
+        payload: { recipient: 'self' },
+      })
+
+      expect(response.statusCode).toBe(401)
+    })
+
+    it('returns 404 when user is not a participant of invite-only plan', async () => {
       const [plan] = await seedTestPlans(1, {
         createdByUserId: OWNER_USER_ID,
         visibility: 'invite_only',
@@ -234,71 +472,10 @@ describe('WhatsApp Integration', () => {
         method: 'POST',
         url: `/plans/${plan.planId}/send-list`,
         headers: { authorization: `Bearer ${requesterToken}` },
-        payload: {
-          phone: '+972503333333',
-        },
+        payload: { recipient: 'self' },
       })
 
-      expect(response.statusCode).toBe(403)
-    })
-
-    it('returns 401 without auth', async () => {
-      const [plan] = await seedTestPlans(1)
-
-      const response = await app.inject({
-        method: 'POST',
-        url: `/plans/${plan.planId}/send-list`,
-        payload: {
-          phone: '+972503333333',
-        },
-      })
-
-      expect(response.statusCode).toBe(401)
-    })
-
-    it('rejects invalid phone number format', async () => {
-      const [plan] = await seedTestPlans(1, {
-        createdByUserId: OWNER_USER_ID,
-      })
-      await seedTestParticipants(plan.planId, 1, {
-        ownerUserId: OWNER_USER_ID,
-      })
-
-      const response = await app.inject({
-        method: 'POST',
-        url: `/plans/${plan.planId}/send-list`,
-        headers: { authorization: `Bearer ${ownerToken}` },
-        payload: {
-          phone: '555-123-4567',
-        },
-      })
-
-      expect(response.statusCode).toBe(400)
-    })
-
-    it('sends empty list message when plan has no items', async () => {
-      const [plan] = await seedTestPlans(1, {
-        createdByUserId: OWNER_USER_ID,
-      })
-      await seedTestParticipants(plan.planId, 1, {
-        ownerUserId: OWNER_USER_ID,
-      })
-
-      const response = await app.inject({
-        method: 'POST',
-        url: `/plans/${plan.planId}/send-list`,
-        headers: { authorization: `Bearer ${ownerToken}` },
-        payload: {
-          phone: '+972504444444',
-        },
-      })
-
-      expect(response.statusCode).toBe(200)
-      expect(response.json().sent).toBe(true)
-
-      const messages = fakeGreenApi.getSentMessages()
-      expect(messages).toHaveLength(1)
-      expect(messages[0].message).toContain('No items yet')
+      expect(response.statusCode).toBe(404)
     })
   })
 

--- a/tests/unit/whatsapp/item-filters.test.ts
+++ b/tests/unit/whatsapp/item-filters.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import {
+  filterItemsForList,
+  type ItemWithAssignments,
+} from '../../../src/services/whatsapp/item-filters.js'
+
+function makeItem(
+  overrides: Partial<ItemWithAssignments> = {}
+): ItemWithAssignments {
+  return {
+    name: 'Test Item',
+    quantity: 1,
+    unit: 'pcs',
+    category: 'food',
+    isAllParticipants: false,
+    assignmentStatusList: [],
+    ...overrides,
+  }
+}
+
+const P1 = 'participant-1'
+const P2 = 'participant-2'
+
+describe('filterItemsForList', () => {
+  describe('full', () => {
+    it('returns all items', () => {
+      const items = [makeItem({ name: 'A' }), makeItem({ name: 'B' })]
+      expect(filterItemsForList(items, 'full')).toEqual(items)
+    })
+
+    it('returns empty array for empty input', () => {
+      expect(filterItemsForList([], 'full')).toEqual([])
+    })
+  })
+
+  describe('buying', () => {
+    it('includes items with pending assignments', () => {
+      const items = [
+        makeItem({
+          name: 'Pending',
+          assignmentStatusList: [{ participantId: P1, status: 'pending' }],
+        }),
+        makeItem({
+          name: 'Purchased',
+          assignmentStatusList: [{ participantId: P1, status: 'purchased' }],
+        }),
+      ]
+      const result = filterItemsForList(items, 'buying')
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('Pending')
+    })
+
+    it('filters by participantId when provided', () => {
+      const items = [
+        makeItem({
+          name: 'P1 Pending',
+          assignmentStatusList: [{ participantId: P1, status: 'pending' }],
+        }),
+        makeItem({
+          name: 'P2 Pending',
+          assignmentStatusList: [{ participantId: P2, status: 'pending' }],
+        }),
+      ]
+      const result = filterItemsForList(items, 'buying', P1)
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('P1 Pending')
+    })
+
+    it('excludes items with no assignments', () => {
+      const items = [makeItem({ name: 'Unassigned' })]
+      expect(filterItemsForList(items, 'buying')).toEqual([])
+    })
+
+    it('includes item if any assignment is pending (no participant filter)', () => {
+      const items = [
+        makeItem({
+          name: 'Mixed',
+          assignmentStatusList: [
+            { participantId: P1, status: 'purchased' },
+            { participantId: P2, status: 'pending' },
+          ],
+        }),
+      ]
+      const result = filterItemsForList(items, 'buying')
+      expect(result).toHaveLength(1)
+    })
+  })
+
+  describe('packing', () => {
+    it('includes items with purchased assignments', () => {
+      const items = [
+        makeItem({
+          name: 'Purchased',
+          assignmentStatusList: [{ participantId: P1, status: 'purchased' }],
+        }),
+        makeItem({
+          name: 'Pending',
+          assignmentStatusList: [{ participantId: P1, status: 'pending' }],
+        }),
+      ]
+      const result = filterItemsForList(items, 'packing')
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('Purchased')
+    })
+
+    it('filters by participantId when provided', () => {
+      const items = [
+        makeItem({
+          name: 'P1 Purchased',
+          assignmentStatusList: [{ participantId: P1, status: 'purchased' }],
+        }),
+        makeItem({
+          name: 'P2 Purchased',
+          assignmentStatusList: [{ participantId: P2, status: 'purchased' }],
+        }),
+      ]
+      const result = filterItemsForList(items, 'packing', P1)
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('P1 Purchased')
+    })
+
+    it('excludes packed items', () => {
+      const items = [
+        makeItem({
+          name: 'Packed',
+          assignmentStatusList: [{ participantId: P1, status: 'packed' }],
+        }),
+      ]
+      expect(filterItemsForList(items, 'packing')).toEqual([])
+    })
+  })
+
+  describe('unassigned', () => {
+    it('includes items with empty assignments and isAllParticipants false', () => {
+      const items = [
+        makeItem({
+          name: 'Unassigned',
+          assignmentStatusList: [],
+          isAllParticipants: false,
+        }),
+        makeItem({
+          name: 'Assigned',
+          assignmentStatusList: [{ participantId: P1, status: 'pending' }],
+          isAllParticipants: false,
+        }),
+      ]
+      const result = filterItemsForList(items, 'unassigned')
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('Unassigned')
+    })
+
+    it('excludes isAllParticipants items even if no assignments', () => {
+      const items = [
+        makeItem({
+          name: 'AllParticipants',
+          assignmentStatusList: [],
+          isAllParticipants: true,
+        }),
+      ]
+      expect(filterItemsForList(items, 'unassigned')).toEqual([])
+    })
+
+    it('returns empty for no unassigned items', () => {
+      const items = [
+        makeItem({
+          name: 'Assigned',
+          assignmentStatusList: [{ participantId: P1, status: 'pending' }],
+        }),
+      ]
+      expect(filterItemsForList(items, 'unassigned')).toEqual([])
+    })
+
+    it('participantId parameter is ignored for unassigned filter', () => {
+      const items = [
+        makeItem({
+          name: 'Unassigned',
+          assignmentStatusList: [],
+          isAllParticipants: false,
+        }),
+      ]
+      const result = filterItemsForList(items, 'unassigned', P1)
+      expect(result).toHaveLength(1)
+    })
+  })
+})

--- a/tests/unit/whatsapp/messages.test.ts
+++ b/tests/unit/whatsapp/messages.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatItemList,
+  resolvePlanTitle,
+  resolveLanguage,
+  sendListMessage,
+  inviteMessage,
+  joinRequestMessage,
+  joinRequestApprovedMessage,
+  joinRequestRejectedMessage,
+  translateCategory,
+  translateUnit,
+} from '../../../src/services/whatsapp/messages.js'
+
+describe('formatItemList', () => {
+  it('returns empty string for empty items array', () => {
+    expect(formatItemList([], 'en')).toBe('')
+    expect(formatItemList([], 'he')).toBe('')
+  })
+
+  it('groups items by translated category', () => {
+    const items = [
+      { name: 'Tent', quantity: 1, unit: 'pcs', category: 'equipment' },
+      { name: 'Sleeping Bag', quantity: 2, unit: 'pcs', category: 'equipment' },
+      { name: 'Burgers', quantity: 5, unit: 'kg', category: 'food' },
+    ]
+    const result = formatItemList(items, 'en')
+    expect(result).toContain('*Equipment*')
+    expect(result).toContain('*Food*')
+    expect(result).toContain('• Tent')
+    expect(result).toContain('• Sleeping Bag (2 pcs)')
+    expect(result).toContain('• Burgers (5 kg)')
+  })
+
+  it('translates categories and units for Hebrew', () => {
+    const items = [
+      { name: 'אוהל', quantity: 2, unit: 'pcs', category: 'equipment' },
+      { name: 'המבורגר', quantity: 3, unit: 'kg', category: 'food' },
+    ]
+    const result = formatItemList(items, 'he')
+    expect(result).toContain('*ציוד*')
+    expect(result).toContain('*אוכל*')
+    expect(result).toContain('(2 יח׳)')
+    expect(result).toContain('(3 ק"ג)')
+  })
+
+  it('omits quantity/unit when quantity is 1', () => {
+    const items = [
+      { name: 'Tent', quantity: 1, unit: 'pcs', category: 'equipment' },
+    ]
+    const result = formatItemList(items, 'en')
+    expect(result).toBe('*Equipment*\n• Tent\n\n')
+  })
+
+  it('handles null category as raw string', () => {
+    const items = [{ name: 'Mystery', quantity: 1, unit: null, category: null }]
+    const result = formatItemList(items, 'en')
+    expect(result).toContain('*other*')
+    expect(result).toContain('• Mystery')
+  })
+
+  it('handles null unit with quantity > 1', () => {
+    const items = [
+      { name: 'Stuff', quantity: 3, unit: null, category: 'equipment' },
+    ]
+    const result = formatItemList(items, 'en')
+    expect(result).toContain('• Stuff (3)')
+  })
+
+  it('handles unknown category as raw string', () => {
+    const items = [
+      { name: 'Widget', quantity: 1, unit: 'pcs', category: 'custom_cat' },
+    ]
+    const result = formatItemList(items, 'en')
+    expect(result).toContain('*custom_cat*')
+  })
+})
+
+describe('resolvePlanTitle', () => {
+  it('returns title when provided', () => {
+    expect(resolvePlanTitle('Beach BBQ', 'en')).toBe('Beach BBQ')
+    expect(resolvePlanTitle('Beach BBQ', 'he')).toBe('Beach BBQ')
+  })
+
+  it('returns English fallback for null title', () => {
+    expect(resolvePlanTitle(null, 'en')).toBe('Untitled Plan')
+  })
+
+  it('returns Hebrew fallback for null title', () => {
+    expect(resolvePlanTitle(null, 'he')).toBe('תוכנית ללא שם')
+  })
+
+  it('returns fallback for undefined title', () => {
+    expect(resolvePlanTitle(undefined, 'en')).toBe('Untitled Plan')
+  })
+})
+
+describe('resolveLanguage', () => {
+  it('returns he for Hebrew', () => {
+    expect(resolveLanguage('he')).toBe('he')
+  })
+
+  it('returns en for anything else', () => {
+    expect(resolveLanguage('en')).toBe('en')
+    expect(resolveLanguage(null)).toBe('en')
+    expect(resolveLanguage(undefined)).toBe('en')
+    expect(resolveLanguage('fr')).toBe('en')
+  })
+})
+
+describe('sendListMessage', () => {
+  it('builds message with header and category blocks', () => {
+    const msg = sendListMessage('en', {
+      planTitle: 'Trip',
+      categoryBlocks: '*Food*\n• Burgers\n\n',
+      emptyList: false,
+    })
+    expect(msg).toContain('📋 *Trip*')
+    expect(msg).toContain('*Food*')
+    expect(msg).toContain('• Burgers')
+  })
+
+  it('builds empty list message', () => {
+    const msg = sendListMessage('en', {
+      planTitle: 'Trip',
+      categoryBlocks: '',
+      emptyList: true,
+    })
+    expect(msg).toContain('📋 *Trip*')
+    expect(msg).toContain('No items yet')
+  })
+
+  it('builds Hebrew empty list message', () => {
+    const msg = sendListMessage('he', {
+      planTitle: 'טיול',
+      categoryBlocks: '',
+      emptyList: true,
+    })
+    expect(msg).toContain('אין פריטים עדיין')
+  })
+})
+
+describe('inviteMessage', () => {
+  it('includes plan title and deep link (en)', () => {
+    const msg = inviteMessage('en', {
+      planTitle: 'BBQ',
+      deepLink: 'https://example.com/invite',
+    })
+    expect(msg).toContain('BBQ')
+    expect(msg).toContain('https://example.com/invite')
+    expect(msg).toContain('invited')
+  })
+
+  it('includes plan title and deep link (he)', () => {
+    const msg = inviteMessage('he', {
+      planTitle: 'מסיבה',
+      deepLink: 'https://example.com/invite',
+    })
+    expect(msg).toContain('מסיבה')
+    expect(msg).toContain('הוזמנת')
+  })
+})
+
+describe('joinRequestMessage', () => {
+  it('includes requester name, plan title and link', () => {
+    const msg = joinRequestMessage('en', {
+      requesterName: 'John Doe',
+      planTitle: 'Camping',
+      deepLink: 'https://example.com/requests',
+    })
+    expect(msg).toContain('John Doe')
+    expect(msg).toContain('Camping')
+    expect(msg).toContain('join')
+  })
+})
+
+describe('joinRequestApprovedMessage', () => {
+  it('includes plan title and link', () => {
+    const msg = joinRequestApprovedMessage('en', {
+      planTitle: 'Camping',
+      deepLink: 'https://example.com/plan',
+    })
+    expect(msg).toContain('approved')
+    expect(msg).toContain('Camping')
+  })
+
+  it('Hebrew version', () => {
+    const msg = joinRequestApprovedMessage('he', {
+      planTitle: 'קמפינג',
+      deepLink: 'https://example.com/plan',
+    })
+    expect(msg).toContain('אושרה')
+    expect(msg).toContain('קמפינג')
+  })
+})
+
+describe('joinRequestRejectedMessage', () => {
+  it('includes plan title (en)', () => {
+    const msg = joinRequestRejectedMessage('en', { planTitle: 'Camping' })
+    expect(msg).toContain('Camping')
+    expect(msg).toContain('not approved')
+  })
+
+  it('includes plan title (he)', () => {
+    const msg = joinRequestRejectedMessage('he', { planTitle: 'קמפינג' })
+    expect(msg).toContain('קמפינג')
+    expect(msg).toContain('לא אושרה')
+  })
+})
+
+describe('translateCategory', () => {
+  it('translates known categories', () => {
+    expect(translateCategory('food', 'en')).toBe('Food')
+    expect(translateCategory('food', 'he')).toBe('אוכל')
+    expect(translateCategory('equipment', 'en')).toBe('Equipment')
+  })
+
+  it('returns raw string for unknown categories', () => {
+    expect(translateCategory('mystery', 'en')).toBe('mystery')
+  })
+})
+
+describe('translateUnit', () => {
+  it('translates known units', () => {
+    expect(translateUnit('kg', 'en')).toBe('kg')
+    expect(translateUnit('kg', 'he')).toBe('ק"ג')
+    expect(translateUnit('pcs', 'he')).toBe('יח׳')
+  })
+
+  it('returns raw string for unknown units', () => {
+    expect(translateUnit('bushel', 'en')).toBe('bushel')
+  })
+})


### PR DESCRIPTION
## Changes

### Phase 0 — Extracted shared helpers
- **`formatItemList()`** and **`resolvePlanTitle()`** in `messages.ts` — replaces duplicated item grouping logic
- **`fireAndForgetNotification()`** in `notify.ts` — reusable fire-and-forget WhatsApp + audit pattern, refactored 3 call sites

### Phase 1 — Join request rejection notification
- DB migration `0021` — adds `join_request_rejected` to enum
- `joinRequestRejectedMessage` template (en/he)
- Fires rejection notification on join request rejection

### Phase 2 — Unified `/send-list` endpoint
- **`filterItemsForList()`** — supports `full`, `buying`, `packing`, `unassigned` with optional per-participant filtering
- Replaces both `/send-list` and `/send-list-all` with a single endpoint:
  - `recipient`: `self` | `all` | `<participantId>`
  - `listType`: `full` | `buying` | `packing` | `unassigned`
  - Per-participant filtering for buying/packing when `recipient=all`
- Unified `SendListResponse` schema

### Tests
- 13 unit tests for item filters
- 27 unit tests for messages
- 10 integration tests for unified send-list
- 679 total tests passing