### PR TITLE
feat: plan tag taxonomy API (issue #186)

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -40,6 +40,7 @@ Do NOT scan the entire codebase upfront - only look at files directly related to
 
 Always do the following before committing:
 
+0. **Branch check (MANDATORY FIRST STEP):** Run `git branch --show-current`. If you are on `main`, STOP. Stash any changes (`git stash`), create a feature branch (`git checkout -b feat/<slug>`), then pop the stash (`git stash pop`) before doing anything else. **NEVER commit directly to `main`** — all work ships via feature branch + PR per `../chillist-docs/rules/common.md`.
 1. Run through the review checklist (`.cursor/rules/review.mdc`) — verify route→service delegation, test layering, and rule compliance
 2. Pull main and merge: `git fetch origin main && git merge origin/main` (resolve conflicts if any)
 3. Run `npm run openapi:generate` to regenerate the OpenAPI spec

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3791,6 +3791,221 @@
           "summary"
         ],
         "title": "ChatbotAiUsageResponse"
+      },
+      "def-99": {
+        "type": "object",
+        "description": "Full 3-tier plan tag taxonomy",
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "Taxonomy version string, e.g. \"1.2\""
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable description of this taxonomy version"
+          },
+          "tiers": {
+            "type": "object",
+            "properties": {
+              "tier1": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "UI label for the tier-1 question"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Tier key identifier, e.g. \"plan_type\""
+                  },
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique tier-1 option id, e.g. \"camping\""
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "emoji": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "label",
+                        "emoji"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "label",
+                  "key",
+                  "options"
+                ]
+              },
+              "tier2": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "UI label for the tier-2 question"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Tier key identifier, e.g. \"logistics\""
+                  },
+                  "conditional_on": {
+                    "type": "string",
+                    "description": "The tier key this tier depends on, e.g. \"tier1\""
+                  },
+                  "options_by_parent": {
+                    "type": "object",
+                    "description": "Map from tier-1 option id to tier-2 option block (options, mutex_groups, cross_group_rules)",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "label"
+                            ]
+                          }
+                        },
+                        "mutex_groups": {
+                          "type": "array",
+                          "description": "Groups of mutually exclusive option ids — selecting one deselects the others in the same group",
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "cross_group_rules": {
+                          "type": "array",
+                          "description": "Rules that disable or deselect options across mutex groups when a trigger option is selected",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "trigger": {
+                                "type": "string",
+                                "description": "Option id that activates this rule"
+                              },
+                              "disable": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Option ids to disable when trigger is selected"
+                              },
+                              "deselect": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Option ids to deselect when trigger is selected"
+                              },
+                              "disable_tooltip": {
+                                "type": "string",
+                                "description": "Tooltip shown on disabled options"
+                              }
+                            },
+                            "required": [
+                              "trigger"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "options",
+                        "mutex_groups",
+                        "cross_group_rules"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "label",
+                  "key",
+                  "conditional_on",
+                  "options_by_parent"
+                ]
+              },
+              "tier3": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "UI label for the tier-3 question"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Tier key identifier, e.g. \"specifics\""
+                  },
+                  "conditional_on": {
+                    "type": "string",
+                    "description": "The tier key this tier depends on, e.g. \"tier2\""
+                  },
+                  "options_by_parent": {
+                    "type": "object",
+                    "description": "Map from tier-2 option id to array of tier-3 options",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "label"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "label",
+                  "key",
+                  "conditional_on",
+                  "options_by_parent"
+                ]
+              }
+            },
+            "required": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ]
+          }
+        },
+        "required": [
+          "version",
+          "tiers"
+        ],
+        "title": "PlanTagsResponse"
       }
     }
   },
@@ -7497,6 +7712,61 @@
         }
       }
     },
+    "/plan-tags": {
+      "get": {
+        "summary": "Get plan tag taxonomy",
+        "tags": [
+          "plan-tags"
+        ],
+        "description": "Returns the full 3-tier plan tag taxonomy (plan types, logistics, specifics) used by the plan creation wizard. Response matches the structure expected by PlanTagWizard and tag-utils on the frontend.",
+        "responses": {
+          "200": {
+            "description": "Full tag taxonomy with version, tier labels, and all options",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Full tag taxonomy with version, tier labels, and all options",
+                  "$ref": "#/components/schemas/def-99"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required — JWT token missing or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Authentication required — JWT token missing or invalid",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No tag taxonomy found in the database",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "No tag taxonomy found in the database",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Internal server error",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/internal/auth/identify": {
       "post": {
         "summary": "Resolve a WhatsApp phone number to a Chillist user",
@@ -7760,6 +8030,61 @@
               "application/json": {
                 "schema": {
                   "description": "Unexpected error while updating item",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/internal/plan-tags": {
+      "get": {
+        "summary": "Get plan tag taxonomy for chatbot",
+        "tags": [
+          "internal"
+        ],
+        "description": "Returns the full 3-tier plan tag taxonomy. Requires x-service-key header. Does not require x-user-id as the taxonomy is global reference data, not user-specific.",
+        "responses": {
+          "200": {
+            "description": "Full tag taxonomy with version, tier labels, and all options",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Full tag taxonomy with version, tier labels, and all options",
+                  "$ref": "#/components/schemas/def-99"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-service-key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Missing or invalid x-service-key",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No tag taxonomy found in the database",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "No tag taxonomy found in the database",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error while loading plan tags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unexpected error while loading plan tags",
                   "$ref": "#/components/schemas/def-0"
                 }
               }

--- a/drizzle/0032_plan_tag_tables.sql
+++ b/drizzle/0032_plan_tag_tables.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS "plan_tag_versions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"version" varchar(20) NOT NULL,
+	"description" text,
+	"tier_labels" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "plan_tag_versions_version_unique" UNIQUE("version")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "plan_tag_options" (
+	"id" text PRIMARY KEY NOT NULL,
+	"version_id" uuid NOT NULL,
+	"tier" smallint NOT NULL,
+	"parent_id" text,
+	"label" text NOT NULL,
+	"emoji" text,
+	"sort_order" smallint DEFAULT 0 NOT NULL,
+	"mutex_group" text,
+	"cross_group_rules" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "plan_tag_options" ADD CONSTRAINT "plan_tag_options_version_id_fk" FOREIGN KEY ("version_id") REFERENCES "public"."plan_tag_versions"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "plan_tag_options" ADD CONSTRAINT "plan_tag_options_parent_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."plan_tag_options"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "plan_tag_options_version_tier_idx" ON "plan_tag_options" USING btree ("version_id","tier");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "plan_tag_options_parent_idx" ON "plan_tag_options" USING btree ("parent_id");

--- a/drizzle/meta/0032_snapshot.json
+++ b/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,1880 @@
+{
+  "id": "20205e8f-b5f9-4d7c-b8a5-eafd31b74cc4",
+  "prevId": "85e2e14d-8b20-4859-8d7e-0e273568a48b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "ai_feature_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_usage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_length": {
+          "name": "prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_text": {
+          "name": "raw_response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_plan_id_plans_plan_id_fk": {
+          "name": "ai_usage_logs_plan_id_plans_plan_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chatbot_ai_usage": {
+      "name": "chatbot_ai_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_index": {
+          "name": "message_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guest_profiles": {
+      "name": "guest_profiles",
+      "schema": "",
+      "columns": {
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_changes": {
+      "name": "item_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "item_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_participant_id": {
+          "name": "changed_by_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_changes_item_id_items_item_id_fk": {
+          "name": "item_changes_item_id_items_item_id_fk",
+          "tableFrom": "item_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "item_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pcs'"
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_all_participants": {
+          "name": "is_all_participants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignment_status_list": {
+          "name": "assignment_status_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_plan_id_plans_plan_id_fk": {
+          "name": "items_plan_id_plans_plan_id_fk",
+          "tableFrom": "items",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_expenses": {
+      "name": "participant_expenses",
+      "schema": "",
+      "columns": {
+        "expense_id": {
+          "name": "expense_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_expenses_participant_id_participants_participant_id_fk": {
+          "name": "participant_expenses_participant_id_participants_participant_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participant_expenses_plan_id_plans_plan_id_fk": {
+          "name": "participant_expenses_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_expenses",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participant_join_requests": {
+      "name": "participant_join_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_members": {
+          "name": "dietary_members",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participant_join_requests_plan_id_plans_plan_id_fk": {
+          "name": "participant_join_requests_plan_id_plans_plan_id_fk",
+          "tableFrom": "participant_join_requests",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "join_request_plan_user_unique": {
+          "name": "join_request_plan_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_profile_id": {
+          "name": "guest_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "adults_count": {
+          "name": "adults_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kids_count": {
+          "name": "kids_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_members": {
+          "name": "dietary_members",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsvp_status": {
+          "name": "rsvp_status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_plan_id_plans_plan_id_fk": {
+          "name": "participants_plan_id_plans_plan_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "participants_guest_profile_id_guest_profiles_guest_id_fk": {
+          "name": "participants_guest_profile_id_guest_profiles_guest_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "guest_profiles",
+          "columnsFrom": [
+            "guest_profile_id"
+          ],
+          "columnsTo": [
+            "guest_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "participants_invite_token_unique": {
+          "name": "participants_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_invites": {
+      "name": "plan_invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_invites_plan_id_plans_plan_id_fk": {
+          "name": "plan_invites_plan_id_plans_plan_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_invites_participant_id_participants_participant_id_fk": {
+          "name": "plan_invites_participant_id_participants_participant_id_fk",
+          "tableFrom": "plan_invites",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_tag_options": {
+      "name": "plan_tag_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mutex_group": {
+          "name": "mutex_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_group_rules": {
+          "name": "cross_group_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "plan_tag_options_version_tier_idx": {
+          "name": "plan_tag_options_version_tier_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plan_tag_options_parent_idx": {
+          "name": "plan_tag_options_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_tag_options_version_id_plan_tag_versions_id_fk": {
+          "name": "plan_tag_options_version_id_plan_tag_versions_id_fk",
+          "tableFrom": "plan_tag_options",
+          "tableTo": "plan_tag_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_tag_options_parent_id_plan_tag_options_id_fk": {
+          "name": "plan_tag_options_parent_id_plan_tag_options_id_fk",
+          "tableFrom": "plan_tag_options",
+          "tableTo": "plan_tag_options",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_tag_versions": {
+      "name": "plan_tag_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_labels": {
+          "name": "tier_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plan_tag_versions_version_unique": {
+          "name": "plan_tag_versions_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "owner_participant_id": {
+          "name": "owner_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lang": {
+          "name": "default_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_adults": {
+          "name": "estimated_adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_kids": {
+          "name": "estimated_kids",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generation_count": {
+          "name": "ai_generation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "device_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_lang": {
+          "name": "preferred_lang",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_preferences": {
+          "name": "food_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_equipment": {
+          "name": "default_equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_idx": {
+          "name": "users_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.whatsapp_notifications": {
+      "name": "whatsapp_notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_phone": {
+          "name": "recipient_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_participant_id": {
+          "name": "recipient_participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "whatsapp_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "whatsapp_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "whatsapp_notifications_plan_id_plans_plan_id_fk": {
+          "name": "whatsapp_notifications_plan_id_plans_plan_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "plan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk": {
+          "name": "whatsapp_notifications_recipient_participant_id_participants_participant_id_fk",
+          "tableFrom": "whatsapp_notifications",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "recipient_participant_id"
+          ],
+          "columnsTo": [
+            "participant_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_feature_type": {
+      "name": "ai_feature_type",
+      "schema": "public",
+      "values": [
+        "item_suggestions"
+      ]
+    },
+    "public.ai_usage_status": {
+      "name": "ai_usage_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "partial",
+        "error"
+      ]
+    },
+    "public.device_type": {
+      "name": "device_type",
+      "schema": "public",
+      "values": [
+        "mobile",
+        "tablet",
+        "desktop"
+      ]
+    },
+    "public.invite_send_status": {
+      "name": "invite_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "accepted"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invited",
+        "accepted"
+      ]
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "public",
+      "values": [
+        "group_equipment",
+        "personal_equipment",
+        "food"
+      ]
+    },
+    "public.item_change_type": {
+      "name": "item_change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "purchased",
+        "packed",
+        "canceled"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.participant_role": {
+      "name": "participant_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "participant",
+        "viewer"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "not_sure"
+      ]
+    },
+    "public.unit": {
+      "name": "unit",
+      "schema": "public",
+      "values": [
+        "pcs",
+        "kg",
+        "g",
+        "lb",
+        "oz",
+        "l",
+        "ml",
+        "m",
+        "cm",
+        "pack",
+        "set"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "invite_only",
+        "private"
+      ]
+    },
+    "public.whatsapp_notification_status": {
+      "name": "whatsapp_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed"
+      ]
+    },
+    "public.whatsapp_notification_type": {
+      "name": "whatsapp_notification_type",
+      "schema": "public",
+      "values": [
+        "invitation_sent",
+        "join_request_pending",
+        "join_request_approved",
+        "join_request_rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1775100000000,
       "tag": "0031_chatbot_ai_usage",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0032_plan_tag_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import { aiSuggestionsRoutes } from './routes/ai-suggestions.route.js'
 import { adminAiUsageRoutes } from './routes/admin-ai-usage.route.js'
 import { adminChatbotAiUsageRoutes } from './routes/admin-chatbot-ai-usage.route.js'
 import { internalRoutes } from './routes/internal.route.js'
+import { planTagsRoutes } from './routes/plan-tags.route.js'
 
 export interface AppDependencies {
   db: Database
@@ -225,6 +226,7 @@ export async function buildApp(
   await fastify.register(aiSuggestionsRoutes)
   await fastify.register(adminAiUsageRoutes)
   await fastify.register(adminChatbotAiUsageRoutes)
+  await fastify.register(planTagsRoutes)
   await fastify.register(internalRoutes, { prefix: '/api/internal' })
 
   return fastify

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,8 +11,10 @@ import {
   boolean,
   numeric,
   index,
+  smallint,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
+import type { AnyPgColumn } from 'drizzle-orm/pg-core'
 
 export const guestProfiles = pgTable('guest_profiles', {
   guestId: uuid('guest_id').primaryKey().defaultRandom(),
@@ -585,6 +587,52 @@ export const aiUsageLogsRelations = relations(aiUsageLogs, ({ one }) => ({
   }),
 }))
 
+export type TierLabels = {
+  tier1: { label: string; key: string }
+  tier2: { label: string; key: string; conditional_on: string }
+  tier3: { label: string; key: string; conditional_on: string }
+}
+
+export type CrossGroupRule = {
+  disable?: string[]
+  deselect?: string[]
+  disable_tooltip?: string
+}
+
+export const planTagVersions = pgTable('plan_tag_versions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  version: varchar('version', { length: 20 }).notNull().unique(),
+  description: text('description'),
+  tierLabels: jsonb('tier_labels').$type<TierLabels>().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+})
+
+export const planTagOptions = pgTable(
+  'plan_tag_options',
+  {
+    id: text('id').primaryKey(),
+    versionId: uuid('version_id')
+      .notNull()
+      .references(() => planTagVersions.id, { onDelete: 'cascade' }),
+    tier: smallint('tier').notNull(),
+    parentId: text('parent_id').references(
+      (): AnyPgColumn => planTagOptions.id,
+      { onDelete: 'cascade' }
+    ),
+    label: text('label').notNull(),
+    emoji: text('emoji'),
+    sortOrder: smallint('sort_order').notNull().default(0),
+    mutexGroup: text('mutex_group'),
+    crossGroupRules: jsonb('cross_group_rules').$type<CrossGroupRule[]>(),
+  },
+  (table) => [
+    index('plan_tag_options_version_tier_idx').on(table.versionId, table.tier),
+    index('plan_tag_options_parent_idx').on(table.parentId),
+  ]
+)
+
 export type GuestProfile = typeof guestProfiles.$inferSelect
 export type NewGuestProfile = typeof guestProfiles.$inferInsert
 export type UserRecord = typeof users.$inferSelect
@@ -613,3 +661,7 @@ export type ChatbotAiUsageLog = typeof chatbotAiUsage.$inferSelect
 export type NewChatbotAiUsageLog = typeof chatbotAiUsage.$inferInsert
 export type Session = typeof sessions.$inferSelect
 export type NewSession = typeof sessions.$inferInsert
+export type PlanTagVersion = typeof planTagVersions.$inferSelect
+export type NewPlanTagVersion = typeof planTagVersions.$inferInsert
+export type PlanTagOption = typeof planTagOptions.$inferSelect
+export type NewPlanTagOption = typeof planTagOptions.$inferInsert

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -12,8 +12,12 @@ import {
   participantJoinRequests,
   aiUsageLogs,
   chatbotAiUsage,
+  planTagVersions,
+  planTagOptions,
   type Location,
   type Assignment,
+  type TierLabels,
+  type CrossGroupRule,
 } from './schema.js'
 
 function loadEnvLocal() {
@@ -52,7 +56,7 @@ async function seed() {
 
   try {
     await db.execute(
-      sql`TRUNCATE plans, participants, items, plan_invites, participant_join_requests, participant_expenses, guest_profiles, users, whatsapp_notifications, ai_usage_logs, chatbot_ai_usage CASCADE`
+      sql`TRUNCATE plans, participants, items, plan_invites, participant_join_requests, participant_expenses, guest_profiles, users, whatsapp_notifications, ai_usage_logs, chatbot_ai_usage, plan_tag_versions CASCADE`
     )
     console.log('Cleared all tables')
 
@@ -1102,6 +1106,1368 @@ async function seed() {
     console.log('Chatbot AI Usage:')
     console.log('  7 logs across 3 sessions (2 DM, 1 group)')
     console.log('  5 success, 1 error, mixed tool calls')
+    console.log('')
+
+    // --- Plan Tag Taxonomy v1.2 ---
+    const tierLabels: TierLabels = {
+      tier1: { label: 'What kind of trip is this?', key: 'plan_type' },
+      tier2: {
+        label: 'Tell us a bit more',
+        key: 'logistics',
+        conditional_on: 'tier1',
+      },
+      tier3: {
+        label: 'A few more details',
+        key: 'specifics',
+        conditional_on: 'tier2',
+      },
+    }
+
+    const [tagVersion] = await db
+      .insert(planTagVersions)
+      .values({
+        version: '1.2',
+        description:
+          'Three-tier conditional tag system for Chillist plan creation wizard. Tier 2 uses mutex_groups for mutually exclusive selections within a concern (stay, food, vibe) and cross_group_rules for dependent deselection/disabling. Duration/day-count questions removed (handled by date picker).',
+        tierLabels,
+      })
+      .returning()
+
+    const vId = tagVersion.id
+
+    type OptionSeed = {
+      id: string
+      versionId: string
+      tier: number
+      parentId: string | null
+      label: string
+      emoji?: string | null
+      sortOrder: number
+      mutexGroup?: string | null
+      crossGroupRules?: CrossGroupRule[] | null
+    }
+
+    const tagOptions: OptionSeed[] = [
+      // ── Tier 1 ──
+      {
+        id: 'camping',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+      },
+      {
+        id: 'hotel_trip',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Hotel Stay',
+        emoji: '🏨',
+        sortOrder: 1,
+      },
+      {
+        id: 'road_trip',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Road Trip',
+        emoji: '🚗',
+        sortOrder: 2,
+      },
+      {
+        id: 'day_trip',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Day Trip',
+        emoji: '🌅',
+        sortOrder: 3,
+      },
+      {
+        id: 'beach',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Beach',
+        emoji: '🏖️',
+        sortOrder: 4,
+      },
+      {
+        id: 'city_break',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'City Break',
+        emoji: '🏙️',
+        sortOrder: 5,
+      },
+      {
+        id: 'hiking',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Hiking / Trekking',
+        emoji: '🥾',
+        sortOrder: 6,
+      },
+      {
+        id: 'festival',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Festival / Event',
+        emoji: '🎪',
+        sortOrder: 7,
+      },
+      {
+        id: 'dinner_party',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Dinner / Party',
+        emoji: '🍽️',
+        sortOrder: 8,
+      },
+      {
+        id: 'other',
+        versionId: vId,
+        tier: 1,
+        parentId: null,
+        label: 'Other',
+        emoji: '✨',
+        sortOrder: 9,
+      },
+
+      // ── Tier 2: camping ──
+      {
+        id: 'camping_cooking',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: "We're cooking our own food",
+        sortOrder: 0,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'camping_mixed_food',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: 'Mix of cooking and eating out',
+        sortOrder: 1,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'camping_tent',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: 'Sleeping in tents',
+        sortOrder: 2,
+        mutexGroup: 'sleep',
+      },
+      {
+        id: 'camping_cabin',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: 'Sleeping in cabins / glamping',
+        sortOrder: 3,
+        mutexGroup: 'sleep',
+      },
+      {
+        id: 'camping_caravan',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: 'Caravan / campervan',
+        sortOrder: 4,
+        mutexGroup: 'sleep',
+      },
+      {
+        id: 'camping_organized',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: 'Organized campsite',
+        sortOrder: 5,
+        mutexGroup: 'site',
+      },
+      {
+        id: 'camping_wild',
+        versionId: vId,
+        tier: 2,
+        parentId: 'camping',
+        label: 'Wild / off-grid camping',
+        sortOrder: 6,
+        mutexGroup: 'site',
+      },
+
+      // ── Tier 2: hotel_trip ──
+      {
+        id: 'hotel_hotel',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Hotel',
+        sortOrder: 0,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'hotel_apartment',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Airbnb / apartment',
+        sortOrder: 1,
+        mutexGroup: 'stay',
+        crossGroupRules: [
+          {
+            disable: ['hotel_hotel_meals'],
+            disable_tooltip:
+              'Hotel meals only available when staying in a hotel',
+          },
+        ],
+      },
+      {
+        id: 'hotel_hotel_meals',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Eating at the hotel',
+        sortOrder: 2,
+        mutexGroup: 'food',
+        crossGroupRules: [
+          {
+            disable: ['hotel_cook'],
+            disable_tooltip: 'Not relevant when hotel provides meals',
+          },
+        ],
+      },
+      {
+        id: 'hotel_restaurants',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Restaurants / eating out',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'hotel_cook',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Cooking ourselves',
+        sortOrder: 4,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'hotel_meals_mixed',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Mix of eating in and out',
+        sortOrder: 5,
+        mutexGroup: 'food',
+      },
+
+      // ── Tier 2: road_trip ──
+      {
+        id: 'road_hotels',
+        versionId: vId,
+        tier: 2,
+        parentId: 'road_trip',
+        label: 'Staying in hotels along the way',
+        sortOrder: 0,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'road_camping',
+        versionId: vId,
+        tier: 2,
+        parentId: 'road_trip',
+        label: 'Camping along the way',
+        sortOrder: 1,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'road_mixed_stay',
+        versionId: vId,
+        tier: 2,
+        parentId: 'road_trip',
+        label: 'Mix of accommodation',
+        sortOrder: 2,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'road_eating_out',
+        versionId: vId,
+        tier: 2,
+        parentId: 'road_trip',
+        label: 'Eating out / restaurants',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'road_cooking',
+        versionId: vId,
+        tier: 2,
+        parentId: 'road_trip',
+        label: 'Cooking our own food',
+        sortOrder: 4,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'road_mixed_food',
+        versionId: vId,
+        tier: 2,
+        parentId: 'road_trip',
+        label: 'Mix of eating in and out',
+        sortOrder: 5,
+        mutexGroup: 'food',
+      },
+
+      // ── Tier 2: day_trip ──
+      {
+        id: 'day_nature',
+        versionId: vId,
+        tier: 2,
+        parentId: 'day_trip',
+        label: 'Nature / outdoors',
+        sortOrder: 0,
+      },
+      {
+        id: 'day_city',
+        versionId: vId,
+        tier: 2,
+        parentId: 'day_trip',
+        label: 'City / sightseeing',
+        sortOrder: 1,
+      },
+      {
+        id: 'day_activity',
+        versionId: vId,
+        tier: 2,
+        parentId: 'day_trip',
+        label: 'Specific activity (kayaking, cycling, etc.)',
+        sortOrder: 2,
+      },
+      {
+        id: 'day_venue',
+        versionId: vId,
+        tier: 2,
+        parentId: 'day_trip',
+        label: 'Specific venue (winery, museum, zoo, etc.)',
+        sortOrder: 3,
+      },
+      {
+        id: 'day_packed_lunch',
+        versionId: vId,
+        tier: 2,
+        parentId: 'day_trip',
+        label: 'Bringing packed lunch',
+        sortOrder: 4,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'day_eating_out',
+        versionId: vId,
+        tier: 2,
+        parentId: 'day_trip',
+        label: 'Eating out',
+        sortOrder: 5,
+        mutexGroup: 'food',
+      },
+
+      // ── Tier 2: beach ──
+      {
+        id: 'beach_hotel',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'Staying in a hotel / resort',
+        sortOrder: 0,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'beach_camping',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'Beach camping',
+        sortOrder: 1,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'beach_cooking',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'Bringing / cooking food',
+        sortOrder: 2,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'beach_eating_out',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'Eating out',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'beach_relaxing',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'Relaxing / sunbathing',
+        sortOrder: 4,
+        mutexGroup: 'activity',
+      },
+      {
+        id: 'beach_active',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'Active (water sports, volleyball, etc.)',
+        sortOrder: 5,
+        mutexGroup: 'activity',
+      },
+      {
+        id: 'beach_kids',
+        versionId: vId,
+        tier: 2,
+        parentId: 'beach',
+        label: 'With young kids',
+        sortOrder: 6,
+      },
+
+      // ── Tier 2: city_break ──
+      {
+        id: 'city_hotel',
+        versionId: vId,
+        tier: 2,
+        parentId: 'city_break',
+        label: 'Hotel',
+        sortOrder: 0,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'city_airbnb',
+        versionId: vId,
+        tier: 2,
+        parentId: 'city_break',
+        label: 'Airbnb / apartment',
+        sortOrder: 1,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'city_eating_out',
+        versionId: vId,
+        tier: 2,
+        parentId: 'city_break',
+        label: 'Eating out for most meals',
+        sortOrder: 2,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'city_mixed_food',
+        versionId: vId,
+        tier: 2,
+        parentId: 'city_break',
+        label: 'Mix of cooking and eating out',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'city_activities',
+        versionId: vId,
+        tier: 2,
+        parentId: 'city_break',
+        label: 'Focused on activities / sightseeing',
+        sortOrder: 4,
+      },
+      {
+        id: 'city_nightlife',
+        versionId: vId,
+        tier: 2,
+        parentId: 'city_break',
+        label: 'Nightlife / bars / clubs',
+        sortOrder: 5,
+      },
+
+      // ── Tier 2: hiking ──
+      {
+        id: 'hiking_hut',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hiking',
+        label: 'Staying in mountain huts',
+        sortOrder: 0,
+        mutexGroup: 'sleep',
+      },
+      {
+        id: 'hiking_tent',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hiking',
+        label: 'Tent camping',
+        sortOrder: 1,
+        mutexGroup: 'sleep',
+      },
+      {
+        id: 'hiking_packed_food',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hiking',
+        label: 'Bringing all food',
+        sortOrder: 2,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'hiking_mixed_food',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hiking',
+        label: 'Mix of packed and buying along the way',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'hiking_guided',
+        versionId: vId,
+        tier: 2,
+        parentId: 'hiking',
+        label: 'Guided / organized group',
+        sortOrder: 4,
+      },
+
+      // ── Tier 2: festival ──
+      {
+        id: 'festival_camping',
+        versionId: vId,
+        tier: 2,
+        parentId: 'festival',
+        label: 'Camping at the festival',
+        sortOrder: 0,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'festival_hotel',
+        versionId: vId,
+        tier: 2,
+        parentId: 'festival',
+        label: 'Staying nearby in a hotel',
+        sortOrder: 1,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'festival_day_only',
+        versionId: vId,
+        tier: 2,
+        parentId: 'festival',
+        label: 'Day visits only',
+        sortOrder: 2,
+        mutexGroup: 'stay',
+      },
+      {
+        id: 'festival_food_there',
+        versionId: vId,
+        tier: 2,
+        parentId: 'festival',
+        label: 'Eating at the festival',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'festival_packed_food',
+        versionId: vId,
+        tier: 2,
+        parentId: 'festival',
+        label: 'Bringing our own food',
+        sortOrder: 4,
+        mutexGroup: 'food',
+      },
+
+      // ── Tier 2: dinner_party ──
+      {
+        id: 'dinner_restaurant',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: 'Restaurant / venue',
+        sortOrder: 0,
+        mutexGroup: 'venue',
+        crossGroupRules: [
+          {
+            disable: ['dinner_potluck'],
+            disable_tooltip: "Potluck isn't available at a restaurant",
+          },
+        ],
+      },
+      {
+        id: 'dinner_home',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: "Someone's home",
+        sortOrder: 1,
+        mutexGroup: 'venue',
+      },
+      {
+        id: 'dinner_potluck',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: 'Potluck / each brings something',
+        sortOrder: 2,
+        mutexGroup: 'catering',
+      },
+      {
+        id: 'dinner_catered',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: 'Catered',
+        sortOrder: 3,
+        mutexGroup: 'catering',
+      },
+      {
+        id: 'dinner_bbq',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: 'BBQ / outdoor',
+        sortOrder: 4,
+        mutexGroup: 'venue',
+      },
+      {
+        id: 'dinner_drinks_only',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: 'Drinks / no food focus',
+        sortOrder: 5,
+        crossGroupRules: [
+          {
+            disable: ['dinner_potluck', 'dinner_catered'],
+            disable_tooltip: 'No food logistics when drinks-only',
+          },
+        ],
+      },
+      {
+        id: 'dinner_games_gathering',
+        versionId: vId,
+        tier: 2,
+        parentId: 'dinner_party',
+        label: 'Games night / gathering',
+        sortOrder: 6,
+      },
+
+      // ── Tier 2: other ──
+      {
+        id: 'other_indoor',
+        versionId: vId,
+        tier: 2,
+        parentId: 'other',
+        label: 'Indoor activity',
+        sortOrder: 0,
+        mutexGroup: 'setting',
+      },
+      {
+        id: 'other_outdoor',
+        versionId: vId,
+        tier: 2,
+        parentId: 'other',
+        label: 'Outdoor activity',
+        sortOrder: 1,
+        mutexGroup: 'setting',
+      },
+      {
+        id: 'other_mixed',
+        versionId: vId,
+        tier: 2,
+        parentId: 'other',
+        label: 'Mix of indoor and outdoor',
+        sortOrder: 2,
+        mutexGroup: 'setting',
+      },
+      {
+        id: 'other_food_included',
+        versionId: vId,
+        tier: 2,
+        parentId: 'other',
+        label: 'Food / drinks included',
+        sortOrder: 3,
+        mutexGroup: 'food',
+      },
+      {
+        id: 'other_food_self',
+        versionId: vId,
+        tier: 2,
+        parentId: 'other',
+        label: 'Everyone sorts their own food',
+        sortOrder: 4,
+        mutexGroup: 'food',
+      },
+
+      // ── Tier 3: camping_cooking ──
+      {
+        id: 'cooking_shared_meals',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_cooking',
+        label: 'Shared group meals',
+        sortOrder: 0,
+      },
+      {
+        id: 'cooking_each_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_cooking',
+        label: 'Everyone cooks their own',
+        sortOrder: 1,
+      },
+      {
+        id: 'cooking_assigned',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_cooking',
+        label: 'Assigned cooking duties per day',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: camping_mixed_food ──
+      {
+        id: 'mixed_food_shared_cook',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_mixed_food',
+        label: 'Some meals shared, some eating out',
+        sortOrder: 0,
+      },
+      {
+        id: 'mixed_food_each_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_mixed_food',
+        label: 'Each person handles their own',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: camping_tent ──
+      {
+        id: 'tent_shared',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_tent',
+        label: 'Sharing tents',
+        sortOrder: 0,
+      },
+      {
+        id: 'tent_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_tent',
+        label: 'Everyone brings their own tent',
+        sortOrder: 1,
+      },
+      {
+        id: 'tent_renting',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_tent',
+        label: 'Renting tents on-site',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: camping_cabin ──
+      {
+        id: 'cabin_full_kitchen',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_cabin',
+        label: 'Fully equipped kitchen',
+        sortOrder: 0,
+      },
+      {
+        id: 'cabin_basic',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_cabin',
+        label: 'Basic facilities only',
+        sortOrder: 1,
+      },
+      {
+        id: 'cabin_no_kitchen',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_cabin',
+        label: 'No kitchen, eating out',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: camping_caravan ──
+      {
+        id: 'caravan_cooking',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_caravan',
+        label: 'Cooking in the caravan',
+        sortOrder: 0,
+      },
+      {
+        id: 'caravan_mixed',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_caravan',
+        label: 'Mix of caravan and eating out',
+        sortOrder: 1,
+      },
+      {
+        id: 'caravan_eating_out',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_caravan',
+        label: 'Eating out mostly',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: camping_organized ──
+      {
+        id: 'organized_site_equipment',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_organized',
+        label: 'Site provides equipment (tent, bedding)',
+        sortOrder: 0,
+      },
+      {
+        id: 'organized_own_equipment',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_organized',
+        label: 'Bring your own equipment',
+        sortOrder: 1,
+      },
+      {
+        id: 'organized_communal_kitchen',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_organized',
+        label: 'Site has a communal kitchen',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: camping_wild ──
+      {
+        id: 'wild_hiking_in',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_wild',
+        label: 'Hiking in to the spot',
+        sortOrder: 0,
+      },
+      {
+        id: 'wild_drive_in',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_wild',
+        label: 'Driving to the spot',
+        sortOrder: 1,
+      },
+      {
+        id: 'wild_water_source',
+        versionId: vId,
+        tier: 3,
+        parentId: 'camping_wild',
+        label: 'Need to plan water supply',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: hotel_hotel_meals ──
+      {
+        id: 'hotel_meals_all_inclusive',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_hotel_meals',
+        label: 'All-inclusive (all meals)',
+        sortOrder: 0,
+      },
+      {
+        id: 'hotel_meals_half_board',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_hotel_meals',
+        label: 'Half board (breakfast + dinner)',
+        sortOrder: 1,
+      },
+      {
+        id: 'hotel_meals_bb',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_hotel_meals',
+        label: 'Breakfast only',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: hotel_cook ──
+      {
+        id: 'hotel_cook_shared',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_cook',
+        label: 'Group cooking together',
+        sortOrder: 0,
+      },
+      {
+        id: 'hotel_cook_individual',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_cook',
+        label: 'Everyone cooks their own',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: hotel_apartment ──
+      {
+        id: 'hotel_apt_full_kitchen',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_apartment',
+        label: 'Fully equipped kitchen',
+        sortOrder: 0,
+      },
+      {
+        id: 'hotel_apt_basic',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hotel_apartment',
+        label: 'Basic facilities only',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: road_hotels ──
+      {
+        id: 'road_hotel_prebooked',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_hotels',
+        label: 'Pre-booked stops',
+        sortOrder: 0,
+      },
+      {
+        id: 'road_hotel_flexible',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_hotels',
+        label: 'Finding places as we go',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: road_camping ──
+      {
+        id: 'road_camp_sites',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_camping',
+        label: 'Using established campsites',
+        sortOrder: 0,
+      },
+      {
+        id: 'road_camp_wild',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_camping',
+        label: 'Wild camping',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: road_mixed_stay ──
+      {
+        id: 'road_mixed_hotels_camping',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_mixed_stay',
+        label: 'Hotels and camping',
+        sortOrder: 0,
+      },
+      {
+        id: 'road_mixed_hotels_airbnb',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_mixed_stay',
+        label: 'Hotels and Airbnbs',
+        sortOrder: 1,
+      },
+      {
+        id: 'road_mixed_all_three',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_mixed_stay',
+        label: 'All three',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: road_cooking ──
+      {
+        id: 'road_cook_shared',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_cooking',
+        label: 'Shared group cooking',
+        sortOrder: 0,
+      },
+      {
+        id: 'road_cook_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'road_cooking',
+        label: 'Individual cooking',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: day_activity ──
+      {
+        id: 'activity_equipment_needed',
+        versionId: vId,
+        tier: 3,
+        parentId: 'day_activity',
+        label: 'Requires special equipment',
+        sortOrder: 0,
+      },
+      {
+        id: 'activity_equipment_rental',
+        versionId: vId,
+        tier: 3,
+        parentId: 'day_activity',
+        label: 'Equipment can be rented there',
+        sortOrder: 1,
+      },
+      {
+        id: 'activity_booking_needed',
+        versionId: vId,
+        tier: 3,
+        parentId: 'day_activity',
+        label: 'Needs advance booking',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: beach_cooking ──
+      {
+        id: 'beach_cook_bbq',
+        versionId: vId,
+        tier: 3,
+        parentId: 'beach_cooking',
+        label: 'BBQ / grill on the beach',
+        sortOrder: 0,
+      },
+      {
+        id: 'beach_cook_packed',
+        versionId: vId,
+        tier: 3,
+        parentId: 'beach_cooking',
+        label: 'Packed food, no cooking',
+        sortOrder: 1,
+      },
+      {
+        id: 'beach_cook_camp_kitchen',
+        versionId: vId,
+        tier: 3,
+        parentId: 'beach_cooking',
+        label: 'Full camp kitchen setup',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: city_airbnb ──
+      {
+        id: 'city_airbnb_cooking',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_airbnb',
+        label: 'Yes, cooking some meals',
+        sortOrder: 0,
+      },
+      {
+        id: 'city_airbnb_sleeping_only',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_airbnb',
+        label: 'No, just for sleeping',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: city_mixed_food ──
+      {
+        id: 'city_mixed_airbnb_kitchen',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_mixed_food',
+        label: 'Airbnb kitchen',
+        sortOrder: 0,
+      },
+      {
+        id: 'city_mixed_picnic',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_mixed_food',
+        label: 'Picnic / packed food',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: city_activities ──
+      {
+        id: 'city_activities_booked',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_activities',
+        label: 'Already booked',
+        sortOrder: 0,
+      },
+      {
+        id: 'city_activities_planning',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_activities',
+        label: 'Need to plan and book',
+        sortOrder: 1,
+      },
+      {
+        id: 'city_activities_spontaneous',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_activities',
+        label: 'Spontaneous, deciding there',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: city_nightlife ──
+      {
+        id: 'nightlife_bars',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_nightlife',
+        label: 'Bars / pub crawl',
+        sortOrder: 0,
+      },
+      {
+        id: 'nightlife_clubs',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_nightlife',
+        label: 'Clubs / dancing',
+        sortOrder: 1,
+      },
+      {
+        id: 'nightlife_mixed',
+        versionId: vId,
+        tier: 3,
+        parentId: 'city_nightlife',
+        label: 'Mix of both',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: hiking_packed_food ──
+      {
+        id: 'packed_shared_supplies',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hiking_packed_food',
+        label: 'Shared group food supplies',
+        sortOrder: 0,
+      },
+      {
+        id: 'packed_each_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'hiking_packed_food',
+        label: 'Each person packs their own',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: festival_camping ──
+      {
+        id: 'fest_camp_shared',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_camping',
+        label: 'Shared campsite / pitching together',
+        sortOrder: 0,
+      },
+      {
+        id: 'fest_camp_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_camping',
+        label: 'Everyone gets their own spot',
+        sortOrder: 1,
+      },
+      {
+        id: 'fest_camp_glamping',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_camping',
+        label: 'Glamping option',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: festival_hotel ──
+      {
+        id: 'fest_hotel_walking',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_hotel',
+        label: 'Walking distance',
+        sortOrder: 0,
+      },
+      {
+        id: 'fest_hotel_transport',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_hotel',
+        label: 'Need transport each day',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: festival_day_only ──
+      {
+        id: 'fest_day_driving',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_day_only',
+        label: 'Driving each day',
+        sortOrder: 0,
+      },
+      {
+        id: 'fest_day_public_transport',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_day_only',
+        label: 'Public transport',
+        sortOrder: 1,
+      },
+      {
+        id: 'fest_day_shuttle',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_day_only',
+        label: 'Organized shuttle',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: festival_packed_food ──
+      {
+        id: 'fest_packed_cooler',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_packed_food',
+        label: 'Full cooler / picnic setup',
+        sortOrder: 0,
+      },
+      {
+        id: 'fest_packed_light',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_packed_food',
+        label: 'Light snacks only',
+        sortOrder: 1,
+      },
+      {
+        id: 'fest_packed_dietary',
+        versionId: vId,
+        tier: 3,
+        parentId: 'festival_packed_food',
+        label: 'Dietary restrictions to plan around',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: dinner_potluck ──
+      {
+        id: 'potluck_assigned',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_potluck',
+        label: 'Assigned dishes per person',
+        sortOrder: 0,
+      },
+      {
+        id: 'potluck_free',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_potluck',
+        label: 'Everyone brings what they want',
+        sortOrder: 1,
+      },
+
+      // ── Tier 3: dinner_home ──
+      {
+        id: 'home_host_cooks',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_home',
+        label: 'Host cooks everything',
+        sortOrder: 0,
+      },
+      {
+        id: 'home_potluck',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_home',
+        label: 'Everyone brings something',
+        sortOrder: 1,
+      },
+      {
+        id: 'home_hired_chef',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_home',
+        label: 'Hired chef / catering',
+        sortOrder: 2,
+      },
+
+      // ── Tier 3: dinner_bbq ──
+      {
+        id: 'bbq_shared_food',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_bbq',
+        label: 'Shared group food',
+        sortOrder: 0,
+      },
+      {
+        id: 'bbq_bring_own',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_bbq',
+        label: 'Everyone brings their own meat/food',
+        sortOrder: 1,
+      },
+      {
+        id: 'bbq_assigned',
+        versionId: vId,
+        tier: 3,
+        parentId: 'dinner_bbq',
+        label: 'Assigned items per person',
+        sortOrder: 2,
+      },
+    ]
+
+    await db.insert(planTagOptions).values(tagOptions)
+
+    console.log('Plan Tag Taxonomy v1.2:')
+    console.log(
+      `  ${tagOptions.filter((o) => o.tier === 1).length} tier-1 options`
+    )
+    console.log(
+      `  ${tagOptions.filter((o) => o.tier === 2).length} tier-2 options`
+    )
+    console.log(
+      `  ${tagOptions.filter((o) => o.tier === 3).length} tier-3 options`
+    )
     console.log('')
     console.log('--------------------\n')
 

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify'
 import { eq, inArray, count, and, asc, or, isNull, gte, sql } from 'drizzle-orm'
 import { resolveUserByPhone } from '../services/internal-auth.service.js'
 import { persistAssignments } from '../services/item.service.js'
+import { getLatestTagTaxonomy } from '../services/plan-tags.service.js'
 import { normalizePhone } from '../utils/phone.js'
 import { plans, participants, items } from '../db/schema.js'
 import type { ItemCategory, ItemStatus } from '../db/schema.js'
@@ -482,6 +483,57 @@ export async function internalRoutes(fastify: FastifyInstance) {
           name: itemRow.name,
           status: responseStatus,
         },
+      }
+    }
+  )
+
+  fastify.get(
+    '/plan-tags',
+    {
+      config: { rateLimit: INTERNAL_RATE_LIMIT },
+      schema: {
+        tags: ['internal'],
+        summary: 'Get plan tag taxonomy for chatbot',
+        description:
+          'Returns the full 3-tier plan tag taxonomy. Requires x-service-key header. Does not require x-user-id as the taxonomy is global reference data, not user-specific.',
+        response: {
+          200: {
+            description:
+              'Full tag taxonomy with version, tier labels, and all options',
+            $ref: 'PlanTagsResponse#',
+          },
+          401: {
+            description: 'Missing or invalid x-service-key',
+            $ref: 'ErrorResponse#',
+          },
+          404: {
+            description: 'No tag taxonomy found in the database',
+            $ref: 'ErrorResponse#',
+          },
+          500: {
+            description: 'Unexpected error while loading plan tags',
+            $ref: 'ErrorResponse#',
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const taxonomy = await getLatestTagTaxonomy(fastify.db)
+        if (!taxonomy) {
+          request.log.warn(
+            'Internal plan tags requested but no taxonomy found in database'
+          )
+          return reply.code(404).send({ message: 'No tag taxonomy found' })
+        }
+        request.log.info(
+          { version: taxonomy.version },
+          'Internal plan tags retrieved'
+        )
+        return taxonomy
+      } catch (err) {
+        request.log.error({ err }, 'Internal plan tags failed')
+        return reply.code(500).send({ message: 'Failed to retrieve plan tags' })
       }
     }
   )

--- a/src/routes/plan-tags.route.ts
+++ b/src/routes/plan-tags.route.ts
@@ -1,0 +1,67 @@
+import { FastifyInstance } from 'fastify'
+import { getLatestTagTaxonomy } from '../services/plan-tags.service.js'
+
+export async function planTagsRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', async (request, reply) => {
+    if (request.method === 'OPTIONS') return
+    const hasJwt = request.headers.authorization?.startsWith('Bearer ')
+    if (!hasJwt) {
+      return reply.status(401).send({ message: 'Authentication required' })
+    }
+    if (!request.user) {
+      return reply
+        .status(401)
+        .send({ message: 'JWT token present but verification failed' })
+    }
+  })
+
+  fastify.get(
+    '/plan-tags',
+    {
+      schema: {
+        tags: ['plan-tags'],
+        summary: 'Get plan tag taxonomy',
+        description:
+          'Returns the full 3-tier plan tag taxonomy (plan types, logistics, specifics) used by the plan creation wizard. Response matches the structure expected by PlanTagWizard and tag-utils on the frontend.',
+        response: {
+          200: {
+            description:
+              'Full tag taxonomy with version, tier labels, and all options',
+            $ref: 'PlanTagsResponse#',
+          },
+          401: {
+            description:
+              'Authentication required — JWT token missing or invalid',
+            $ref: 'ErrorResponse#',
+          },
+          404: {
+            description: 'No tag taxonomy found in the database',
+            $ref: 'ErrorResponse#',
+          },
+          500: {
+            description: 'Internal server error',
+            $ref: 'ErrorResponse#',
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const taxonomy = await getLatestTagTaxonomy(fastify.db)
+        if (!taxonomy) {
+          request.log.warn(
+            'Plan tags requested but no taxonomy found in database'
+          )
+          return reply.status(404).send({ message: 'No tag taxonomy found' })
+        }
+        request.log.info({ version: taxonomy.version }, 'Plan tags retrieved')
+        return taxonomy
+      } catch (err) {
+        request.log.error({ err }, 'Failed to retrieve plan tags')
+        return reply
+          .status(500)
+          .send({ message: 'Failed to retrieve plan tags' })
+      }
+    }
+  )
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -126,6 +126,7 @@ import {
   chatbotAiUsageQuerySchema,
   chatbotAiUsageResponseSchema,
 } from './chatbot-ai-usage.schema.js'
+import { planTagsResponseSchema } from './plan-tags.schema.js'
 
 const schemas = [
   errorResponseSchema,
@@ -227,6 +228,7 @@ const schemas = [
   chatbotAiUsageSummarySchema,
   chatbotAiUsageQuerySchema,
   chatbotAiUsageResponseSchema,
+  planTagsResponseSchema,
 ]
 
 export function registerSchemas(fastify: FastifyInstance) {
@@ -250,3 +252,4 @@ export * from './dietary.schema.js'
 export * from './ai-suggestions.schema.js'
 export * from './ai-usage.schema.js'
 export * from './chatbot-ai-usage.schema.js'
+export * from './plan-tags.schema.js'

--- a/src/schemas/plan-tags.schema.ts
+++ b/src/schemas/plan-tags.schema.ts
@@ -1,0 +1,157 @@
+const tier1OptionSchema = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+      description: 'Unique tier-1 option id, e.g. "camping"',
+    },
+    label: { type: 'string' },
+    emoji: { type: 'string' },
+  },
+  required: ['id', 'label', 'emoji'],
+} as const
+
+const tier1Schema = {
+  type: 'object',
+  properties: {
+    label: { type: 'string', description: 'UI label for the tier-1 question' },
+    key: {
+      type: 'string',
+      description: 'Tier key identifier, e.g. "plan_type"',
+    },
+    options: { type: 'array', items: tier1OptionSchema },
+  },
+  required: ['label', 'key', 'options'],
+} as const
+
+const tier2Schema = {
+  type: 'object',
+  properties: {
+    label: { type: 'string', description: 'UI label for the tier-2 question' },
+    key: {
+      type: 'string',
+      description: 'Tier key identifier, e.g. "logistics"',
+    },
+    conditional_on: {
+      type: 'string',
+      description: 'The tier key this tier depends on, e.g. "tier1"',
+    },
+    options_by_parent: {
+      type: 'object',
+      description:
+        'Map from tier-1 option id to tier-2 option block (options, mutex_groups, cross_group_rules)',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          options: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                label: { type: 'string' },
+              },
+              required: ['id', 'label'],
+            },
+          },
+          mutex_groups: {
+            type: 'array',
+            description:
+              'Groups of mutually exclusive option ids — selecting one deselects the others in the same group',
+            items: { type: 'array', items: { type: 'string' } },
+          },
+          cross_group_rules: {
+            type: 'array',
+            description:
+              'Rules that disable or deselect options across mutex groups when a trigger option is selected',
+            items: {
+              type: 'object',
+              properties: {
+                trigger: {
+                  type: 'string',
+                  description: 'Option id that activates this rule',
+                },
+                disable: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Option ids to disable when trigger is selected',
+                },
+                deselect: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description:
+                    'Option ids to deselect when trigger is selected',
+                },
+                disable_tooltip: {
+                  type: 'string',
+                  description: 'Tooltip shown on disabled options',
+                },
+              },
+              required: ['trigger'],
+            },
+          },
+        },
+        required: ['options', 'mutex_groups', 'cross_group_rules'],
+      },
+    },
+  },
+  required: ['label', 'key', 'conditional_on', 'options_by_parent'],
+} as const
+
+const tier3Schema = {
+  type: 'object',
+  properties: {
+    label: { type: 'string', description: 'UI label for the tier-3 question' },
+    key: {
+      type: 'string',
+      description: 'Tier key identifier, e.g. "specifics"',
+    },
+    conditional_on: {
+      type: 'string',
+      description: 'The tier key this tier depends on, e.g. "tier2"',
+    },
+    options_by_parent: {
+      type: 'object',
+      description: 'Map from tier-2 option id to array of tier-3 options',
+      additionalProperties: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            label: { type: 'string' },
+          },
+          required: ['id', 'label'],
+        },
+      },
+    },
+  },
+  required: ['label', 'key', 'conditional_on', 'options_by_parent'],
+} as const
+
+export const planTagsResponseSchema = {
+  $id: 'PlanTagsResponse',
+  type: 'object',
+  description: 'Full 3-tier plan tag taxonomy',
+  properties: {
+    version: {
+      type: 'string',
+      description: 'Taxonomy version string, e.g. "1.2"',
+    },
+    description: {
+      type: 'string',
+      nullable: true,
+      description: 'Human-readable description of this taxonomy version',
+    },
+    tiers: {
+      type: 'object',
+      properties: {
+        tier1: tier1Schema,
+        tier2: tier2Schema,
+        tier3: tier3Schema,
+      },
+      required: ['tier1', 'tier2', 'tier3'],
+    },
+  },
+  required: ['version', 'tiers'],
+} as const

--- a/src/services/plan-tags.service.ts
+++ b/src/services/plan-tags.service.ts
@@ -1,0 +1,183 @@
+import { eq, desc } from 'drizzle-orm'
+import type { Database } from '../db/index.js'
+import { planTagVersions, planTagOptions } from '../db/schema.js'
+import type { TierLabels, CrossGroupRule } from '../db/schema.js'
+
+type Tier1Option = { id: string; label: string; emoji: string }
+type Tier2Option = { id: string; label: string }
+type Tier3Option = { id: string; label: string }
+
+type Tier2CrossGroupRule = {
+  trigger: string
+  disable?: string[]
+  deselect?: string[]
+  disable_tooltip?: string
+}
+
+type Tier2Block = {
+  options: Tier2Option[]
+  mutex_groups: string[][]
+  cross_group_rules: Tier2CrossGroupRule[]
+}
+
+export type TaxonomyTier1 = {
+  label: string
+  key: string
+  options: Tier1Option[]
+}
+
+export type TaxonomyTier2 = {
+  label: string
+  key: string
+  conditional_on: string
+  options_by_parent: Record<string, Tier2Block>
+}
+
+export type TaxonomyTier3 = {
+  label: string
+  key: string
+  conditional_on: string
+  options_by_parent: Record<string, Tier3Option[]>
+}
+
+export type TaxonomyResponse = {
+  version: string
+  description: string | null
+  tiers: {
+    tier1: TaxonomyTier1
+    tier2: TaxonomyTier2
+    tier3: TaxonomyTier3
+  }
+}
+
+type OptionRow = {
+  id: string
+  tier: number
+  parentId: string | null
+  label: string
+  emoji: string | null
+  sortOrder: number
+  mutexGroup: string | null
+  crossGroupRules: CrossGroupRule[] | null
+}
+
+export function assembleTaxonomyResponse(
+  version: {
+    version: string
+    description: string | null
+    tierLabels: TierLabels
+  },
+  options: OptionRow[]
+): TaxonomyResponse {
+  const tier1Options = options
+    .filter((o) => o.tier === 1)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+
+  const tier2Options = options
+    .filter((o) => o.tier === 2)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+
+  const tier3Options = options
+    .filter((o) => o.tier === 3)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+
+  const tier1: TaxonomyTier1 = {
+    label: version.tierLabels.tier1.label,
+    key: version.tierLabels.tier1.key,
+    options: tier1Options.map((o) => ({
+      id: o.id,
+      label: o.label,
+      emoji: o.emoji ?? '',
+    })),
+  }
+
+  const tier2ByParent: Record<string, Tier2Block> = {}
+
+  for (const option of tier2Options) {
+    const parentId = option.parentId ?? ''
+    if (!tier2ByParent[parentId]) {
+      tier2ByParent[parentId] = {
+        options: [],
+        mutex_groups: [],
+        cross_group_rules: [],
+      }
+    }
+    tier2ByParent[parentId].options.push({ id: option.id, label: option.label })
+
+    if (option.crossGroupRules && option.crossGroupRules.length > 0) {
+      for (const rule of option.crossGroupRules) {
+        tier2ByParent[parentId].cross_group_rules.push({
+          trigger: option.id,
+          ...rule,
+        })
+      }
+    }
+  }
+
+  for (const parentId of Object.keys(tier2ByParent)) {
+    const optionsUnderParent = tier2Options.filter(
+      (o) => o.parentId === parentId
+    )
+    const mutexGroupMap = new Map<string, string[]>()
+    for (const opt of optionsUnderParent) {
+      if (opt.mutexGroup) {
+        const existing = mutexGroupMap.get(opt.mutexGroup) ?? []
+        existing.push(opt.id)
+        mutexGroupMap.set(opt.mutexGroup, existing)
+      }
+    }
+    tier2ByParent[parentId].mutex_groups = Array.from(
+      mutexGroupMap.values()
+    ).filter((g) => g.length > 1)
+  }
+
+  const tier2: TaxonomyTier2 = {
+    label: version.tierLabels.tier2.label,
+    key: version.tierLabels.tier2.key,
+    conditional_on: version.tierLabels.tier2.conditional_on,
+    options_by_parent: tier2ByParent,
+  }
+
+  const tier3ByParent: Record<string, Tier3Option[]> = {}
+  for (const option of tier3Options) {
+    const parentId = option.parentId ?? ''
+    if (!tier3ByParent[parentId]) {
+      tier3ByParent[parentId] = []
+    }
+    tier3ByParent[parentId].push({ id: option.id, label: option.label })
+  }
+
+  const tier3: TaxonomyTier3 = {
+    label: version.tierLabels.tier3.label,
+    key: version.tierLabels.tier3.key,
+    conditional_on: version.tierLabels.tier3.conditional_on,
+    options_by_parent: tier3ByParent,
+  }
+
+  return {
+    version: version.version,
+    description: version.description,
+    tiers: { tier1, tier2, tier3 },
+  }
+}
+
+export async function getLatestTagTaxonomy(
+  db: Database
+): Promise<TaxonomyResponse | null> {
+  const [latestVersion] = await db
+    .select()
+    .from(planTagVersions)
+    .orderBy(desc(planTagVersions.createdAt))
+    .limit(1)
+
+  if (!latestVersion) return null
+
+  const options = await db
+    .select()
+    .from(planTagOptions)
+    .where(eq(planTagOptions.versionId, latestVersion.id))
+
+  if (options.length === 0) return null
+
+  return assembleTaxonomyResponse(latestVersion, options)
+}

--- a/tests/integration/plan-tags.test.ts
+++ b/tests/integration/plan-tags.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  closeTestDatabase,
+  getTestDb,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+} from '../helpers/auth.js'
+import { planTagVersions, planTagOptions } from '../../src/db/schema.js'
+import type { TierLabels } from '../../src/db/schema.js'
+
+const SERVICE_KEY = 'test-service-key-12345'
+
+const TIER_LABELS: TierLabels = {
+  tier1: { label: 'What kind of trip is this?', key: 'plan_type' },
+  tier2: {
+    label: 'Tell us a bit more',
+    key: 'logistics',
+    conditional_on: 'tier1',
+  },
+  tier3: {
+    label: 'A few more details',
+    key: 'specifics',
+    conditional_on: 'tier2',
+  },
+}
+
+async function seedMinimalTaxonomy() {
+  const db = await getTestDb()
+  const [version] = await db
+    .insert(planTagVersions)
+    .values({
+      version: '1.0',
+      description: 'Test taxonomy',
+      tierLabels: TIER_LABELS,
+    })
+    .returning()
+
+  await db.insert(planTagOptions).values([
+    {
+      id: 'camping',
+      versionId: version.id,
+      tier: 1,
+      parentId: null,
+      label: 'Camping',
+      emoji: '⛺',
+      sortOrder: 0,
+    },
+    {
+      id: 'camping_tent',
+      versionId: version.id,
+      tier: 2,
+      parentId: 'camping',
+      label: 'Tent',
+      sortOrder: 0,
+      mutexGroup: 'sleep',
+    },
+    {
+      id: 'camping_cabin',
+      versionId: version.id,
+      tier: 2,
+      parentId: 'camping',
+      label: 'Cabin',
+      sortOrder: 1,
+      mutexGroup: 'sleep',
+    },
+    {
+      id: 'tent_shared',
+      versionId: version.id,
+      tier: 3,
+      parentId: 'camping_tent',
+      label: 'Sharing tents',
+      sortOrder: 0,
+    },
+  ])
+
+  return version
+}
+
+async function clearTaxonomy() {
+  const db = await getTestDb()
+  await db.delete(planTagVersions)
+}
+
+describe('GET /plan-tags (FE endpoint — JWT required)', () => {
+  let app: FastifyInstance
+  let userToken: string
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    await setupTestKeys()
+    userToken = await signTestJwt({
+      sub: 'aaaaaaaa-1111-2222-3333-444444444444',
+    })
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+        rateLimit: false,
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await clearTaxonomy()
+  })
+
+  it('returns 401 without JWT', async () => {
+    const response = await app.inject({ method: 'GET', url: '/plan-tags' })
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 401 with invalid JWT', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: 'Bearer not-a-real-token' },
+    })
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 404 when no taxonomy exists', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: `Bearer ${userToken}` },
+    })
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('No tag taxonomy found')
+  })
+
+  it('returns 200 with full taxonomy structure when authenticated', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: `Bearer ${userToken}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+
+    expect(body.version).toBe('1.0')
+    expect(body.description).toBe('Test taxonomy')
+    expect(body.tiers).toBeDefined()
+    expect(body.tiers.tier1).toBeDefined()
+    expect(body.tiers.tier2).toBeDefined()
+    expect(body.tiers.tier3).toBeDefined()
+  })
+
+  it('returns tier1 options array', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: `Bearer ${userToken}` },
+    })
+
+    const body = response.json()
+    expect(body.tiers.tier1.options).toHaveLength(1)
+    expect(body.tiers.tier1.options[0]).toEqual({
+      id: 'camping',
+      label: 'Camping',
+      emoji: '⛺',
+    })
+  })
+
+  it('returns tier2 options_by_parent with mutex_groups', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: `Bearer ${userToken}` },
+    })
+
+    const body = response.json()
+    const camping = body.tiers.tier2.options_by_parent['camping']
+    expect(camping).toBeDefined()
+    expect(camping.options).toHaveLength(2)
+    expect(camping.mutex_groups).toContainEqual([
+      'camping_tent',
+      'camping_cabin',
+    ])
+    expect(camping.cross_group_rules).toEqual([])
+  })
+
+  it('returns tier3 options_by_parent', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: `Bearer ${userToken}` },
+    })
+
+    const body = response.json()
+    expect(body.tiers.tier3.options_by_parent['camping_tent']).toEqual([
+      { id: 'tent_shared', label: 'Sharing tents' },
+    ])
+  })
+
+  it('returns the latest version when multiple versions exist', async () => {
+    const db = await getTestDb()
+    await seedMinimalTaxonomy()
+
+    const [v2] = await db
+      .insert(planTagVersions)
+      .values({
+        version: '2.0',
+        description: 'Newer taxonomy',
+        tierLabels: TIER_LABELS,
+      })
+      .returning()
+
+    await db.insert(planTagOptions).values([
+      {
+        id: 'beach',
+        versionId: v2.id,
+        tier: 1,
+        parentId: null,
+        label: 'Beach',
+        emoji: '🏖️',
+        sortOrder: 0,
+      },
+    ])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/plan-tags',
+      headers: { authorization: `Bearer ${userToken}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().version).toBe('2.0')
+  })
+})
+
+describe('GET /api/internal/plan-tags (chatbot endpoint — x-service-key)', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    process.env.CHATBOT_SERVICE_KEY = SERVICE_KEY
+    app = await buildApp({ db }, { logger: false, rateLimit: false })
+  })
+
+  afterAll(async () => {
+    await app.close()
+    delete process.env.CHATBOT_SERVICE_KEY
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await clearTaxonomy()
+  })
+
+  it('returns 401 without x-service-key', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/internal/plan-tags',
+    })
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 401 with invalid x-service-key', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/internal/plan-tags',
+      headers: { 'x-service-key': 'wrong-key' },
+    })
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('returns 404 when no taxonomy exists', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/internal/plan-tags',
+      headers: { 'x-service-key': SERVICE_KEY },
+    })
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('No tag taxonomy found')
+  })
+
+  it('returns 200 with full taxonomy using valid service key', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/internal/plan-tags',
+      headers: { 'x-service-key': SERVICE_KEY },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.version).toBe('1.0')
+    expect(body.tiers.tier1.options[0].id).toBe('camping')
+  })
+
+  it('works without x-user-id header — taxonomy is not user-specific', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/internal/plan-tags',
+      headers: { 'x-service-key': SERVICE_KEY },
+    })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('returns the same taxonomy version as the FE endpoint (both read latest version)', async () => {
+    await seedMinimalTaxonomy()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/internal/plan-tags',
+      headers: { 'x-service-key': SERVICE_KEY },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.version).toBe('1.0')
+    expect(body.tiers.tier1).toBeDefined()
+    expect(body.tiers.tier2).toBeDefined()
+    expect(body.tiers.tier3).toBeDefined()
+  })
+})

--- a/tests/unit/plan-tags.test.ts
+++ b/tests/unit/plan-tags.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect } from 'vitest'
+import { assembleTaxonomyResponse } from '../../src/services/plan-tags.service.js'
+import type { TierLabels } from '../../src/db/schema.js'
+
+const TEST_TIER_LABELS: TierLabels = {
+  tier1: { label: 'What kind of trip?', key: 'plan_type' },
+  tier2: { label: 'More details', key: 'logistics', conditional_on: 'tier1' },
+  tier3: { label: 'Specifics', key: 'specifics', conditional_on: 'tier2' },
+}
+
+const TEST_VERSION = {
+  version: '1.0',
+  description: 'Test taxonomy',
+  tierLabels: TEST_TIER_LABELS,
+}
+
+describe('assembleTaxonomyResponse', () => {
+  it('builds correct tier1 options with sort order and emoji', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'beach',
+        tier: 1,
+        parentId: null,
+        label: 'Beach',
+        emoji: '🏖️',
+        sortOrder: 1,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    expect(result.version).toBe('1.0')
+    expect(result.description).toBe('Test taxonomy')
+    expect(result.tiers.tier1.options).toHaveLength(2)
+    expect(result.tiers.tier1.options[0]).toEqual({
+      id: 'camping',
+      label: 'Camping',
+      emoji: '⛺',
+    })
+    expect(result.tiers.tier1.options[1]).toEqual({
+      id: 'beach',
+      label: 'Beach',
+      emoji: '🏖️',
+    })
+  })
+
+  it('sorts options by sortOrder within each tier and parent', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 1,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'beach',
+        tier: 1,
+        parentId: null,
+        label: 'Beach',
+        emoji: '🏖️',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_wild',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Wild camping',
+        emoji: null,
+        sortOrder: 1,
+        mutexGroup: 'site',
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_organized',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Organized',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: 'site',
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    expect(result.tiers.tier1.options[0].id).toBe('beach')
+    expect(result.tiers.tier1.options[1].id).toBe('camping')
+    expect(result.tiers.tier2.options_by_parent['camping'].options[0].id).toBe(
+      'camping_organized'
+    )
+    expect(result.tiers.tier2.options_by_parent['camping'].options[1].id).toBe(
+      'camping_wild'
+    )
+  })
+
+  it('groups tier-2 options by parent_id into options_by_parent', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'beach',
+        tier: 1,
+        parentId: null,
+        label: 'Beach',
+        emoji: '🏖️',
+        sortOrder: 1,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_tent',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Tent',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'beach_hotel',
+        tier: 2,
+        parentId: 'beach',
+        label: 'Hotel',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    expect(Object.keys(result.tiers.tier2.options_by_parent)).toEqual([
+      'camping',
+      'beach',
+    ])
+    expect(
+      result.tiers.tier2.options_by_parent['camping'].options
+    ).toHaveLength(1)
+    expect(result.tiers.tier2.options_by_parent['beach'].options).toHaveLength(
+      1
+    )
+  })
+
+  it('reconstructs mutex_groups from mutex_group column', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_tent',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Tent',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: 'sleep',
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_cabin',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Cabin',
+        emoji: null,
+        sortOrder: 1,
+        mutexGroup: 'sleep',
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_cooking',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Cooking',
+        emoji: null,
+        sortOrder: 2,
+        mutexGroup: 'food',
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_eating_out',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Eating out',
+        emoji: null,
+        sortOrder: 3,
+        mutexGroup: 'food',
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_organized',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Organized',
+        emoji: null,
+        sortOrder: 4,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    const block = result.tiers.tier2.options_by_parent['camping']
+    expect(block.mutex_groups).toHaveLength(2)
+    expect(block.mutex_groups).toContainEqual(['camping_tent', 'camping_cabin'])
+    expect(block.mutex_groups).toContainEqual([
+      'camping_cooking',
+      'camping_eating_out',
+    ])
+  })
+
+  it('options with no mutex_group are not included in mutex_groups', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_tent',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Tent',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_cabin',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Cabin',
+        emoji: null,
+        sortOrder: 1,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    expect(
+      result.tiers.tier2.options_by_parent['camping'].mutex_groups
+    ).toHaveLength(0)
+  })
+
+  it('attaches cross_group_rules with trigger field from option id', () => {
+    const options = [
+      {
+        id: 'hotel_trip',
+        tier: 1,
+        parentId: null,
+        label: 'Hotel Stay',
+        emoji: '🏨',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'hotel_apartment',
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Airbnb',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: 'stay',
+        crossGroupRules: [
+          {
+            disable: ['hotel_hotel_meals'],
+            disable_tooltip: 'Hotel meals only with hotel stay',
+          },
+        ],
+      },
+      {
+        id: 'hotel_hotel_meals',
+        tier: 2,
+        parentId: 'hotel_trip',
+        label: 'Hotel meals',
+        emoji: null,
+        sortOrder: 1,
+        mutexGroup: 'food',
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    const block = result.tiers.tier2.options_by_parent['hotel_trip']
+    expect(block.cross_group_rules).toHaveLength(1)
+    expect(block.cross_group_rules[0]).toEqual({
+      trigger: 'hotel_apartment',
+      disable: ['hotel_hotel_meals'],
+      disable_tooltip: 'Hotel meals only with hotel stay',
+    })
+  })
+
+  it('groups tier-3 options by parent_id', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_cooking',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Cooking',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'cooking_shared',
+        tier: 3,
+        parentId: 'camping_cooking',
+        label: 'Shared meals',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'cooking_own',
+        tier: 3,
+        parentId: 'camping_cooking',
+        label: 'Own meals',
+        emoji: null,
+        sortOrder: 1,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    expect(result.tiers.tier3.options_by_parent['camping_cooking']).toEqual([
+      { id: 'cooking_shared', label: 'Shared meals' },
+      { id: 'cooking_own', label: 'Own meals' },
+    ])
+  })
+
+  it('returns empty mutex_groups and cross_group_rules arrays when none exist', () => {
+    const options = [
+      {
+        id: 'camping',
+        tier: 1,
+        parentId: null,
+        label: 'Camping',
+        emoji: '⛺',
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+      {
+        id: 'camping_tent',
+        tier: 2,
+        parentId: 'camping',
+        label: 'Tent',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+
+    const block = result.tiers.tier2.options_by_parent['camping']
+    expect(block.mutex_groups).toEqual([])
+    expect(block.cross_group_rules).toEqual([])
+  })
+
+  it('uses tier_labels from the version row for tier keys and labels', () => {
+    const result = assembleTaxonomyResponse(TEST_VERSION, [])
+
+    expect(result.tiers.tier1.label).toBe('What kind of trip?')
+    expect(result.tiers.tier1.key).toBe('plan_type')
+    expect(result.tiers.tier2.conditional_on).toBe('tier1')
+    expect(result.tiers.tier3.conditional_on).toBe('tier2')
+  })
+
+  it('uses empty string for emoji when emoji is null', () => {
+    const options = [
+      {
+        id: 'other',
+        tier: 1,
+        parentId: null,
+        label: 'Other',
+        emoji: null,
+        sortOrder: 0,
+        mutexGroup: null,
+        crossGroupRules: null,
+      },
+    ]
+    const result = assembleTaxonomyResponse(TEST_VERSION, options)
+    expect(result.tiers.tier1.options[0].emoji).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Store the 3-tier plan-creation tag taxonomy in the database and expose it via two endpoints:

- `GET /plan-tags` (JWT required) — returns the full assembled taxonomy for the plan creation wizard
- `GET /api/internal/plan-tags` (x-service-key, no x-user-id) — same response for the WhatsApp chatbot

The taxonomy is stored in two normalized tables (`plan_tag_versions` + `plan_tag_options`) with explicit parent-child FKs, mutex group columns, and cross-group rules as JSONB on the triggering option. A service function assembles the nested JSON the frontend already expects, so no FE changes are needed to the response shape. Seeded with v1.2 taxonomy (10 plan types, ~64 tier-2 logistics options with mutex groups + cross-group rules, ~70 tier-3 specifics).

Also adds a Step 0 branch check to `workflow.mdc` to prevent future commits directly to main.

## Test on Production

- [ ] `GET /plan-tags` with a valid JWT → 200, response has `version: "1.2"`, `tiers.tier1.options` contains 10 plan types with emojis
- [ ] `GET /plan-tags` without a token → 401
- [ ] `GET /api/internal/plan-tags` with valid `x-service-key` → 200, same structure
- [ ] `GET /api/internal/plan-tags` without `x-service-key` → 401
- [ ] After deploy: run `npm run db:migrate:prod` then `npm run db:seed` to apply the migration and seed v1.2 taxonomy

## Closes

Closes #186

Made with [Cursor](https://cursor.com)