### PR TITLE
feat(participants): add per-person dietary preferences (dietaryMember…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -892,6 +892,17 @@
             "type": "string",
             "nullable": true
           },
+          "dietaryMembers": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-74"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-person dietary preferences for each adult/kid in this participant group. Replaces the legacy foodPreferences/allergies text fields for new clients."
+          },
           "notes": {
             "type": "string",
             "nullable": true
@@ -980,6 +991,10 @@
           "allergies": {
             "type": "string"
           },
+          "dietaryMembers": {
+            "$ref": "#/components/schemas/def-74",
+            "description": "Per-person dietary preferences. Optional on create — send to populate structured dietary data for the participant group."
+          },
           "notes": {
             "type": "string"
           }
@@ -1050,6 +1065,17 @@
           "allergies": {
             "type": "string",
             "nullable": true
+          },
+          "dietaryMembers": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-74"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-person dietary preferences. Send null to clear. Partial updates are not supported — send the full members array each time."
           },
           "notes": {
             "type": "string",
@@ -1307,6 +1333,17 @@
             "type": "string",
             "nullable": true
           },
+          "dietaryMembers": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-74"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-person dietary preferences carried from the join request."
+          },
           "notes": {
             "type": "string",
             "nullable": true
@@ -1456,6 +1493,10 @@
           "allergies": {
             "type": "string"
           },
+          "dietaryMembers": {
+            "$ref": "#/components/schemas/def-74",
+            "description": "Per-person dietary preferences for this join request. Optional — carried through to the participant record on approval."
+          },
           "notes": {
             "type": "string"
           }
@@ -1537,6 +1578,17 @@
           "allergies": {
             "type": "string",
             "nullable": true
+          },
+          "dietaryMembers": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-74"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-person dietary preferences for this participant group. Null if not yet set."
           },
           "notes": {
             "type": "string",
@@ -1694,6 +1746,17 @@
             "type": "string",
             "nullable": true
           },
+          "dietaryMembers": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-74"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-person dietary preferences. Send null to clear. Send the full members array each time — partial updates are not supported."
+          },
           "notes": {
             "type": "string",
             "nullable": true
@@ -1750,6 +1813,17 @@
           "allergies": {
             "type": "string",
             "nullable": true
+          },
+          "dietaryMembers": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-74"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-person dietary preferences after the update."
           },
           "notes": {
             "type": "string",
@@ -2663,6 +2737,82 @@
         },
         "additionalProperties": false,
         "title": "InternalPlansResponse"
+      },
+      "def-73": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "adult",
+              "kid"
+            ],
+            "description": "Whether this group member is an adult or a kid"
+          },
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based index within the member type (adult 0, adult 1, kid 0, etc.)"
+          },
+          "diet": {
+            "type": "string",
+            "enum": [
+              "everything",
+              "vegetarian",
+              "vegan",
+              "pescatarian",
+              "kosher",
+              "halal",
+              "gluten_free",
+              "dairy_free",
+              "keto",
+              "paleo"
+            ],
+            "description": "Single food preference for this person"
+          },
+          "allergies": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "none",
+                "nuts",
+                "peanuts",
+                "gluten",
+                "dairy",
+                "eggs",
+                "soy",
+                "shellfish",
+                "sesame",
+                "fish"
+              ]
+            },
+            "description": "List of allergies for this person. Use [\"none\"] or [] for no allergies."
+          }
+        },
+        "required": [
+          "type",
+          "index",
+          "diet",
+          "allergies"
+        ],
+        "title": "DietaryMember"
+      },
+      "def-74": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/def-73"
+            },
+            "description": "Per-person dietary data for each adult/kid in this participant group. Each entry has a type (adult|kid), a 0-based index within that type, a single diet preference, and an allergies list."
+          }
+        },
+        "required": [
+          "members"
+        ],
+        "title": "DietaryMembersBody"
       }
     }
   },

--- a/drizzle/0022_flat_golden_guardian.sql
+++ b/drizzle/0022_flat_golden_guardian.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "participant_join_requests" ADD COLUMN "dietary_members" jsonb;--> statement-breakpoint
+ALTER TABLE "participants" ADD COLUMN "dietary_members" jsonb;

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1230 @@
+{
+  "id": "4359f90a-8e81-49d0-b786-c2b129703edd",
+  "prevId": "b008fe13-542d-43dc-91bc-151d069f435a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignment_status_list": {
+          "name": "assignment_status_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_expenses": {
+      "name": "participant_expenses",
+      "schema": "",
+      "columns": {
+        "expense_id": {
+          "name": "expense_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_expenses_participant_id_participants_participant_id_fk": {
+          "name": "participant_expenses_participant_id_participants_participant_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_expenses_plan_id_plans_plan_id_fk": {
+          "name": "participant_expenses_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_members": {
+          "name": "dietary_members",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_members": {
+          "name": "dietary_members",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lang": {
+          "name": "default_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_adults": {
+          "name": "estimated_adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_kids": {
+          "name": "estimated_kids",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_notifications": {
+      "name": "whatsapp_notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_phone": {
+          "name": "recipient_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_participant_id": {
+          "name": "recipient_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "whatsapp_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "whatsapp_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "whatsapp_notifications_plan_id_plans_plan_id_fk": {
+          "name": "whatsapp_notifications_plan_id_plans_plan_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk": {
+          "name": "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "recipient_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    },
+    "public.whatsapp_notification_status": {
+      "name": "whatsapp_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed"
+      ]
+    },
+    "public.whatsapp_notification_type": {
+      "name": "whatsapp_notification_type",
+      "schema": "public",
+      "values": [
+        "invitation_sent",
+        "join_request_pending",
+        "join_request_approved",
+        "join_request_rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1773584947760,
       "tag": "0021_productive_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1773935175984,
+      "tag": "0022_flat_golden_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -119,6 +119,45 @@ export type Location = {
   timezone?: string
 }
 
+export const DIET_TYPE_VALUES = [
+  'everything',
+  'vegetarian',
+  'vegan',
+  'pescatarian',
+  'kosher',
+  'halal',
+  'gluten_free',
+  'dairy_free',
+  'keto',
+  'paleo',
+] as const
+export type DietType = (typeof DIET_TYPE_VALUES)[number]
+
+export const ALLERGY_TYPE_VALUES = [
+  'none',
+  'nuts',
+  'peanuts',
+  'gluten',
+  'dairy',
+  'eggs',
+  'soy',
+  'shellfish',
+  'sesame',
+  'fish',
+] as const
+export type AllergyType = (typeof ALLERGY_TYPE_VALUES)[number]
+
+export type DietaryMember = {
+  type: 'adult' | 'kid'
+  index: number
+  diet: DietType
+  allergies: AllergyType[]
+}
+
+export type DietaryMembers = {
+  members: DietaryMember[]
+}
+
 export const plans = pgTable('plans', {
   planId: uuid('plan_id').primaryKey().defaultRandom(),
   title: varchar('title', { length: 255 }).notNull(),
@@ -166,6 +205,7 @@ export const participants = pgTable('participants', {
   kidsCount: integer('kids_count'),
   foodPreferences: text('food_preferences'),
   allergies: text('allergies'),
+  dietaryMembers: jsonb('dietary_members').$type<DietaryMembers>(),
   notes: text('notes'),
   rsvpStatus: rsvpStatusEnum('rsvp_status').default('pending').notNull(),
   lastActivityAt: timestamp('last_activity_at', { withTimezone: true }),
@@ -259,6 +299,7 @@ export const participantJoinRequests = pgTable(
     kidsCount: integer('kids_count'),
     foodPreferences: text('food_preferences'),
     allergies: text('allergies'),
+    dietaryMembers: jsonb('dietary_members').$type<DietaryMembers>(),
     notes: text('notes'),
     status: joinRequestStatusEnum('status').default('pending').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })

--- a/src/routes/invite.route.ts
+++ b/src/routes/invite.route.ts
@@ -7,6 +7,7 @@ import {
   Unit,
   ItemCategory,
   Assignment,
+  DietaryMembers,
 } from '../db/schema.js'
 import * as schema from '../db/schema.js'
 import { recordItemCreated, recordItemUpdated } from '../utils/item-changes.js'
@@ -64,6 +65,7 @@ export async function inviteRoutes(fastify: FastifyInstance) {
             kidsCount: participants.kidsCount,
             foodPreferences: participants.foodPreferences,
             allergies: participants.allergies,
+            dietaryMembers: participants.dietaryMembers,
             notes: participants.notes,
           })
           .from(participants)
@@ -161,6 +163,7 @@ export async function inviteRoutes(fastify: FastifyInstance) {
             kidsCount: participant.kidsCount,
             foodPreferences: participant.foodPreferences,
             allergies: participant.allergies,
+            dietaryMembers: participant.dietaryMembers,
             notes: participant.notes,
           },
         }
@@ -196,6 +199,7 @@ export async function inviteRoutes(fastify: FastifyInstance) {
       kidsCount?: number | null
       foodPreferences?: string | null
       allergies?: string | null
+      dietaryMembers?: DietaryMembers | null
       notes?: string | null
       rsvpStatus?: 'confirmed' | 'not_sure'
     }
@@ -289,6 +293,7 @@ export async function inviteRoutes(fastify: FastifyInstance) {
           kidsCount: updated.kidsCount,
           foodPreferences: updated.foodPreferences,
           allergies: updated.allergies,
+          dietaryMembers: updated.dietaryMembers,
           notes: updated.notes,
         }
       } catch (error) {

--- a/src/routes/join-request.route.ts
+++ b/src/routes/join-request.route.ts
@@ -1,6 +1,11 @@
 import { FastifyInstance } from 'fastify'
 import { eq, and } from 'drizzle-orm'
-import { plans, participants, participantJoinRequests } from '../db/schema.js'
+import {
+  plans,
+  participants,
+  participantJoinRequests,
+  DietaryMembers,
+} from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { addParticipantToPlan } from '../services/participant.service.js'
 import { config } from '../config.js'
@@ -22,6 +27,7 @@ interface CreateJoinRequestBody {
   kidsCount?: number
   foodPreferences?: string
   allergies?: string
+  dietaryMembers?: DietaryMembers
   notes?: string
 }
 
@@ -146,6 +152,7 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
             kidsCount: existing.kidsCount,
             foodPreferences: existing.foodPreferences,
             allergies: existing.allergies,
+            dietaryMembers: existing.dietaryMembers,
             notes: existing.notes,
             status: existing.status,
             createdAt: existing.createdAt,
@@ -167,6 +174,7 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
             kidsCount: body.kidsCount ?? null,
             foodPreferences: body.foodPreferences ?? null,
             allergies: body.allergies ?? null,
+            dietaryMembers: body.dietaryMembers ?? null,
             notes: body.notes ?? null,
           })
           .returning()
@@ -229,6 +237,7 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
           kidsCount: created.kidsCount,
           foodPreferences: created.foodPreferences,
           allergies: created.allergies,
+          dietaryMembers: created.dietaryMembers,
           notes: created.notes,
           status: created.status,
           createdAt: created.createdAt,
@@ -367,6 +376,7 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
             kidsCount: joinRequest.kidsCount,
             foodPreferences: joinRequest.foodPreferences,
             allergies: joinRequest.allergies,
+            dietaryMembers: joinRequest.dietaryMembers,
             notes: joinRequest.notes,
             inviteStatus: 'accepted',
           })
@@ -453,6 +463,7 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
           kidsCount: updated.kidsCount,
           foodPreferences: updated.foodPreferences,
           allergies: updated.allergies,
+          dietaryMembers: updated.dietaryMembers,
           notes: updated.notes,
           status: updated.status,
           createdAt: updated.createdAt,

--- a/src/routes/participants.route.ts
+++ b/src/routes/participants.route.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import { FastifyInstance } from 'fastify'
 import { eq } from 'drizzle-orm'
-import { participants, plans } from '../db/schema.js'
+import { participants, plans, DietaryMembers } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { removeParticipantFromAssignments } from '../services/item.service.js'
 import { config } from '../config.js'
@@ -27,6 +27,7 @@ interface CreateParticipantBody {
   kidsCount?: number
   foodPreferences?: string
   allergies?: string
+  dietaryMembers?: DietaryMembers
   notes?: string
 }
 
@@ -42,6 +43,7 @@ interface UpdateParticipantBody {
   kidsCount?: number | null
   foodPreferences?: string | null
   allergies?: string | null
+  dietaryMembers?: DietaryMembers | null
   notes?: string | null
   rsvpStatus?: 'pending' | 'confirmed' | 'not_sure'
 }

--- a/src/schemas/dietary.schema.ts
+++ b/src/schemas/dietary.schema.ts
@@ -1,0 +1,45 @@
+import { DIET_TYPE_VALUES, ALLERGY_TYPE_VALUES } from '../db/schema.js'
+
+export const dietaryMemberSchema = {
+  $id: 'DietaryMember',
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['adult', 'kid'],
+      description: 'Whether this group member is an adult or a kid',
+    },
+    index: {
+      type: 'integer',
+      minimum: 0,
+      description:
+        '0-based index within the member type (adult 0, adult 1, kid 0, etc.)',
+    },
+    diet: {
+      type: 'string',
+      enum: [...DIET_TYPE_VALUES],
+      description: 'Single food preference for this person',
+    },
+    allergies: {
+      type: 'array',
+      items: { type: 'string', enum: [...ALLERGY_TYPE_VALUES] },
+      description:
+        'List of allergies for this person. Use ["none"] or [] for no allergies.',
+    },
+  },
+  required: ['type', 'index', 'diet', 'allergies'],
+} as const
+
+export const dietaryMembersBodySchema = {
+  $id: 'DietaryMembersBody',
+  type: 'object',
+  properties: {
+    members: {
+      type: 'array',
+      items: { $ref: 'DietaryMember#' },
+      description:
+        'Per-person dietary data for each adult/kid in this participant group. Each entry has a type (adult|kid), a 0-based index within that type, a single diet preference, and an allergies list.',
+    },
+  },
+  required: ['members'],
+} as const

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -92,6 +92,10 @@ import {
   internalPlanSummarySchema,
   internalPlansResponseSchema,
 } from './internal.schema.js'
+import {
+  dietaryMemberSchema,
+  dietaryMembersBodySchema,
+} from './dietary.schema.js'
 
 const schemas = [
   errorResponseSchema,
@@ -167,6 +171,8 @@ const schemas = [
   identifyResponseSchema,
   internalPlanSummarySchema,
   internalPlansResponseSchema,
+  dietaryMemberSchema,
+  dietaryMembersBodySchema,
 ]
 
 export function registerSchemas(fastify: FastifyInstance) {
@@ -186,3 +192,4 @@ export * from './join-request.schema.js'
 export * from './expense.schema.js'
 export * from './send-list.schema.js'
 export * from './internal.schema.js'
+export * from './dietary.schema.js'

--- a/src/schemas/invite.schema.ts
+++ b/src/schemas/invite.schema.ts
@@ -78,6 +78,11 @@ export const inviteMyPreferencesSchema = {
     kidsCount: { type: 'integer', nullable: true },
     foodPreferences: { type: 'string', nullable: true },
     allergies: { type: 'string', nullable: true },
+    dietaryMembers: {
+      oneOf: [{ $ref: 'DietaryMembersBody#' }, { type: 'null' }],
+      description:
+        'Per-person dietary preferences for this participant group. Null if not yet set.',
+    },
     notes: { type: 'string', nullable: true },
   },
 } as const
@@ -110,6 +115,11 @@ export const updateInvitePreferencesBodySchema = {
     kidsCount: { type: 'integer', minimum: 0, nullable: true },
     foodPreferences: { type: 'string', nullable: true },
     allergies: { type: 'string', nullable: true },
+    dietaryMembers: {
+      oneOf: [{ $ref: 'DietaryMembersBody#' }, { type: 'null' }],
+      description:
+        'Per-person dietary preferences. Send null to clear. Send the full members array each time — partial updates are not supported.',
+    },
     notes: { type: 'string', nullable: true },
     rsvpStatus: { type: 'string', enum: ['confirmed', 'not_sure'] },
   },
@@ -130,6 +140,10 @@ export const invitePreferencesResponseSchema = {
     kidsCount: { type: 'integer', nullable: true },
     foodPreferences: { type: 'string', nullable: true },
     allergies: { type: 'string', nullable: true },
+    dietaryMembers: {
+      oneOf: [{ $ref: 'DietaryMembersBody#' }, { type: 'null' }],
+      description: 'Per-person dietary preferences after the update.',
+    },
     notes: { type: 'string', nullable: true },
   },
   required: ['participantId', 'role', 'rsvpStatus'],

--- a/src/schemas/join-request.schema.ts
+++ b/src/schemas/join-request.schema.ts
@@ -19,6 +19,11 @@ export const createJoinRequestBodySchema = {
     kidsCount: { type: 'integer', minimum: 0 },
     foodPreferences: { type: 'string' },
     allergies: { type: 'string' },
+    dietaryMembers: {
+      $ref: 'DietaryMembersBody#',
+      description:
+        'Per-person dietary preferences for this join request. Optional — carried through to the participant record on approval.',
+    },
     notes: { type: 'string' },
   },
   required: ['name', 'lastName', 'contactPhone'],
@@ -65,6 +70,11 @@ export const joinRequestSchema = {
     kidsCount: { type: 'integer', nullable: true },
     foodPreferences: { type: 'string', nullable: true },
     allergies: { type: 'string', nullable: true },
+    dietaryMembers: {
+      oneOf: [{ $ref: 'DietaryMembersBody#' }, { type: 'null' }],
+      description:
+        'Per-person dietary preferences carried from the join request.',
+    },
     notes: { type: 'string', nullable: true },
     status: {
       type: 'string',

--- a/src/schemas/participant.schema.ts
+++ b/src/schemas/participant.schema.ts
@@ -26,6 +26,11 @@ export const participantSchema = {
     kidsCount: { type: 'integer', nullable: true },
     foodPreferences: { type: 'string', nullable: true },
     allergies: { type: 'string', nullable: true },
+    dietaryMembers: {
+      oneOf: [{ $ref: 'DietaryMembersBody#' }, { type: 'null' }],
+      description:
+        'Per-person dietary preferences for each adult/kid in this participant group. Replaces the legacy foodPreferences/allergies text fields for new clients.',
+    },
     notes: { type: 'string', nullable: true },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
@@ -73,6 +78,11 @@ export const createParticipantBodySchema = {
     kidsCount: { type: 'integer', minimum: 0 },
     foodPreferences: { type: 'string' },
     allergies: { type: 'string' },
+    dietaryMembers: {
+      $ref: 'DietaryMembersBody#',
+      description:
+        'Per-person dietary preferences. Optional on create — send to populate structured dietary data for the participant group.',
+    },
     notes: { type: 'string' },
   },
   required: ['name', 'lastName', 'contactPhone'],
@@ -100,6 +110,11 @@ export const updateParticipantBodySchema = {
     kidsCount: { type: 'integer', minimum: 0, nullable: true },
     foodPreferences: { type: 'string', nullable: true },
     allergies: { type: 'string', nullable: true },
+    dietaryMembers: {
+      oneOf: [{ $ref: 'DietaryMembersBody#' }, { type: 'null' }],
+      description:
+        'Per-person dietary preferences. Send null to clear. Partial updates are not supported — send the full members array each time.',
+    },
     notes: { type: 'string', nullable: true },
     rsvpStatus: {
       type: 'string',

--- a/src/services/participant.service.ts
+++ b/src/services/participant.service.ts
@@ -1,6 +1,11 @@
 import { eq } from 'drizzle-orm'
 import type { Database } from '../db/index.js'
-import { participants, userDetails, Participant } from '../db/schema.js'
+import {
+  participants,
+  userDetails,
+  Participant,
+  DietaryMembers,
+} from '../db/schema.js'
 import { addParticipantToAllFlaggedItems } from './item.service.js'
 
 export interface AddParticipantData {
@@ -15,6 +20,7 @@ export interface AddParticipantData {
   kidsCount?: number | null
   foodPreferences?: string | null
   allergies?: string | null
+  dietaryMembers?: DietaryMembers | null
   notes?: string | null
   role?: 'participant' | 'viewer'
   inviteToken?: string | null
@@ -59,6 +65,7 @@ export async function addParticipantToPlan(
       kidsCount: data.kidsCount ?? null,
       foodPreferences,
       allergies,
+      dietaryMembers: data.dietaryMembers ?? null,
       notes: data.notes ?? null,
       role: data.role ?? 'participant',
       inviteToken: data.inviteToken ?? null,

--- a/tests/integration/invite.test.ts
+++ b/tests/integration/invite.test.ts
@@ -327,6 +327,76 @@ describe('Invite Route', () => {
       expect(response.json().foodPreferences).toBeNull()
     })
 
+    it('accepts and returns dietaryMembers structured data', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participantList = await seedTestParticipants(plan.planId, 1)
+      const token = participantList[0].inviteToken!
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/invite/${token}/preferences`,
+        payload: {
+          adultsCount: 2,
+          kidsCount: 1,
+          dietaryMembers: {
+            members: [
+              {
+                type: 'adult',
+                index: 0,
+                diet: 'vegetarian',
+                allergies: ['nuts'],
+              },
+              { type: 'adult', index: 1, diet: 'everything', allergies: [] },
+              {
+                type: 'kid',
+                index: 0,
+                diet: 'everything',
+                allergies: ['gluten'],
+              },
+            ],
+          },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.adultsCount).toBe(2)
+      expect(body.kidsCount).toBe(1)
+      expect(body.dietaryMembers).toBeDefined()
+      expect(body.dietaryMembers.members).toHaveLength(3)
+      expect(body.dietaryMembers.members[0].diet).toBe('vegetarian')
+      expect(body.dietaryMembers.members[0].allergies).toEqual(['nuts'])
+      expect(body.dietaryMembers.members[2].type).toBe('kid')
+      expect(body.dietaryMembers.members[2].allergies).toEqual(['gluten'])
+    })
+
+    it('clears dietaryMembers when null is sent', async () => {
+      const [plan] = await seedTestPlans(1)
+      const participantList = await seedTestParticipants(plan.planId, 1)
+      const token = participantList[0].inviteToken!
+
+      await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/invite/${token}/preferences`,
+        payload: {
+          dietaryMembers: {
+            members: [
+              { type: 'adult', index: 0, diet: 'vegan', allergies: [] },
+            ],
+          },
+        },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/invite/${token}/preferences`,
+        payload: { dietaryMembers: null },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().dietaryMembers).toBeNull()
+    })
+
     it('returns 400 when body is empty', async () => {
       const [plan] = await seedTestPlans(1)
       const participants = await seedTestParticipants(plan.planId, 1)
@@ -453,6 +523,7 @@ describe('Invite Route', () => {
       expect(prefs.kidsCount).toBeNull()
       expect(prefs.foodPreferences).toBeNull()
       expect(prefs.allergies).toBeNull()
+      expect(prefs.dietaryMembers).toBeNull()
       expect(prefs.notes).toBeNull()
     })
 

--- a/tests/integration/join-request.test.ts
+++ b/tests/integration/join-request.test.ts
@@ -244,6 +244,41 @@ describe('Join Request Management', () => {
       expect(body.allergies).toBe('peanuts')
     })
 
+    it('carries dietaryMembers from join request to participant on approval', async () => {
+      const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
+      const joinRequest = await seedTestJoinRequests(
+        plan.planId,
+        REQUESTER_USER_ID,
+        {
+          name: 'Jane',
+          lastName: 'Doe',
+          contactPhone: '+15559990000',
+          dietaryMembers: {
+            members: [
+              { type: 'adult', index: 0, diet: 'vegan', allergies: ['nuts'] },
+              { type: 'kid', index: 0, diet: 'everything', allergies: [] },
+            ],
+          },
+        }
+      )
+
+      const ownerToken = await signTestJwt({ sub: OWNER_USER_ID })
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/plans/${plan.planId}/join-requests/${joinRequest.requestId}`,
+        headers: { authorization: `Bearer ${ownerToken}` },
+        payload: { status: 'approved' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const approved = response.json()
+      expect(approved.dietaryMembers).toBeDefined()
+      expect(approved.dietaryMembers.members).toHaveLength(2)
+      expect(approved.dietaryMembers.members[0].diet).toBe('vegan')
+      expect(approved.dietaryMembers.members[0].allergies).toEqual(['nuts'])
+      expect(approved.dietaryMembers.members[1].type).toBe('kid')
+    })
+
     it('returns 409 for already-approved request', async () => {
       const { plan } = await createPlanWithOwner(db, OWNER_USER_ID)
       const joinRequest = await seedTestJoinRequests(

--- a/tests/integration/participants.test.ts
+++ b/tests/integration/participants.test.ts
@@ -420,6 +420,70 @@ describe('Participants Route', () => {
       expect(updated.contactEmail).toBe('new@example.com')
     })
 
+    it('updates dietaryMembers and returns structured dietary data', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const [participant] = await seedTestParticipants(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/participants/${participant.participantId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          dietaryMembers: {
+            members: [
+              {
+                type: 'adult',
+                index: 0,
+                diet: 'vegetarian',
+                allergies: ['nuts'],
+              },
+              { type: 'kid', index: 0, diet: 'everything', allergies: [] },
+            ],
+          },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const updated = response.json()
+      expect(updated.dietaryMembers).toBeDefined()
+      expect(updated.dietaryMembers.members).toHaveLength(2)
+      expect(updated.dietaryMembers.members[0].diet).toBe('vegetarian')
+      expect(updated.dietaryMembers.members[0].allergies).toEqual(['nuts'])
+      expect(updated.dietaryMembers.members[1].type).toBe('kid')
+    })
+
+    it('clears dietaryMembers when null is sent', async () => {
+      const [plan] = await seedTestPlans(1, {
+        createdByUserId: TEST_USER_ID,
+      })
+      const [participant] = await seedTestParticipants(plan.planId, 1)
+
+      await app.inject({
+        method: 'PATCH',
+        url: `/participants/${participant.participantId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          dietaryMembers: {
+            members: [
+              { type: 'adult', index: 0, diet: 'vegan', allergies: [] },
+            ],
+          },
+        },
+      })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/participants/${participant.participantId}`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { dietaryMembers: null },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().dietaryMembers).toBeNull()
+    })
+
     it('sets nullable fields to null', async () => {
       const [plan] = await seedTestPlans(1, {
         createdByUserId: TEST_USER_ID,


### PR DESCRIPTION
…s JSONB)

- Add DietType, AllergyType, DietaryMember, DietaryMembers types to schema.ts
- Add dietaryMembers jsonb column to participants and participant_join_requests tables
- Generate migration drizzle/0022_flat_golden_guardian.sql
- New src/schemas/dietary.schema.ts with DietaryMember + DietaryMembersBody schemas
- Update Participant, CreateParticipantBody, UpdateParticipantBody schemas
- Update InviteMyPreferences, UpdateInvitePreferencesBody, InvitePreferencesResponse schemas
- Update CreateJoinRequestBody, JoinRequest schemas
- Update route interfaces and response shapes in participants, invite, join-request routes
- Update AddParticipantData in participant.service.ts to carry dietaryMembers
- Add 5 new integration tests covering PATCH and clear for dietaryMembers
- Regenerate docs/openapi.json

Backward compatible — existing foodPreferences/allergies text columns untouched.

Closes #154