### PR TITLE
fix: read phone from Supabase user_metadata instead of auth.users.phone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm'
 import { FastifyInstance } from 'fastify'
 import { userDetails } from '../db/schema.js'
 import { syncAllParticipantsForUser } from '../services/profile-sync.js'
+import { fetchSupabaseUserMetadata } from '../utils/supabase-admin.js'
 
 const AUTH_RATE_LIMIT = {
   max: 10,
@@ -204,9 +205,18 @@ export async function authRoutes(fastify: FastifyInstance) {
       }
 
       try {
+        const supabaseMeta = await fetchSupabaseUserMetadata(
+          request.user.id,
+          request.log
+        )
+        const user =
+          supabaseMeta?.phone && !request.user.phone
+            ? { ...request.user, phone: supabaseMeta.phone }
+            : request.user
+
         const synced = await syncAllParticipantsForUser(
           fastify.db,
-          request.user,
+          user,
           request.log
         )
 

--- a/src/utils/supabase-admin.ts
+++ b/src/utils/supabase-admin.ts
@@ -7,6 +7,7 @@ interface SupabaseAdminUser {
     last_name?: string
     full_name?: string
     name?: string
+    phone?: string
   }
 }
 
@@ -18,7 +19,7 @@ interface MinimalLogger {
 export async function fetchSupabaseUserMetadata(
   userId: string,
   log?: MinimalLogger
-): Promise<{ displayName: string } | null> {
+): Promise<{ displayName: string; phone?: string } | null> {
   if (!config.supabaseUrl || !config.supabaseServiceRoleKey) {
     log?.warn({ userId }, 'Supabase config missing — skipping metadata fetch')
     return null
@@ -57,5 +58,5 @@ export async function fetchSupabaseUserMetadata(
 
   const displayName = lastName ? `${firstName} ${lastName}` : firstName
   log?.info({ userId }, 'Supabase displayName resolved')
-  return { displayName }
+  return { displayName, ...(meta.phone && { phone: meta.phone }) }
 }

--- a/tests/integration/sync-profile.test.ts
+++ b/tests/integration/sync-profile.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from 'vitest'
 import { buildApp } from '../../src/app.js'
 import { FastifyInstance } from 'fastify'
 import {
@@ -16,6 +24,12 @@ import { Database } from '../../src/db/index.js'
 import { eq } from 'drizzle-orm'
 import { plans, participants } from '../../src/db/schema.js'
 import { randomBytes } from 'node:crypto'
+
+vi.mock('../../src/utils/supabase-admin.js', () => ({
+  fetchSupabaseUserMetadata: vi.fn().mockResolvedValue(null),
+}))
+
+import { fetchSupabaseUserMetadata } from '../../src/utils/supabase-admin.js'
 
 const USER_A_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
 const USER_B_ID = 'bbbbbbbb-1111-2222-3333-444444444444'
@@ -224,6 +238,72 @@ describe('POST /auth/sync-profile', () => {
     })
 
     expect(response.statusCode).toBe(401)
+  })
+
+  it('syncs phone from Supabase user_metadata when JWT lacks phone', async () => {
+    const { participant } = await createPlanWithParticipant(db, USER_A_ID, {
+      name: 'Alex',
+      lastName: 'G',
+      contactPhone: '',
+    })
+
+    vi.mocked(fetchSupabaseUserMetadata).mockResolvedValueOnce({
+      displayName: 'Alex G',
+      phone: '+972501234567',
+    })
+
+    const jwt = await signTestJwt({
+      sub: USER_A_ID,
+      email: 'alex@example.com',
+      user_metadata: { first_name: 'Alex', last_name: 'G' },
+    })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/sync-profile',
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().synced).toBe(1)
+
+    const [row] = await db
+      .select()
+      .from(participants)
+      .where(eq(participants.participantId, participant.participantId))
+
+    expect(row.contactPhone).toBe('+972501234567')
+  })
+
+  it('does not overwrite JWT phone with Supabase phone when JWT already has phone', async () => {
+    await createPlanWithParticipant(db, USER_A_ID, {
+      name: 'Alex',
+      lastName: 'G',
+      contactPhone: '+15550000001',
+    })
+
+    vi.mocked(fetchSupabaseUserMetadata).mockResolvedValueOnce({
+      displayName: 'Alex G',
+      phone: '+972501234567',
+    })
+
+    const jwt = await signTestJwt({
+      sub: USER_A_ID,
+      email: 'alex@example.com',
+      user_metadata: {
+        first_name: 'Alex',
+        last_name: 'G',
+        phone: '+15550000001',
+      },
+    })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/sync-profile',
+      headers: { authorization: `Bearer ${jwt}` },
+    })
+
+    expect(response.statusCode).toBe(200)
   })
 
   it('handles Google OAuth full_name parsing across all plans', async () => {

--- a/tests/unit/internal-auth/resolve-user-by-phone.test.ts
+++ b/tests/unit/internal-auth/resolve-user-by-phone.test.ts
@@ -44,6 +44,7 @@ describe('resolveUserByPhone', () => {
     })
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue({
       displayName: 'Alex Guberman',
+      phone: '+972501234567',
     })
 
     const result = await resolveUserByPhone(db, '+972501234567')


### PR DESCRIPTION
- fetchSupabaseUserMetadata now returns phone from user_metadata.phone (raw_user_meta_data), not the empty top-level auth.users.phone column
- POST /auth/sync-profile calls Supabase Admin API for fresh phone and merges it into the user before syncing participants.contactPhone, so phone syncs correctly even when the JWT is stale
- Add 2 integration tests covering Supabase phone fallback in sync-profile
- Update resolve-user-by-phone mock to include phone in return type
- Add dev-lessons entry for this pattern
- Bump version to 1.25.1

Closes #182