### PR TITLE
feat: log prompt text, raw response, error type and finish reason in …

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3033,6 +3033,11 @@
             "nullable": true,
             "description": "Character count of the assembled prompt"
           },
+          "promptText": {
+            "type": "string",
+            "nullable": true,
+            "description": "Full prompt string sent to the model"
+          },
           "resultCount": {
             "type": "integer",
             "nullable": true,
@@ -3042,6 +3047,21 @@
             "type": "string",
             "nullable": true,
             "description": "Error message when status is error"
+          },
+          "errorType": {
+            "type": "string",
+            "nullable": true,
+            "description": "SDK error class name (e.g. AI_NoObjectGeneratedError, AI_APICallError); null on success or partial"
+          },
+          "finishReason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Model finish reason from the provider SDK — stop, length, content-filter, error, or unknown"
+          },
+          "rawResponseText": {
+            "type": "string",
+            "nullable": true,
+            "description": "Raw model output: serialised JSON array on success, raw text on partial/error (error.text), null when unavailable"
           },
           "metadata": {
             "type": "object",

--- a/drizzle/0027_worthless_madame_hydra.sql
+++ b/drizzle/0027_worthless_madame_hydra.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "ai_usage_logs" ADD COLUMN "prompt_text" text;--> statement-breakpoint
+ALTER TABLE "ai_usage_logs" ADD COLUMN "error_type" text;--> statement-breakpoint
+ALTER TABLE "ai_usage_logs" ADD COLUMN "finish_reason" varchar(50);--> statement-breakpoint
+ALTER TABLE "ai_usage_logs" ADD COLUMN "raw_response_text" text;

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1445 @@
+{
+  "id": "85e2e14d-8b20-4859-8d7e-0e273568a48b",
+  "prevId": "e37e2424-7bdd-42c7-95f0-73f956d7faba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "ai_feature_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_usage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_length": {
+          "name": "prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_text": {
+          "name": "raw_response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_plan_id_plans_plan_id_fk": {
+          "name": "ai_usage_logs_plan_id_plans_plan_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignment_status_list": {
+          "name": "assignment_status_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_expenses": {
+      "name": "participant_expenses",
+      "schema": "",
+      "columns": {
+        "expense_id": {
+          "name": "expense_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_expenses_participant_id_participants_participant_id_fk": {
+          "name": "participant_expenses_participant_id_participants_participant_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_expenses_plan_id_plans_plan_id_fk": {
+          "name": "participant_expenses_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_members": {
+          "name": "dietary_members",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_members": {
+          "name": "dietary_members",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lang": {
+          "name": "default_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_adults": {
+          "name": "estimated_adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_kids": {
+          "name": "estimated_kids",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generation_count": {
+          "name": "ai_generation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_lang": {
+          "name": "preferred_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_idx": {
+          "name": "users_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_notifications": {
+      "name": "whatsapp_notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_phone": {
+          "name": "recipient_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_participant_id": {
+          "name": "recipient_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "whatsapp_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "whatsapp_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "whatsapp_notifications_plan_id_plans_plan_id_fk": {
+          "name": "whatsapp_notifications_plan_id_plans_plan_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk": {
+          "name": "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "recipient_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_feature_type": {
+      "name": "ai_feature_type",
+      "schema": "public",
+      "values": [
+        "item_suggestions"
+      ]
+    },
+    "public.ai_usage_status": {
+      "name": "ai_usage_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "partial",
+        "error"
+      ]
+    },
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "group_equipment",
+        "personal_equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    },
+    "public.whatsapp_notification_status": {
+      "name": "whatsapp_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed"
+      ]
+    },
+    "public.whatsapp_notification_type": {
+      "name": "whatsapp_notification_type",
+      "schema": "public",
+      "values": [
+        "invitation_sent",
+        "join_request_pending",
+        "join_request_approved",
+        "join_request_rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1774802793244,
       "tag": "0026_users_table",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1774885248790,
+      "tag": "0027_worthless_madame_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -413,8 +413,12 @@ export const aiUsageLogs = pgTable('ai_usage_logs', {
   estimatedCost: numeric('estimated_cost', { precision: 10, scale: 6 }),
   durationMs: integer('duration_ms').notNull(),
   promptLength: integer('prompt_length'),
+  promptText: text('prompt_text'),
   resultCount: integer('result_count'),
   errorMessage: text('error_message'),
+  errorType: text('error_type'),
+  finishReason: varchar('finish_reason', { length: 50 }),
+  rawResponseText: text('raw_response_text'),
   metadata: jsonb('metadata').$type<Record<string, unknown>>(),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()

--- a/src/routes/ai-suggestions.route.ts
+++ b/src/routes/ai-suggestions.route.ts
@@ -124,50 +124,10 @@ export async function aiSuggestionsRoutes(fastify: FastifyInstance) {
 
         const model = resolveLanguageModel(config.aiProvider, lang)
 
-        try {
-          const result = await generateItemSuggestions(model, planContext, lang)
-          const durationMs = Date.now() - startMs
+        const result = await generateItemSuggestions(model, planContext, lang)
+        const durationMs = Date.now() - startMs
 
-          await fastify.db
-            .update(plans)
-            .set({ aiGenerationCount: sql`${plans.aiGenerationCount} + 1` })
-            .where(eq(plans.planId, planId))
-
-          recordAiUsage(fastify.db, {
-            featureType: 'item_suggestions',
-            planId,
-            userId: request.user?.id,
-            provider: config.aiProvider,
-            modelId: model.modelId,
-            lang,
-            status: result.status,
-            inputTokens: result.usage.inputTokens,
-            outputTokens: result.usage.outputTokens,
-            totalTokens: result.usage.totalTokens,
-            durationMs,
-            promptLength: result.prompt.length,
-            resultCount: result.suggestions.length,
-            metadata: { planTitle: plan.title },
-          })
-
-          const durationSec = (durationMs / 1000).toFixed(1)
-          request.log.info(
-            {
-              planId,
-              lang,
-              modelId: model.modelId,
-              promptLength: result.prompt.length,
-              suggestionsCount: result.suggestions.length,
-              usage: result.usage,
-              durationSec,
-            },
-            `AI item suggestions generated in ${durationSec}s — ${result.suggestions.length} items, ${result.usage.totalTokens ?? '?'} tokens (${model.modelId})`
-          )
-
-          return { suggestions: result.suggestions }
-        } catch (error) {
-          const durationMs = Date.now() - startMs
-
+        if (result.status === 'error') {
           recordAiUsage(fastify.db, {
             featureType: 'item_suggestions',
             planId,
@@ -176,31 +136,75 @@ export async function aiSuggestionsRoutes(fastify: FastifyInstance) {
             modelId: model.modelId,
             lang,
             status: 'error',
+            inputTokens: result.usage.inputTokens,
+            outputTokens: result.usage.outputTokens,
+            totalTokens: result.usage.totalTokens,
             durationMs,
-            promptLength: undefined,
-            errorMessage:
-              error instanceof Error ? error.message : String(error),
+            promptLength: result.prompt.length,
+            promptText: result.prompt,
+            rawResponseText: result.rawResponseText,
+            errorType: result.errorType,
+            errorMessage: result.errorMessage,
             metadata: { planTitle: plan.title },
           })
 
           request.log.error(
-            { err: error, planId },
+            {
+              planId,
+              errorType: result.errorType,
+              errorMessage: result.errorMessage,
+            },
             'Failed to generate AI suggestions'
           )
 
-          const isAiError =
-            error instanceof Error && error.name?.startsWith('AI_')
-
-          if (isAiError) {
-            return reply.status(503).send({
-              message: 'AI service temporarily unavailable',
-            })
-          }
-
-          return reply.status(500).send({
-            message: 'Failed to generate suggestions',
+          const isAiError = result.errorType?.startsWith('AI_')
+          return reply.status(isAiError ? 503 : 500).send({
+            message: isAiError
+              ? 'AI service temporarily unavailable'
+              : 'Failed to generate suggestions',
           })
         }
+
+        await fastify.db
+          .update(plans)
+          .set({ aiGenerationCount: sql`${plans.aiGenerationCount} + 1` })
+          .where(eq(plans.planId, planId))
+
+        recordAiUsage(fastify.db, {
+          featureType: 'item_suggestions',
+          planId,
+          userId: request.user?.id,
+          provider: config.aiProvider,
+          modelId: model.modelId,
+          lang,
+          status: result.status,
+          inputTokens: result.usage.inputTokens,
+          outputTokens: result.usage.outputTokens,
+          totalTokens: result.usage.totalTokens,
+          durationMs,
+          promptLength: result.prompt.length,
+          promptText: result.prompt,
+          rawResponseText: result.rawResponseText,
+          finishReason: result.finishReason,
+          resultCount: result.suggestions.length,
+          metadata: { planTitle: plan.title },
+        })
+
+        const durationSec = (durationMs / 1000).toFixed(1)
+        request.log.info(
+          {
+            planId,
+            lang,
+            modelId: model.modelId,
+            promptLength: result.prompt.length,
+            suggestionsCount: result.suggestions.length,
+            usage: result.usage,
+            durationSec,
+          },
+          `AI item suggestions generated in ${durationSec}s — ${result.suggestions.length} items, ${result.usage.totalTokens ?? '?'} tokens (${model.modelId})`
+        )
+
+        return { suggestions: result.suggestions }
       } catch (error) {
         request.log.error(
           { err: error, planId },

--- a/src/schemas/ai-usage.schema.ts
+++ b/src/schemas/ai-usage.schema.ts
@@ -75,6 +75,11 @@ export const aiUsageLogSchema = {
       nullable: true,
       description: 'Character count of the assembled prompt',
     },
+    promptText: {
+      type: 'string',
+      nullable: true,
+      description: 'Full prompt string sent to the model',
+    },
     resultCount: {
       type: 'integer',
       nullable: true,
@@ -84,6 +89,24 @@ export const aiUsageLogSchema = {
       type: 'string',
       nullable: true,
       description: 'Error message when status is error',
+    },
+    errorType: {
+      type: 'string',
+      nullable: true,
+      description:
+        'SDK error class name (e.g. AI_NoObjectGeneratedError, AI_APICallError); null on success or partial',
+    },
+    finishReason: {
+      type: 'string',
+      nullable: true,
+      description:
+        'Model finish reason from the provider SDK — stop, length, content-filter, error, or unknown',
+    },
+    rawResponseText: {
+      type: 'string',
+      nullable: true,
+      description:
+        'Raw model output: serialised JSON array on success, raw text on partial/error (error.text), null when unavailable',
     },
     metadata: {
       type: 'object',

--- a/src/services/ai/item-suggestions/generate.ts
+++ b/src/services/ai/item-suggestions/generate.ts
@@ -5,16 +5,42 @@ import { buildItemSuggestionsPrompt } from './build-prompt.js'
 import type { PlanForAiContext } from '../plan-context-formatters.js'
 import type { SupportedAiLang } from './prompt-templates.js'
 
-export interface ItemSuggestionsResult {
-  suggestions: ItemSuggestion[]
-  prompt: string
-  status: 'success' | 'partial'
-  usage: {
-    inputTokens: number | undefined
-    outputTokens: number | undefined
-    totalTokens: number | undefined
-  }
+interface TokenUsage {
+  inputTokens: number | undefined
+  outputTokens: number | undefined
+  totalTokens: number | undefined
 }
+
+interface ItemSuggestionsBase {
+  prompt: string
+  usage: TokenUsage
+  finishReason?: string
+}
+
+export interface ItemSuggestionsSuccess extends ItemSuggestionsBase {
+  status: 'success'
+  suggestions: ItemSuggestion[]
+  rawResponseText: string
+}
+
+export interface ItemSuggestionsPartial extends ItemSuggestionsBase {
+  status: 'partial'
+  suggestions: ItemSuggestion[]
+  rawResponseText: string
+}
+
+export interface ItemSuggestionsError extends ItemSuggestionsBase {
+  status: 'error'
+  suggestions: []
+  rawResponseText: string | null
+  errorType: string
+  errorMessage: string
+}
+
+export type ItemSuggestionsResult =
+  | ItemSuggestionsSuccess
+  | ItemSuggestionsPartial
+  | ItemSuggestionsError
 
 function salvageFromRawText(text: string): ItemSuggestion[] {
   try {
@@ -39,7 +65,11 @@ export async function generateItemSuggestions(
   const prompt = buildItemSuggestionsPrompt(plan, lang)
 
   try {
-    const { object: suggestions, usage } = await generateObject({
+    const {
+      object: suggestions,
+      usage,
+      finishReason,
+    } = await generateObject({
       model,
       output: 'array',
       schema: itemSuggestionSchema,
@@ -47,9 +77,11 @@ export async function generateItemSuggestions(
     })
 
     return {
+      status: 'success',
       suggestions,
       prompt,
-      status: 'success' as const,
+      rawResponseText: JSON.stringify(suggestions),
+      finishReason,
       usage: {
         inputTokens: usage.inputTokens,
         outputTokens: usage.outputTokens,
@@ -61,9 +93,10 @@ export async function generateItemSuggestions(
       const salvaged = salvageFromRawText(error.text)
       if (salvaged.length > 0) {
         return {
+          status: 'partial',
           suggestions: salvaged,
           prompt,
-          status: 'partial' as const,
+          rawResponseText: error.text,
           usage: {
             inputTokens: error.usage?.inputTokens,
             outputTokens: error.usage?.outputTokens,
@@ -72,6 +105,28 @@ export async function generateItemSuggestions(
         }
       }
     }
-    throw error
+
+    const err = error instanceof Error ? error : new Error(String(error))
+    return {
+      status: 'error',
+      suggestions: [],
+      prompt,
+      rawResponseText: NoObjectGeneratedError.isInstance(error)
+        ? (error.text ?? null)
+        : null,
+      errorType: err.name,
+      errorMessage: err.message,
+      usage: NoObjectGeneratedError.isInstance(error)
+        ? {
+            inputTokens: error.usage?.inputTokens,
+            outputTokens: error.usage?.outputTokens,
+            totalTokens: error.usage?.totalTokens,
+          }
+        : {
+            inputTokens: undefined,
+            outputTokens: undefined,
+            totalTokens: undefined,
+          },
+    }
   }
 }

--- a/src/services/ai/usage-tracking.ts
+++ b/src/services/ai/usage-tracking.ts
@@ -14,8 +14,12 @@ export interface AiUsageRecord {
   totalTokens?: number
   durationMs: number
   promptLength?: number
+  promptText?: string
   resultCount?: number
   errorMessage?: string
+  errorType?: string
+  finishReason?: string
+  rawResponseText?: string | null
   metadata?: Record<string, unknown>
 }
 
@@ -70,8 +74,12 @@ export async function recordAiUsage(
       estimatedCost: cost?.toFixed(6) ?? null,
       durationMs: record.durationMs,
       promptLength: record.promptLength ?? null,
+      promptText: record.promptText ?? null,
       resultCount: record.resultCount ?? null,
       errorMessage: record.errorMessage ?? null,
+      errorType: record.errorType ?? null,
+      finishReason: record.finishReason ?? null,
+      rawResponseText: record.rawResponseText ?? null,
       metadata: record.metadata ?? null,
     })
   } catch (err) {

--- a/tests/unit/ai-suggestions.route.test.ts
+++ b/tests/unit/ai-suggestions.route.test.ts
@@ -215,7 +215,7 @@ describe('AI Suggestions Route', () => {
     expect(mockDb.update).toHaveBeenCalled()
   })
 
-  it('records AI usage on successful generation', async () => {
+  it('records AI usage on successful generation including promptText and rawResponseText', async () => {
     mockPlanAccessAllowed(mockDb)
     mockPlanDataQuery(mockDb, FAKE_PLAN_ROW)
     mockParticipantDietaryQuery(mockDb, [])
@@ -238,6 +238,43 @@ describe('AI Suggestions Route', () => {
         lang: 'en',
         resultCount: 3,
         metadata: { planTitle: 'Beach trip' },
+        promptText: expect.any(String),
+        rawResponseText: expect.any(String),
+        finishReason: 'stop',
+      })
+    )
+  })
+
+  it('records AI usage on partial generation with rawResponseText and promptText', async () => {
+    mockPlanAccessAllowed(mockDb)
+    mockPlanDataQuery(mockDb, FAKE_PLAN_ROW)
+    mockParticipantDietaryQuery(mockDb, [])
+
+    generateSpy.mockResolvedValueOnce({
+      status: 'partial' as const,
+      suggestions: [FAKE_SUGGESTIONS[0]],
+      prompt: 'partial prompt text',
+      rawResponseText: 'raw partial output from model',
+      finishReason: 'length',
+      usage: { inputTokens: 80, outputTokens: 40, totalTokens: 120 },
+    })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${VALID_PLAN_ID}/ai-suggestions`,
+      headers: AUTH_HEADERS,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().suggestions).toHaveLength(1)
+    expect(recordUsageSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: 'partial',
+        promptText: 'partial prompt text',
+        rawResponseText: 'raw partial output from model',
+        finishReason: 'length',
+        resultCount: 1,
       })
     )
   })
@@ -302,37 +339,26 @@ describe('AI Suggestions Route', () => {
     }
   })
 
-  it('returns 503 when AI model throws AI-prefixed error and records error usage', async () => {
-    const failModel = new MockLanguageModelV2({
-      doGenerate: () => {
-        const err = new Error('Rate limit exceeded')
-        err.name = 'AI_APICallError'
-        throw err
+  it('returns 503 when AI returns error with AI-prefixed errorType and records error usage with promptText', async () => {
+    mockPlanAccessAllowed(mockDb)
+    mockPlanDataQuery(mockDb, FAKE_PLAN_ROW)
+    mockParticipantDietaryQuery(mockDb, [])
+
+    generateSpy.mockResolvedValueOnce({
+      status: 'error' as const,
+      suggestions: [],
+      prompt: 'the prompt that was sent',
+      rawResponseText: null,
+      errorType: 'AI_APICallError',
+      errorMessage: 'Rate limit exceeded',
+      usage: {
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
       },
     })
 
-    vi.mocked(modelProvider.resolveLanguageModel).mockReturnValueOnce(failModel)
-
-    const failDb = createMockDb()
-    mockAiGenerationIncrement(failDb)
-    const failApp = Fastify({ logger: false })
-    failApp.decorate('db', failDb)
-    failApp.decorate('aiModel', failModel)
-    failApp.decorateRequest('user', null)
-    failApp.decorateRequest('sessionId', null)
-    failApp.addHook('onRequest', async (request) => {
-      if (request.headers.authorization?.startsWith('Bearer ')) {
-        request.user = FAKE_USER
-      }
-    })
-    registerSchemas(failApp)
-    await failApp.register(aiSuggestionsRoutes)
-
-    mockPlanAccessAllowed(failDb)
-    mockPlanDataQuery(failDb, FAKE_PLAN_ROW)
-    mockParticipantDietaryQuery(failDb, [])
-
-    const response = await failApp.inject({
+    const response = await app.inject({
       method: 'POST',
       url: `/plans/${VALID_PLAN_ID}/ai-suggestions`,
       headers: AUTH_HEADERS,
@@ -340,16 +366,47 @@ describe('AI Suggestions Route', () => {
 
     expect(response.statusCode).toBe(503)
     expect(response.json().message).toContain('AI service')
-    expect(failDb.update).not.toHaveBeenCalled()
+    expect(mockDb.update).not.toHaveBeenCalled()
     expect(recordUsageSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         featureType: 'item_suggestions',
         status: 'error',
+        errorType: 'AI_APICallError',
         errorMessage: 'Rate limit exceeded',
+        promptText: 'the prompt that was sent',
+        rawResponseText: null,
       })
     )
-    await failApp.close()
+  })
+
+  it('returns 500 when AI returns error with non-AI-prefixed errorType', async () => {
+    mockPlanAccessAllowed(mockDb)
+    mockPlanDataQuery(mockDb, FAKE_PLAN_ROW)
+    mockParticipantDietaryQuery(mockDb, [])
+
+    generateSpy.mockResolvedValueOnce({
+      status: 'error' as const,
+      suggestions: [],
+      prompt: 'the prompt',
+      rawResponseText: null,
+      errorType: 'Error',
+      errorMessage: 'Something unexpected',
+      usage: {
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      },
+    })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/plans/${VALID_PLAN_ID}/ai-suggestions`,
+      headers: AUTH_HEADERS,
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(mockDb.update).not.toHaveBeenCalled()
   })
 
   it('returns 500 when non-AI error occurs', async () => {

--- a/tests/unit/ai/item-suggestions/generate.test.ts
+++ b/tests/unit/ai/item-suggestions/generate.test.ts
@@ -110,14 +110,31 @@ describe('generateItemSuggestions', () => {
     })
   })
 
+  it('returns status success', async () => {
+    const model = createMockModel(fakeSuggestions)
+    const result = await generateItemSuggestions(model, basePlan)
+    expect(result.status).toBe('success')
+  })
+
+  it('returns finishReason from the model', async () => {
+    const model = createMockModel(fakeSuggestions)
+    const result = await generateItemSuggestions(model, basePlan)
+    expect(result.finishReason).toBe('stop')
+  })
+
+  it('returns rawResponseText as serialised JSON of suggestions on success', async () => {
+    const model = createMockModel(fakeSuggestions)
+    const result = await generateItemSuggestions(model, basePlan)
+    expect(result.rawResponseText).toBe(JSON.stringify(result.suggestions))
+  })
+
   it('returns empty array when model returns empty array', async () => {
     const model = createMockModel([])
     const result = await generateItemSuggestions(model, basePlan)
-
     expect(result.suggestions).toEqual([])
   })
 
-  it('throws when model returns invalid JSON', async () => {
+  it('returns status error (not throws) when model returns invalid JSON', async () => {
     const model = new MockLanguageModelV2({
       doGenerate: {
         content: [{ type: 'text' as const, text: 'not valid json at all' }],
@@ -127,7 +144,12 @@ describe('generateItemSuggestions', () => {
       },
     })
 
-    await expect(generateItemSuggestions(model, basePlan)).rejects.toThrow()
+    const result = await generateItemSuggestions(model, basePlan)
+    expect(result.status).toBe('error')
+    if (result.status === 'error') {
+      expect(result.prompt).toContain('Summer camping')
+      expect(result.suggestions).toEqual([])
+    }
   })
 
   it('accepts decimal quantities (e.g. 0.5 kg cheese)', async () => {
@@ -143,22 +165,26 @@ describe('generateItemSuggestions', () => {
     expect(result.suggestions[1].quantity).toBe(1.5)
   })
 
-  it('throws when model returns items with invalid category', async () => {
+  it('returns status error (not throws) when model returns items with invalid category', async () => {
     const badItems = [{ ...fakeSuggestions[0], category: 'invalid_category' }]
     const model = createMockModel(badItems)
-
-    await expect(generateItemSuggestions(model, basePlan)).rejects.toThrow()
+    const result = await generateItemSuggestions(model, basePlan)
+    expect(result.status).toBe('error')
   })
 
-  it('throws when model throws an error', async () => {
+  it('returns status error with promptText when model throws', async () => {
     const model = new MockLanguageModelV2({
       doGenerate: () => {
         throw new Error('API rate limit exceeded')
       },
     })
 
-    await expect(generateItemSuggestions(model, basePlan)).rejects.toThrow(
-      'API rate limit exceeded'
-    )
+    const result = await generateItemSuggestions(model, basePlan)
+    expect(result.status).toBe('error')
+    if (result.status === 'error') {
+      expect(result.errorMessage).toBe('API rate limit exceeded')
+      expect(result.prompt).toContain('Summer camping')
+      expect(result.suggestions).toEqual([])
+    }
   })
 })

--- a/tests/unit/ai/usage-tracking.test.ts
+++ b/tests/unit/ai/usage-tracking.test.ts
@@ -117,6 +117,60 @@ describe('recordAiUsage', () => {
     )
   })
 
+  it('persists promptText and rawResponseText when provided', async () => {
+    const valuesMock = vi.fn().mockResolvedValue(undefined)
+    const mockDb = {
+      insert: vi.fn().mockReturnValue({ values: valuesMock }),
+    }
+
+    await recordAiUsage(mockDb as never, {
+      featureType: 'item_suggestions',
+      provider: 'anthropic',
+      modelId: 'claude-haiku-4-5-20251001',
+      status: 'success',
+      durationMs: 3000,
+      promptText: 'Pack items for beach trip...',
+      rawResponseText: '[{"name":"Sunscreen"}]',
+      finishReason: 'stop',
+    })
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptText: 'Pack items for beach trip...',
+        rawResponseText: '[{"name":"Sunscreen"}]',
+        finishReason: 'stop',
+        errorType: null,
+      })
+    )
+  })
+
+  it('persists errorType and defaults new fields to null when absent', async () => {
+    const valuesMock = vi.fn().mockResolvedValue(undefined)
+    const mockDb = {
+      insert: vi.fn().mockReturnValue({ values: valuesMock }),
+    }
+
+    await recordAiUsage(mockDb as never, {
+      featureType: 'item_suggestions',
+      provider: 'anthropic',
+      modelId: 'claude-haiku-4-5-20251001',
+      status: 'error',
+      durationMs: 1000,
+      promptText: 'Pack items...',
+      errorType: 'AI_NoObjectGeneratedError',
+      errorMessage: 'No object generated',
+    })
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptText: 'Pack items...',
+        errorType: 'AI_NoObjectGeneratedError',
+        rawResponseText: null,
+        finishReason: null,
+      })
+    )
+  })
+
   it('does not throw when db.insert fails', async () => {
     const mockDb = {
       insert: vi.fn().mockReturnValue({


### PR DESCRIPTION
…ai_usage_logs

Add four columns (prompt_text, raw_response_text, error_type, finish_reason) to ai_usage_logs so every row captures the full model input/output and enough context to debug partial and error cases.

Refactor generateItemSuggestions to return a discriminated union (success | partial | error) instead of throwing, ensuring prompt text is always persisted regardless of outcome. Route handler now checks result.status instead of try/catch for AI errors. Tests updated and extended to cover all three result variants and the new fields. Migration 0027 adds the four columns.

Made-with: Cursor