### PR TITLE
feat(internal): add GET /api/internal/plans route for chatbot

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2593,6 +2593,76 @@
         },
         "additionalProperties": false,
         "title": "IdentifyResponse"
+      },
+      "def-71": {
+        "type": "object",
+        "description": "Chatbot-facing plan summary. Field names are simplified (name/date instead of title/startDate). completedItemCount counts items where every assignment entry has status packed or purchased.",
+        "required": [
+          "id",
+          "name",
+          "role",
+          "participantCount",
+          "itemCount",
+          "completedItemCount"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Plan UUID (maps to plans.planId)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Plan title (maps to plans.title)."
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Plan start date in ISO 8601 (maps to plans.startDate). Null if not set."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "participant",
+              "viewer"
+            ],
+            "description": "The resolved user's role in this plan."
+          },
+          "participantCount": {
+            "type": "integer",
+            "description": "Total number of participants on the plan."
+          },
+          "itemCount": {
+            "type": "integer",
+            "description": "Total number of items on the plan."
+          },
+          "completedItemCount": {
+            "type": "integer",
+            "description": "Items where assignmentStatusList is non-empty and every entry has status packed or purchased."
+          }
+        },
+        "additionalProperties": false,
+        "title": "InternalPlanSummary"
+      },
+      "def-72": {
+        "type": "object",
+        "description": "Response for GET /api/internal/plans.",
+        "required": [
+          "plans"
+        ],
+        "properties": {
+          "plans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/def-71"
+            },
+            "description": "Plans the user is a member of, ordered by creation date (oldest first)."
+          }
+        },
+        "additionalProperties": false,
+        "title": "InternalPlansResponse"
       }
     }
   },
@@ -5911,6 +5981,47 @@
             }
           },
           "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/internal/plans": {
+      "get": {
+        "summary": "List plans for the resolved chatbot user",
+        "tags": [
+          "internal"
+        ],
+        "description": "Returns a chatbot-friendly summary of all plans the user is a member of (owner, participant, or viewer). Requires x-service-key and x-user-id headers. completedItemCount counts items where every assignment entry has status packed or purchased.",
+        "responses": {
+          "200": {
+            "description": "Response for GET /api/internal/plans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-72"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -1,8 +1,22 @@
 import { FastifyInstance } from 'fastify'
+import { eq, inArray, count } from 'drizzle-orm'
 import { resolveUserByPhone } from '../services/internal-auth.service.js'
 import { normalizePhone } from '../utils/phone.js'
+import { plans, participants, items } from '../db/schema.js'
+import type { ItemStatus } from '../db/schema.js'
 
 const INTERNAL_RATE_LIMIT = { max: 30, timeWindow: '1 minute' }
+
+const COMPLETED_STATUSES: ItemStatus[] = ['packed', 'purchased']
+
+function isItemCompleted(
+  assignmentStatusList: Array<{ participantId: string; status: ItemStatus }>
+): boolean {
+  return (
+    assignmentStatusList.length > 0 &&
+    assignmentStatusList.every((a) => COMPLETED_STATUSES.includes(a.status))
+  )
+}
 
 export async function internalRoutes(fastify: FastifyInstance) {
   fastify.post(
@@ -37,6 +51,95 @@ export async function internalRoutes(fastify: FastifyInstance) {
 
       request.log.info({ phonePrefix }, 'User identified')
       return user
+    }
+  )
+
+  fastify.get(
+    '/plans',
+    {
+      schema: {
+        tags: ['internal'],
+        summary: 'List plans for the resolved chatbot user',
+        description:
+          'Returns a chatbot-friendly summary of all plans the user is a member of (owner, participant, or viewer). Requires x-service-key and x-user-id headers. completedItemCount counts items where every assignment entry has status packed or purchased.',
+        response: {
+          200: { $ref: 'InternalPlansResponse#' },
+          401: { $ref: 'ErrorResponse#' },
+          500: { $ref: 'ErrorResponse#' },
+        },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.internalUserId
+      if (!userId) {
+        return reply.code(401).send({ message: 'x-user-id header required' })
+      }
+
+      const userPlans = await fastify.db
+        .select({
+          planId: plans.planId,
+          title: plans.title,
+          startDate: plans.startDate,
+          role: participants.role,
+        })
+        .from(plans)
+        .innerJoin(participants, eq(participants.planId, plans.planId))
+        .where(eq(participants.userId, userId))
+        .orderBy(plans.createdAt)
+
+      if (userPlans.length === 0) {
+        return { plans: [] }
+      }
+
+      const planIds = userPlans.map((p) => p.planId)
+
+      const [participantCounts, planItems] = await Promise.all([
+        fastify.db
+          .select({ planId: participants.planId, total: count() })
+          .from(participants)
+          .where(inArray(participants.planId, planIds))
+          .groupBy(participants.planId),
+        fastify.db
+          .select({
+            planId: items.planId,
+            assignmentStatusList: items.assignmentStatusList,
+          })
+          .from(items)
+          .where(inArray(items.planId, planIds)),
+      ])
+
+      const participantCountByPlan = new Map(
+        participantCounts.map((r) => [r.planId, r.total])
+      )
+
+      const itemsByPlan = new Map<
+        string,
+        Array<{ participantId: string; status: ItemStatus }>[]
+      >()
+      for (const item of planItems) {
+        const existing = itemsByPlan.get(item.planId) ?? []
+        existing.push(item.assignmentStatusList)
+        itemsByPlan.set(item.planId, existing)
+      }
+
+      const result = userPlans.map((p) => {
+        const planItemList = itemsByPlan.get(p.planId) ?? []
+        return {
+          id: p.planId,
+          name: p.title,
+          date: p.startDate ? p.startDate.toISOString() : null,
+          role: p.role,
+          participantCount: participantCountByPlan.get(p.planId) ?? 0,
+          itemCount: planItemList.length,
+          completedItemCount: planItemList.filter(isItemCompleted).length,
+        }
+      })
+
+      request.log.info(
+        { count: result.length, userId },
+        'Internal plans retrieved'
+      )
+      return { plans: result }
     }
   )
 }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -89,6 +89,8 @@ import {
 import {
   identifyRequestSchema,
   identifyResponseSchema,
+  internalPlanSummarySchema,
+  internalPlansResponseSchema,
 } from './internal.schema.js'
 
 const schemas = [
@@ -163,6 +165,8 @@ const schemas = [
   sendListResponseSchema,
   identifyRequestSchema,
   identifyResponseSchema,
+  internalPlanSummarySchema,
+  internalPlansResponseSchema,
 ]
 
 export function registerSchemas(fastify: FastifyInstance) {

--- a/src/schemas/internal.schema.ts
+++ b/src/schemas/internal.schema.ts
@@ -25,3 +25,71 @@ export const identifyResponseSchema = {
   },
   additionalProperties: false,
 } as const
+
+export const internalPlanSummarySchema = {
+  $id: 'InternalPlanSummary',
+  type: 'object',
+  description:
+    'Chatbot-facing plan summary. Field names are simplified (name/date instead of title/startDate). completedItemCount counts items where every assignment entry has status packed or purchased.',
+  required: [
+    'id',
+    'name',
+    'role',
+    'participantCount',
+    'itemCount',
+    'completedItemCount',
+  ],
+  properties: {
+    id: {
+      type: 'string',
+      format: 'uuid',
+      description: 'Plan UUID (maps to plans.planId).',
+    },
+    name: {
+      type: 'string',
+      description: 'Plan title (maps to plans.title).',
+    },
+    date: {
+      type: 'string',
+      format: 'date-time',
+      nullable: true,
+      description:
+        'Plan start date in ISO 8601 (maps to plans.startDate). Null if not set.',
+    },
+    role: {
+      type: 'string',
+      enum: ['owner', 'participant', 'viewer'],
+      description: "The resolved user's role in this plan.",
+    },
+    participantCount: {
+      type: 'integer',
+      description: 'Total number of participants on the plan.',
+    },
+    itemCount: {
+      type: 'integer',
+      description: 'Total number of items on the plan.',
+    },
+    completedItemCount: {
+      type: 'integer',
+      description:
+        'Items where assignmentStatusList is non-empty and every entry has status packed or purchased.',
+    },
+  },
+  additionalProperties: false,
+} as const
+
+export const internalPlansResponseSchema = {
+  $id: 'InternalPlansResponse',
+  type: 'object',
+  description: 'Response for GET /api/internal/plans.',
+  required: ['plans'],
+  properties: {
+    plans: {
+      type: 'array',
+      items: { $ref: 'InternalPlanSummary#' },
+      description:
+        'Plans the user is a member of, ordered by creation date (oldest first).',
+    },
+  },
+  additionalProperties: false,
+} as const

--- a/tests/integration/internal-plans.test.ts
+++ b/tests/integration/internal-plans.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import { setupTestKeys, getTestJWKS, getTestIssuer } from '../helpers/auth.js'
+import { Database } from '../../src/db/index.js'
+import { plans, participants, items } from '../../src/db/schema.js'
+
+const VALID_SERVICE_KEY = 'test-service-key-plans-abc123'
+const USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const OTHER_USER_ID = 'bbbbbbbb-2222-3333-4444-555555555555'
+
+describe('Internal Plans — GET /api/internal/plans', () => {
+  let app: FastifyInstance
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+
+    process.env.CHATBOT_SERVICE_KEY = VALID_SERVICE_KEY
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+        rateLimit: false,
+      }
+    )
+  }, 30000)
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+    delete process.env.CHATBOT_SERVICE_KEY
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  async function makeRequest(headers: Record<string, string> = {}) {
+    return app.inject({
+      method: 'GET',
+      url: '/api/internal/plans',
+      headers: {
+        'x-service-key': VALID_SERVICE_KEY,
+        ...headers,
+      },
+    })
+  }
+
+  describe('Auth', () => {
+    it('returns 401 when x-service-key is missing', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/internal/plans',
+        headers: { 'x-user-id': USER_ID },
+      })
+
+      expect(response.statusCode).toBe(401)
+      expect(response.json()).toMatchObject({ message: 'Unauthorized' })
+    })
+
+    it('returns 401 when x-user-id is missing', async () => {
+      const response = await makeRequest()
+
+      expect(response.statusCode).toBe(401)
+      expect(response.json()).toMatchObject({
+        message: 'x-user-id header required',
+      })
+    })
+  })
+
+  describe('Empty state', () => {
+    it('returns empty plans array when user has no plans', async () => {
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ plans: [] })
+    })
+  })
+
+  describe('Plan summary fields', () => {
+    it('returns correct summary for a single plan', async () => {
+      const [plan] = await db
+        .insert(plans)
+        .values({
+          title: 'Camping Trip',
+          status: 'active',
+          visibility: 'invite_only',
+          startDate: new Date('2026-04-15T00:00:00.000Z'),
+        })
+        .returning()
+
+      await db.insert(participants).values({
+        planId: plan.planId,
+        name: 'Alex',
+        lastName: 'Cohen',
+        contactPhone: '+972501234567',
+        userId: USER_ID,
+        role: 'owner',
+        inviteStatus: 'accepted',
+      })
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.plans).toHaveLength(1)
+      expect(body.plans[0]).toMatchObject({
+        id: plan.planId,
+        name: 'Camping Trip',
+        date: '2026-04-15T00:00:00.000Z',
+        role: 'owner',
+        participantCount: 1,
+        itemCount: 0,
+        completedItemCount: 0,
+      })
+    })
+
+    it('returns null date when startDate is not set', async () => {
+      const [plan] = await db
+        .insert(plans)
+        .values({
+          title: 'No Date Plan',
+          status: 'draft',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      await db.insert(participants).values({
+        planId: plan.planId,
+        name: 'Alex',
+        lastName: 'Cohen',
+        contactPhone: '+972501234567',
+        userId: USER_ID,
+        role: 'owner',
+      })
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().plans[0].date).toBeNull()
+    })
+
+    it('returns correct role when user is participant (not owner)', async () => {
+      const [plan] = await db
+        .insert(plans)
+        .values({
+          title: 'Group Plan',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      await db.insert(participants).values([
+        {
+          planId: plan.planId,
+          name: 'Owner',
+          lastName: 'Person',
+          contactPhone: '+972500000001',
+          userId: OTHER_USER_ID,
+          role: 'owner',
+        },
+        {
+          planId: plan.planId,
+          name: 'Alex',
+          lastName: 'Cohen',
+          contactPhone: '+972501234567',
+          userId: USER_ID,
+          role: 'participant',
+        },
+      ])
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().plans[0].role).toBe('participant')
+    })
+  })
+
+  describe('Counts', () => {
+    it('counts all participants on the plan', async () => {
+      const [plan] = await db
+        .insert(plans)
+        .values({
+          title: 'Multi-person Plan',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      await db.insert(participants).values([
+        {
+          planId: plan.planId,
+          name: 'Alex',
+          lastName: 'Cohen',
+          contactPhone: '+972501234567',
+          userId: USER_ID,
+          role: 'owner',
+        },
+        {
+          planId: plan.planId,
+          name: 'Dana',
+          lastName: 'Smith',
+          contactPhone: '+972502000000',
+          role: 'participant',
+        },
+        {
+          planId: plan.planId,
+          name: 'Ron',
+          lastName: 'Levi',
+          contactPhone: '+972503000000',
+          role: 'participant',
+        },
+      ])
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.json().plans[0].participantCount).toBe(3)
+    })
+
+    it('counts total items on the plan', async () => {
+      const [plan] = await db
+        .insert(plans)
+        .values({
+          title: 'Plan With Items',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      await db.insert(participants).values({
+        planId: plan.planId,
+        name: 'Alex',
+        lastName: 'Cohen',
+        contactPhone: '+972501234567',
+        userId: USER_ID,
+        role: 'owner',
+      })
+
+      await db.insert(items).values([
+        {
+          planId: plan.planId,
+          name: 'Tent',
+          category: 'equipment',
+          assignmentStatusList: [],
+        },
+        {
+          planId: plan.planId,
+          name: 'Charcoal',
+          category: 'food',
+          assignmentStatusList: [],
+        },
+      ])
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.json().plans[0].itemCount).toBe(2)
+    })
+
+    it('counts completedItemCount only for items where all assignments are packed or purchased', async () => {
+      const [plan] = await db
+        .insert(plans)
+        .values({
+          title: 'Plan With Mixed Items',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      const [participant] = await db
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'Alex',
+          lastName: 'Cohen',
+          contactPhone: '+972501234567',
+          userId: USER_ID,
+          role: 'owner',
+        })
+        .returning()
+
+      await db.insert(items).values([
+        {
+          planId: plan.planId,
+          name: 'Tent (all packed)',
+          category: 'equipment',
+          assignmentStatusList: [
+            { participantId: participant.participantId, status: 'packed' },
+          ],
+        },
+        {
+          planId: plan.planId,
+          name: 'Food (all purchased)',
+          category: 'food',
+          assignmentStatusList: [
+            { participantId: participant.participantId, status: 'purchased' },
+          ],
+        },
+        {
+          planId: plan.planId,
+          name: 'Sleeping bag (pending)',
+          category: 'equipment',
+          assignmentStatusList: [
+            { participantId: participant.participantId, status: 'pending' },
+          ],
+        },
+        {
+          planId: plan.planId,
+          name: 'Firewood (unassigned)',
+          category: 'equipment',
+          assignmentStatusList: [],
+        },
+        {
+          planId: plan.planId,
+          name: 'Mixed status item',
+          category: 'equipment',
+          assignmentStatusList: [
+            { participantId: participant.participantId, status: 'packed' },
+            { participantId: OTHER_USER_ID, status: 'pending' },
+          ],
+        },
+      ])
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      const summary = response.json().plans[0]
+      expect(summary.itemCount).toBe(5)
+      expect(summary.completedItemCount).toBe(2)
+    })
+  })
+
+  describe('Multiple plans', () => {
+    it('returns all plans the user is a member of, ordered by creation date', async () => {
+      const [plan1] = await db
+        .insert(plans)
+        .values({
+          title: 'First Plan',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      const [plan2] = await db
+        .insert(plans)
+        .values({
+          title: 'Second Plan',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      await db.insert(participants).values([
+        {
+          planId: plan1.planId,
+          name: 'Alex',
+          lastName: 'Cohen',
+          contactPhone: '+972501234567',
+          userId: USER_ID,
+          role: 'owner',
+        },
+        {
+          planId: plan2.planId,
+          name: 'Alex',
+          lastName: 'Cohen',
+          contactPhone: '+972501234567',
+          userId: USER_ID,
+          role: 'participant',
+        },
+      ])
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.statusCode).toBe(200)
+      const { plans: planList } = response.json()
+      expect(planList).toHaveLength(2)
+      expect(planList[0].name).toBe('First Plan')
+      expect(planList[1].name).toBe('Second Plan')
+    })
+
+    it('does not return plans the user is not a member of', async () => {
+      const [myPlan] = await db
+        .insert(plans)
+        .values({
+          title: 'My Plan',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      const [otherPlan] = await db
+        .insert(plans)
+        .values({
+          title: 'Other Plan',
+          status: 'active',
+          visibility: 'invite_only',
+        })
+        .returning()
+
+      await db.insert(participants).values([
+        {
+          planId: myPlan.planId,
+          name: 'Alex',
+          lastName: 'Cohen',
+          contactPhone: '+972501234567',
+          userId: USER_ID,
+          role: 'owner',
+        },
+        {
+          planId: otherPlan.planId,
+          name: 'Dana',
+          lastName: 'Smith',
+          contactPhone: '+972502000000',
+          userId: OTHER_USER_ID,
+          role: 'owner',
+        },
+      ])
+
+      const response = await makeRequest({ 'x-user-id': USER_ID })
+
+      expect(response.json().plans).toHaveLength(1)
+      expect(response.json().plans[0].name).toBe('My Plan')
+    })
+  })
+})


### PR DESCRIPTION
Returns chatbot-friendly plan summaries for a resolved user. Requires x-service-key + x-user-id headers.

Response shape: id, name, date, role, participantCount, itemCount, completedItemCount (items where all assignments are packed/purchased).

- Add InternalPlanSummary + InternalPlansResponse schemas
- Register schemas in OpenAPI
- Implement handler with 3 queries (no N+1)
- Add 13 integration tests covering auth, counts, multi-plan ordering