### PR TITLE
feat(plan-tags): add contradiction rules and single-select enforcemen…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3962,6 +3962,19 @@
                   "type": "string",
                   "description": "Internal note explaining why this flag exists. Not shown to users."
                 },
+                "contradictions": {
+                  "type": "array",
+                  "description": "Only present on multi-select flags. Lists pairs of option ids that CANNOT both be selected at the same time.\n\n**FE handling:** When the user selects option A, check every pair in this array. If A appears in a pair, automatically deselect (and visually disable) the other option in that pair. Re-enable it if A is later deselected.\n\nExample: `[[\"chill\", \"party_oriented\"], [\"chill\", \"adventurous\"]]` means selecting \"chill\" should deselect \"party_oriented\" and \"adventurous\".",
+                  "items": {
+                    "type": "array",
+                    "description": "A pair of mutually exclusive option ids.",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
                 "options": {
                   "type": "array",
                   "items": {
@@ -4128,8 +4141,9 @@
           },
           "tier3": {
             "type": "object",
-            "description": "Optional drill-down specifics, conditional on tier2 selections. Absence of a key means no drill-down for that tier2 option.",
+            "description": "Optional drill-down specifics, conditional on tier2 selections.\n\n**Default behaviour: single-select.** Most tier3 groups are mutually exclusive — the user picks exactly one option. Only parent ids listed in `multi_select_parents` allow the user to pick multiple options.\n\n**FE rendering:**\n1. After a tier2 option is chosen, look up `options_by_parent[tier2OptionId]`.\n2. If the array exists → show it as a follow-up question below the tier2 axis.\n3. Check if `tier2OptionId` is in `multi_select_parents`:\n   - YES → render as a **checkbox group** (multi-select, no limit).\n   - NO  → render as a **radio group** (single-select).\n4. If `options_by_parent[tier2OptionId]` is absent → no drill-down for that selection.",
             "required": [
+              "multi_select_parents",
               "options_by_parent"
             ],
             "properties": {
@@ -4137,9 +4151,16 @@
                 "type": "string",
                 "description": "Internal note. Not shown to users."
               },
+              "multi_select_parents": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Array of tier2 option ids whose tier3 drill-down allows **multiple selections** (checkbox). All other tier3 groups are **single-select** (radio).\n\nCurrently only `\"booked_activity\"` is multi-select because its options are additive facts (equipment needed AND bookable AND rentable can all be true simultaneously). Every other tier3 group represents mutually exclusive alternatives.\n\n**FE check:** `tier3.multi_select_parents.includes(chosenTier2OptionId)`"
+              },
               "options_by_parent": {
                 "type": "object",
-                "description": "Maps a **tier2 option id** → array of drill-down options to show after that tier2 value is selected.\nIf a tier2 option id is absent from this map, no tier3 follow-up is shown for it.\nTier3 is always multi-select (the user can pick any combination).",
+                "description": "Maps a **tier2 option id** → array of drill-down options shown after that tier2 value is selected.\nAbsence of a key means no drill-down for that tier2 option.\nSelect mode (single vs multi) is determined by `multi_select_parents` — NOT by this map.",
                 "additionalProperties": {
                   "type": "array",
                   "items": {

--- a/src/data/plan-creation-tags.json
+++ b/src/data/plan-creation-tags.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.2",
-  "description": "Chillist plan creation wizard tag schema. Bilingual (en + he). Tier 1 = plan archetype (single-select). Universal flags asked once regardless of Tier 1. Tier 2 = named axes conditional on Tier 1, each axis internally single-select to prevent contradictions. Tier 3 = specifics conditional on Tier 2 values.",
+  "version": "1.3",
+  "description": "Chillist plan creation wizard tag schema. Bilingual (en + he). Tier 1 = plan archetype (single-select). Universal flags asked once regardless of Tier 1. Tier 2 = named axes conditional on Tier 1, each axis internally single-select to prevent contradictions. Tier 3 = specifics conditional on Tier 2 values (single-select by default; see multi_select_parents).",
 
   "structural_contract": {
     "purpose": "Structural guarantees both consumers (frontend wizard + chatbot service) rely on. Changes to data INSIDE these structures are safe. Changes to the structure ITSELF require coordinated updates to consumer code and bot instructions.",
@@ -9,9 +9,9 @@
       "Every user-facing 'label' field is an object of the shape { en: string, he: string }. Consumers pick the language at render time.",
       "All 'id' values are stable English strings safe to use as database values. Renaming an id is a breaking change; editing a label (en or he) is not.",
       "tier1 has 'select' ('single') and 'options' (array of {id, label, emoji}).",
-      "universal_flags maps flag names to definitions with 'key', 'select', 'required', 'options'. Multi-select flags may include 'max_select'.",
+      "universal_flags maps flag names to definitions with 'key', 'select', 'required', 'options'. Multi-select flags may include 'max_select' and 'contradictions'.",
       "tier2_axes maps axis names to definitions with 'key', 'select', 'shown_for_tier1', 'options'. Single-select axes may include 'defaults_by_tier1' and 'hidden_options_by_tier1'.",
-      "tier3.options_by_parent maps a tier2 option id to an array of drill-down options. Absence means no drill-down.",
+      "tier3.options_by_parent maps a tier2 option id to an array of drill-down options. Absence means no drill-down. Default select is 'single'; tier3.multi_select_parents lists the exceptions.",
       "item_generation_bundles maps bundle names to arrays of item strings (also bilingual)."
     ],
     "safe_changes_no_consumer_update_needed": [
@@ -21,7 +21,9 @@
       "Changing 'defaults_by_tier1' or 'hidden_options_by_tier1' values",
       "Changing which tier1 ids appear in 'shown_for_tier1' for an axis",
       "Adding new entries to tier3.options_by_parent",
-      "Adding new bundles to item_generation_bundles"
+      "Adding new bundles to item_generation_bundles",
+      "Adding or removing pairs in universal_flags[*].contradictions",
+      "Adding or removing ids in tier3.multi_select_parents"
     ],
     "breaking_changes_consumer_update_required": [
       "Adding a new top-level key (e.g. tier4)",
@@ -36,7 +38,8 @@
     "Wizard only captures what the owner knows at creation time, isn't derivable later, and materially changes the item list.",
     "Each Tier 2 axis is internally single-select to prevent contradictions. 'Mix' is its own value, not two checkboxes.",
     "Activities is the only multi-select Tier 2 axis.",
-    "No 'Other' Tier 1 — absence signals which archetype is missing for v1.3.",
+    "Tier 3 is single-select by default. Only groups listed in tier3.multi_select_parents allow multiple selections.",
+    "No 'Other' Tier 1 — absence signals which archetype is missing for v1.4.",
     "Group composition (kids, pets, dietary) and weather/season are excluded — derived later from participants and dates."
   ],
 
@@ -80,12 +83,17 @@
       "required": false,
       "asked_for_all_tier1": true,
       "purpose": "Feeds the LLM item-generation prompt. Each trait demonstrably shifts the item list.",
+      "contradictions": [
+        ["chill", "party_oriented"],
+        ["chill", "adventurous"],
+        ["comfort_first", "adventurous"]
+      ],
       "options": [
-        { "id": "hygiene_conscious", "label": { "en": "Hygiene-conscious",            "he": "מקפידים על ניקיון" }, "emoji": "🧼" },
-        { "id": "party_oriented",    "label": { "en": "Party-oriented / heavy drinkers","he": "אוהבים לחגוג / שותים" }, "emoji": "🍻" },
-        { "id": "chill",             "label": { "en": "Chill / low-key",               "he": "רגועים" },            "emoji": "🧘" },
-        { "id": "adventurous",       "label": { "en": "Adventurous / outdoorsy",      "he": "הרפתקנים / אוהבי טבע" }, "emoji": "🏕️" },
-        { "id": "comfort_first",     "label": { "en": "Comfort-first / glampers",     "he": "אוהבי נוחות / גלמפינג" }, "emoji": "✨" }
+        { "id": "hygiene_conscious", "label": { "en": "Hygiene-conscious",             "he": "מקפידים על ניקיון" },       "emoji": "🧼" },
+        { "id": "party_oriented",    "label": { "en": "Party-oriented / heavy drinkers","he": "אוהבים לחגוג / שותים" },    "emoji": "🍻" },
+        { "id": "chill",             "label": { "en": "Chill / low-key",               "he": "רגועים" },                  "emoji": "🧘" },
+        { "id": "adventurous",       "label": { "en": "Adventurous / outdoorsy",       "he": "הרפתקנים / אוהבי טבע" },    "emoji": "🏕️" },
+        { "id": "comfort_first",     "label": { "en": "Comfort-first / glampers",      "he": "אוהבי נוחות / גלמפינג" },   "emoji": "✨" }
       ]
     }
   },
@@ -181,7 +189,8 @@
   },
 
   "tier3": {
-    "description": "Specifics conditional on Tier 2 values. Keyed by Tier 2 option id.",
+    "description": "Specifics conditional on Tier 2 values. Keyed by Tier 2 option id. Single-select by default. Only parent ids listed in multi_select_parents allow multiple selections.",
+    "multi_select_parents": ["booked_activity"],
     "options_by_parent": {
       "tent": [
         { "id": "tent_shared",  "label": { "en": "Sharing tents",                "he": "מתחלקים באוהלים" } },
@@ -197,8 +206,8 @@
         { "id": "mixed_flexible",  "label": { "en": "Finding places as we go", "he": "מוצאים מקומות תוך כדי" } }
       ],
       "cooking_ourselves": [
-        { "id": "cook_shared_meals", "label": { "en": "Shared group meals",           "he": "ארוחות משותפות לכולם" } },
-        { "id": "cook_each_own",     "label": { "en": "Everyone cooks their own",     "he": "כל אחד מבשל לעצמו" } },
+        { "id": "cook_shared_meals", "label": { "en": "Shared group meals",            "he": "ארוחות משותפות לכולם" } },
+        { "id": "cook_each_own",     "label": { "en": "Everyone cooks their own",      "he": "כל אחד מבשל לעצמו" } },
         { "id": "cook_assigned",     "label": { "en": "Assigned cooking duties per day","he": "תורנות בישול לפי ימים" } }
       ],
       "mixed_food": [
@@ -207,16 +216,16 @@
         { "id": "mix_balanced",     "label": { "en": "Roughly balanced",                              "he": "בערך חצי חצי" } }
       ],
       "all_inclusive": [
-        { "id": "ai_full_board",       "label": { "en": "Full board (all meals)", "he": "פנסיון מלא" } },
-        { "id": "ai_half_board",       "label": { "en": "Half board (2 meals)",   "he": "חצי פנסיון" } },
-        { "id": "ai_drinks_included",  "label": { "en": "Drinks included",        "he": "כולל שתייה" } }
+        { "id": "ai_full_board",  "label": { "en": "Full board (all meals)", "he": "פנסיון מלא" } },
+        { "id": "ai_half_board",  "label": { "en": "Half board (2 meals)",   "he": "חצי פנסיון" } },
+        { "id": "ai_drinks_only", "label": { "en": "Drinks only",            "he": "רק שתייה" } }
       ],
       "potluck": [
-        { "id": "potluck_assigned", "label": { "en": "Assigned dishes per person", "he": "מחלקים מראש מי מביא מה" } },
+        { "id": "potluck_assigned", "label": { "en": "Assigned dishes per person",    "he": "מחלקים מראש מי מביא מה" } },
         { "id": "potluck_free",     "label": { "en": "Everyone brings what they want", "he": "כל אחד מביא מה שבא לו" } }
       ],
       "packed_food": [
-        { "id": "packed_shared",   "label": { "en": "Shared group supplies",   "he": "אוכל משותף לכולם" } },
+        { "id": "packed_shared",   "label": { "en": "Shared group supplies",      "he": "אוכל משותף לכולם" } },
         { "id": "packed_each_own", "label": { "en": "Each person packs their own", "he": "כל אחד אורז לעצמו" } }
       ],
       "booked_activity": [
@@ -225,8 +234,8 @@
         { "id": "activity_booking_needed",    "label": { "en": "Needs advance booking",         "he": "צריך הזמנה מראש" } }
       ],
       "kayaking": [
-        { "id": "water_gear_owned",  "label": { "en": "Bringing own gear",   "he": "מביאים ציוד משלנו" } },
-        { "id": "water_gear_rental", "label": { "en": "Renting on-site",     "he": "שוכרים במקום" } }
+        { "id": "water_gear_owned",  "label": { "en": "Bringing own gear", "he": "מביאים ציוד משלנו" } },
+        { "id": "water_gear_rental", "label": { "en": "Renting on-site",   "he": "שוכרים במקום" } }
       ],
       "someones_home": [
         { "id": "home_host_provides", "label": { "en": "Host provides everything", "he": "המארח דואג להכל" } },
@@ -234,9 +243,9 @@
         { "id": "home_hired_help",    "label": { "en": "Hired chef / catering",    "he": "שף / קייטרינג" } }
       ],
       "outdoor_bbq": [
-        { "id": "bbq_shared_food", "label": { "en": "Shared group food",                    "he": "אוכל משותף לכולם" } },
-        { "id": "bbq_bring_own",   "label": { "en": "Everyone brings their own meat/food",  "he": "כל אחד מביא את הבשר/אוכל שלו" } },
-        { "id": "bbq_assigned",    "label": { "en": "Assigned items per person",            "he": "מחלקים מראש מי מביא מה" } }
+        { "id": "bbq_shared_food", "label": { "en": "Shared group food",                   "he": "אוכל משותף לכולם" } },
+        { "id": "bbq_bring_own",   "label": { "en": "Everyone brings their own meat/food", "he": "כל אחד מביא את הבשר/אוכל שלו" } },
+        { "id": "bbq_assigned",    "label": { "en": "Assigned items per person",           "he": "מחלקים מראש מי מביא מה" } }
       ],
       "restaurant_venue": [
         { "id": "venue_prebooked", "label": { "en": "Pre-booked / reserved", "he": "הזמנו מראש" } },
@@ -259,6 +268,12 @@
   },
 
   "changelog": {
+    "1.3": [
+      "Added group_character.contradictions — pairs of option ids that cannot both be selected. FE should deselect the previous choice when a contradicting option is picked.",
+      "Added tier3.multi_select_parents — array of tier2 option ids whose tier3 drill-downs allow multi-select. All other tier3 groups are single-select.",
+      "Fixed all_inclusive tier3: replaced ambiguous 'ai_drinks_included' add-on with 'ai_drinks_only' as a proper single-select alternative to board options.",
+      "Updated structural_contract and design_principles to document the new selection rules."
+    ],
     "1.2": [
       "Added bilingual labels (en + he) to all user-facing strings.",
       "All 'label' fields now follow the shape { en, he }.",

--- a/src/schemas/plan-tags.schema.ts
+++ b/src/schemas/plan-tags.schema.ts
@@ -19,7 +19,12 @@
  *    - Hide options whose id appears in `hidden_options_by_tier1[chosenTier1Id]`.
  *    - `select: "single"` for most axes; `select: "multi"` for `activities`.
  * 4. After a tier2 option is chosen, check `tier3.options_by_parent[tier2OptionId]`.
- *    If entries exist → show as a follow-up multi-select drill-down.
+ *    If entries exist → show as a follow-up drill-down.
+ *    - Check `tier3.multi_select_parents.includes(tier2OptionId)`:
+ *      YES → multi-select (checkbox). NO → single-select (radio).
+ * 5. For multi-select flags with `contradictions`:
+ *    When the user selects option A, find all pairs containing A and deselect+disable
+ *    the other option in each pair. Re-enable when A is deselected.
  *
  * ## Stable id contract
  * All `id` values are stable English slugs safe to store in the database.
@@ -181,6 +186,23 @@ Render after tier1, before tier2_axes.
             description:
               'Internal note explaining why this flag exists. Not shown to users.',
           },
+          contradictions: {
+            type: 'array',
+            description: `
+Only present on multi-select flags. Lists pairs of option ids that CANNOT both be selected at the same time.
+
+**FE handling:** When the user selects option A, check every pair in this array. If A appears in a pair, automatically deselect (and visually disable) the other option in that pair. Re-enable it if A is later deselected.
+
+Example: \`[["chill", "party_oriented"], ["chill", "adventurous"]]\` means selecting "chill" should deselect "party_oriented" and "adventurous".
+            `.trim(),
+            items: {
+              type: 'array',
+              description: 'A pair of mutually exclusive option ids.',
+              minItems: 2,
+              maxItems: 2,
+              items: { type: 'string' },
+            },
+          },
           options: {
             type: 'array',
             items: tagOption,
@@ -254,20 +276,42 @@ Each key is the axis name (matches the \`key\` field inside).
     // ─── Tier 3 ────────────────────────────────────────────────────────────
     tier3: {
       type: 'object',
-      description:
-        'Optional drill-down specifics, conditional on tier2 selections. Absence of a key means no drill-down for that tier2 option.',
-      required: ['options_by_parent'],
+      description: `
+Optional drill-down specifics, conditional on tier2 selections.
+
+**Default behaviour: single-select.** Most tier3 groups are mutually exclusive — the user picks exactly one option. Only parent ids listed in \`multi_select_parents\` allow the user to pick multiple options.
+
+**FE rendering:**
+1. After a tier2 option is chosen, look up \`options_by_parent[tier2OptionId]\`.
+2. If the array exists → show it as a follow-up question below the tier2 axis.
+3. Check if \`tier2OptionId\` is in \`multi_select_parents\`:
+   - YES → render as a **checkbox group** (multi-select, no limit).
+   - NO  → render as a **radio group** (single-select).
+4. If \`options_by_parent[tier2OptionId]\` is absent → no drill-down for that selection.
+      `.trim(),
+      required: ['multi_select_parents', 'options_by_parent'],
       properties: {
         description: {
           type: 'string',
           description: 'Internal note. Not shown to users.',
         },
+        multi_select_parents: {
+          type: 'array',
+          items: { type: 'string' },
+          description: `
+Array of tier2 option ids whose tier3 drill-down allows **multiple selections** (checkbox). All other tier3 groups are **single-select** (radio).
+
+Currently only \`"booked_activity"\` is multi-select because its options are additive facts (equipment needed AND bookable AND rentable can all be true simultaneously). Every other tier3 group represents mutually exclusive alternatives.
+
+**FE check:** \`tier3.multi_select_parents.includes(chosenTier2OptionId)\`
+          `.trim(),
+        },
         options_by_parent: {
           type: 'object',
           description: `
-Maps a **tier2 option id** → array of drill-down options to show after that tier2 value is selected.
-If a tier2 option id is absent from this map, no tier3 follow-up is shown for it.
-Tier3 is always multi-select (the user can pick any combination).
+Maps a **tier2 option id** → array of drill-down options shown after that tier2 value is selected.
+Absence of a key means no drill-down for that tier2 option.
+Select mode (single vs multi) is determined by \`multi_select_parents\` — NOT by this map.
           `.trim(),
           additionalProperties: {
             type: 'array',

--- a/tests/unit/plan-tags.test.ts
+++ b/tests/unit/plan-tags.test.ts
@@ -13,10 +13,9 @@ describe('getPlanTags', () => {
     expect(tags).toHaveProperty('item_generation_bundles')
   })
 
-  it('version is a non-empty string', () => {
+  it('version is 1.3', () => {
     const tags = getPlanTags()
-    expect(typeof tags['version']).toBe('string')
-    expect((tags['version'] as string).length).toBeGreaterThan(0)
+    expect(tags['version']).toBe('1.3')
   })
 
   it('tier1 has options array with id, bilingual label, emoji on each entry', () => {
@@ -46,12 +45,29 @@ describe('getPlanTags', () => {
     expect(Object.keys(axes).length).toBeGreaterThan(0)
   })
 
-  it('tier3 has options_by_parent mapping', () => {
+  it('tier3 has options_by_parent mapping and multi_select_parents array', () => {
     const tags = getPlanTags()
     const tier3 = tags['tier3'] as {
       options_by_parent: Record<string, unknown>
+      multi_select_parents: string[]
     }
     expect(typeof tier3.options_by_parent).toBe('object')
+    expect(Array.isArray(tier3.multi_select_parents)).toBe(true)
+    expect(tier3.multi_select_parents).toContain('booked_activity')
+  })
+
+  it('group_character flag has contradictions array with valid pairs', () => {
+    const tags = getPlanTags()
+    const flag = (tags['universal_flags'] as Record<string, unknown>)[
+      'group_character'
+    ] as { contradictions: string[][] }
+    expect(Array.isArray(flag.contradictions)).toBe(true)
+    expect(flag.contradictions.length).toBeGreaterThan(0)
+    for (const pair of flag.contradictions) {
+      expect(pair).toHaveLength(2)
+      expect(typeof pair[0]).toBe('string')
+      expect(typeof pair[1]).toBe('string')
+    }
   })
 
   it('returns the same reference on every call (cached)', () => {


### PR DESCRIPTION
…t in v1.3 taxonomy

- Bump taxonomy to v1.3
- Add `contradictions` pairs to group_character flag (chill/party, chill/adventurous, comfort_first/adventurous)
- Add `tier3.multi_select_parents` — only booked_activity is multi-select; all other tier3 groups default to single-select
- Fix all_inclusive tier3: replace ai_drinks_included add-on with ai_drinks_only as a proper single-select alternative
- Update OpenAPI schema with explicit FE handling instructions for both new fields
- Update unit tests to assert v1.3, multi_select_parents, and contradictions structure

Made-with: Cursor