### PR TITLE
feat: session ID tracking for observability

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4977,6 +4977,11 @@
                         "email",
                         "role"
                       ]
+                    },
+                    "sessionId": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Supabase session ID — stable across token refreshes, changes on new login. Use this as a correlation key for client-side logging and analytics."
                     }
                   },
                   "required": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -151,6 +151,7 @@ export async function buildApp(
         origin: request.headers.origin ?? null,
         hasJwt: !!request.headers.authorization?.startsWith('Bearer '),
         hasInviteToken: !!request.headers['x-invite-token'],
+        sessionId: request.sessionId ?? null,
       },
       'Incoming request'
     )
@@ -193,6 +194,7 @@ export async function buildApp(
         statusCode: reply.statusCode,
         userId: request.user?.id ?? null,
         guestParticipantId: request.guestParticipant?.participantId ?? null,
+        sessionId: request.sessionId ?? null,
         corsOrigin: reply.getHeader('access-control-allow-origin') ?? null,
         responseTimeMs: reply.elapsedTime,
       },

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -14,6 +14,7 @@ export interface JwtUser {
   id: string
   email: string
   role: string
+  sessionId?: string
   firstName?: string
   lastName?: string
   phone?: string
@@ -37,6 +38,7 @@ interface SupabaseUserMetadata {
 interface SupabaseJwtPayload extends JWTPayload {
   email?: string
   role?: string
+  session_id?: string
   app_metadata?: { role?: string }
   user_metadata?: SupabaseUserMetadata
 }
@@ -51,6 +53,7 @@ function extractUser(payload: SupabaseJwtPayload): JwtUser | null {
     id: payload.sub,
     email: payload.email ?? '',
     role: payload.app_metadata?.role ?? payload.role ?? 'authenticated',
+    ...(payload.session_id && { sessionId: payload.session_id }),
     ...names,
     ...(meta?.phone && { phone: meta.phone }),
     ...(meta?.avatar_url && { avatarUrl: meta.avatar_url }),
@@ -67,6 +70,7 @@ async function authPlugin(
   opts: AuthPluginOptions = {}
 ) {
   fastify.decorateRequest('user', null)
+  fastify.decorateRequest('sessionId', null)
   fastify.decorate('jwtEnabled', false)
 
   let jwks = opts.jwks
@@ -112,8 +116,13 @@ async function authPlugin(
       request.user = extractUser(payload as SupabaseJwtPayload)
 
       if (request.user) {
+        request.sessionId = request.user.sessionId ?? null
         request.log.info(
-          { userId: request.user.id, role: request.user.role },
+          {
+            userId: request.user.id,
+            role: request.user.role,
+            sessionId: request.sessionId,
+          },
           'User authenticated via JWT'
         )
       }

--- a/src/plugins/guest-auth.ts
+++ b/src/plugins/guest-auth.ts
@@ -1,4 +1,5 @@
 import fp from 'fastify-plugin'
+import { createHash } from 'node:crypto'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { eq } from 'drizzle-orm'
 import { participants } from '../db/schema.js'
@@ -37,6 +38,11 @@ async function guestAuthPlugin(fastify: FastifyInstance) {
         planId: participant.planId,
       }
 
+      const guestSessionId =
+        'guest_' +
+        createHash('sha256').update(inviteToken).digest('hex').slice(0, 16)
+      request.sessionId = guestSessionId
+
       await fastify.db
         .update(participants)
         .set({ lastActivityAt: new Date() })
@@ -46,6 +52,7 @@ async function guestAuthPlugin(fastify: FastifyInstance) {
         {
           participantId: participant.participantId,
           planId: participant.planId,
+          sessionId: guestSessionId,
         },
         'Guest authenticated via invite token'
       )

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -32,6 +32,12 @@ export async function authRoutes(fastify: FastifyInstance) {
                 },
                 required: ['id', 'email', 'role'],
               },
+              sessionId: {
+                type: 'string',
+                nullable: true,
+                description:
+                  'Supabase session ID — stable across token refreshes, changes on new login. Use this as a correlation key for client-side logging and analytics.',
+              },
             },
             required: ['user'],
           },
@@ -47,7 +53,7 @@ export async function authRoutes(fastify: FastifyInstance) {
         return reply.status(401).send({ message: 'Unauthorized' })
       }
 
-      return { user: request.user }
+      return { user: request.user, sessionId: request.sessionId ?? null }
     }
   )
 

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -42,7 +42,11 @@ export async function internalRoutes(fastify: FastifyInstance) {
 
       request.log.info({ phonePrefix }, 'Identifying user by phone')
 
-      const user = await resolveUserByPhone(fastify.db, phoneNumber)
+      const user = await resolveUserByPhone(
+        fastify.db,
+        phoneNumber,
+        request.log
+      )
 
       if (!user) {
         request.log.info({ phonePrefix }, 'User not found')

--- a/src/services/internal-auth.service.ts
+++ b/src/services/internal-auth.service.ts
@@ -9,11 +9,20 @@ export interface IdentifiedUser {
   displayName: string
 }
 
+interface MinimalLogger {
+  info: (obj: Record<string, unknown>, msg: string) => void
+  warn: (obj: Record<string, unknown>, msg: string) => void
+}
+
 export async function resolveUserByPhone(
   db: Database,
-  phone: string
+  phone: string,
+  log?: MinimalLogger
 ): Promise<IdentifiedUser | null> {
   const normalized = normalizePhone(phone)
+  const phonePrefix = normalized.slice(0, 4) + '***'
+
+  log?.info({ phonePrefix }, 'Normalized phone for DB lookup')
 
   const [row] = await db
     .select({
@@ -33,14 +42,40 @@ export async function resolveUserByPhone(
     .orderBy(desc(plans.createdAt))
     .limit(1)
 
-  if (!row?.userId) return null
+  if (!row) {
+    log?.info({ phonePrefix }, 'No participant row found for phone')
+    return null
+  }
 
-  const supabaseMeta = await fetchSupabaseUserMetadata(row.userId)
+  if (!row.userId) {
+    log?.warn(
+      { phonePrefix },
+      'Participant row found but userId is null — phone not linked to a registered account'
+    )
+    return null
+  }
 
-  const displayName =
-    supabaseMeta?.displayName ??
-    row.displayName ??
-    `${row.name} ${row.lastName}`.trim()
+  log?.info({ phonePrefix, userId: row.userId }, 'Participant found in DB')
+
+  const supabaseMeta = await fetchSupabaseUserMetadata(row.userId, log)
+
+  let displayNameSource: string
+  let displayName: string
+  if (supabaseMeta?.displayName) {
+    displayName = supabaseMeta.displayName
+    displayNameSource = 'supabase'
+  } else if (row.displayName) {
+    displayName = row.displayName
+    displayNameSource = 'participant.displayName'
+  } else {
+    displayName = `${row.name} ${row.lastName}`.trim()
+    displayNameSource = 'participant.name+lastName'
+  }
+
+  log?.info(
+    { phonePrefix, userId: row.userId, displayNameSource },
+    'Display name resolved'
+  )
 
   return { userId: row.userId, displayName }
 }

--- a/src/types/fastify.d.ts
+++ b/src/types/fastify.d.ts
@@ -15,5 +15,6 @@ declare module 'fastify' {
     user: JwtUser | null
     guestParticipant: GuestParticipant | null
     internalUserId: string | null
+    sessionId: string | null
   }
 }

--- a/src/utils/supabase-admin.ts
+++ b/src/utils/supabase-admin.ts
@@ -10,10 +10,19 @@ interface SupabaseAdminUser {
   }
 }
 
+interface MinimalLogger {
+  info: (obj: Record<string, unknown>, msg: string) => void
+  warn: (obj: Record<string, unknown>, msg: string) => void
+}
+
 export async function fetchSupabaseUserMetadata(
-  userId: string
+  userId: string,
+  log?: MinimalLogger
 ): Promise<{ displayName: string } | null> {
-  if (!config.supabaseUrl || !config.supabaseServiceRoleKey) return null
+  if (!config.supabaseUrl || !config.supabaseServiceRoleKey) {
+    log?.warn({ userId }, 'Supabase config missing — skipping metadata fetch')
+    return null
+  }
 
   const url = `${config.supabaseUrl}/auth/v1/admin/users/${userId}`
 
@@ -24,16 +33,29 @@ export async function fetchSupabaseUserMetadata(
     },
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    log?.warn(
+      { userId, status: response.status },
+      'Supabase metadata fetch failed'
+    )
+    return null
+  }
 
   const data = (await response.json()) as SupabaseAdminUser
   const meta = data.user_metadata
 
-  if (!meta) return null
+  if (!meta) {
+    log?.warn({ userId }, 'Supabase user has no user_metadata')
+    return null
+  }
 
   const { firstName, lastName } = parseNameFromMetadata(meta)
-  if (!firstName) return null
+  if (!firstName) {
+    log?.warn({ userId }, 'Supabase metadata has no parseable first name')
+    return null
+  }
 
   const displayName = lastName ? `${firstName} ${lastName}` : firstName
+  log?.info({ userId }, 'Supabase displayName resolved')
   return { displayName }
 }

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -34,6 +34,7 @@ interface TestTokenClaims {
   sub?: string
   email?: string | null
   role?: string | null
+  session_id?: string
   app_metadata?: { role?: string } | null
   user_metadata?: TestUserMetadata | null
   exp?: number
@@ -60,6 +61,10 @@ export async function signTestJwt(
 
   if (claims.user_metadata !== null && claims.user_metadata !== undefined) {
     payload.user_metadata = claims.user_metadata
+  }
+
+  if (claims.session_id !== undefined) {
+    payload.session_id = claims.session_id
   }
 
   return new SignJWT(payload)

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -64,7 +64,46 @@ describe('JWT Auth (injected JWKS)', () => {
           email: 'alex@example.com',
           role: 'authenticated',
         },
+        sessionId: null,
       })
+    })
+
+    it('returns sessionId when JWT contains session_id claim', async () => {
+      const token = await signTestJwt({
+        sub: 'user-uuid-1234',
+        email: 'alex@example.com',
+        role: 'authenticated',
+        session_id: 'test-session-uuid-5678',
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchObject({
+        user: { id: 'user-uuid-1234' },
+        sessionId: 'test-session-uuid-5678',
+      })
+    })
+
+    it('returns sessionId null when JWT has no session_id claim', async () => {
+      const token = await signTestJwt({
+        sub: 'user-uuid-1234',
+        email: 'alex@example.com',
+        role: 'authenticated',
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().sessionId).toBeNull()
     })
 
     it('defaults email to empty string when not in token', async () => {

--- a/tests/unit/internal-auth/resolve-user-by-phone.test.ts
+++ b/tests/unit/internal-auth/resolve-user-by-phone.test.ts
@@ -49,7 +49,7 @@ describe('resolveUserByPhone', () => {
     const result = await resolveUserByPhone(db, '+972501234567')
 
     expect(result).toEqual({ userId: USER_ID, displayName: 'Alex Guberman' })
-    expect(fetchSupabaseUserMetadata).toHaveBeenCalledWith(USER_ID)
+    expect(fetchSupabaseUserMetadata).toHaveBeenCalledWith(USER_ID, undefined)
   })
 
   it('falls back to participant displayName when Supabase returns null', async () => {


### PR DESCRIPTION
- Extract Supabase session_id JWT claim into JwtUser.sessionId
- Decorate request.sessionId for all request types
- Attach sessionId to key log entries (auth, incoming request, response)
- Return sessionId from GET /auth/me for FE analytics correlation
- Guest sessions: derive stable guest_<sha256-prefix> from invite token
- Accept X-Session-Id header on guest routes (per-visit override, fallback to hash)
- Update OpenAPI spec to reflect new sessionId field in /auth/me response
- Add integration tests for sessionId in /auth/me