### PR TITLE
feat(plan-tags): add selection_by_tier and tier3 default_select for v1.4

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3794,9 +3794,10 @@
       },
       "def-99": {
         "type": "object",
-        "description": "Plan tag taxonomy served as a static versioned JSON file.\nLabels are bilingual objects `{ en, he }` — pick the active locale at render time.\nAll `id` values are stable slugs safe to persist as tag values.\n\n**Rendering order:** tier1 → universal_flags → tier2_axes (filtered by chosen tier1) → tier3 (drill-down per chosen tier2 value).",
+        "description": "Plan tag taxonomy served as a static versioned JSON file.\nLabels are bilingual objects `{ en, he }` — pick the active locale at render time.\nAll `id` values are stable slugs safe to persist as tag values.\n\n**Rendering order:** tier1 → universal_flags → tier2_axes (filtered by chosen tier1) → tier3 (drill-down per chosen tier2 value).\n\n**Selection summary:** Read `selection_by_tier` for explicit single vs multi per tier and per flag/axis. Nested objects remain authoritative (`tier1.select`, each flag/axis `select`, `tier3.default_select` + `multi_select_parents`).",
         "required": [
           "version",
+          "selection_by_tier",
           "tier1",
           "universal_flags",
           "tier2_axes",
@@ -3806,12 +3807,158 @@
         "properties": {
           "version": {
             "type": "string",
-            "description": "Taxonomy version string, e.g. \"1.2\".",
-            "example": "1.2"
+            "description": "Taxonomy version string, e.g. \"1.4\".",
+            "example": "1.4"
           },
           "description": {
             "type": "string",
             "description": "Human-readable summary of this taxonomy version."
+          },
+          "selection_by_tier": {
+            "type": "object",
+            "description": "At-a-glance summary of **single vs multi-select** for each wizard tier. Mirrors the `select` fields on nested definitions; use for routing (radio vs checkbox) without scanning the full tree.\n\n- **tier1.select** — always `single`.\n- **universal_flags.flags** — each flag has its own `select` (`single` or `multi` + optional `max_select`).\n- **tier2_axes.axes** — each axis has its own `select` (only `activities` is `multi` today).\n- **tier3** — `default_select` is `single`; parents listed in `multi_select_parents` use multi-select for that drill-down group.",
+            "required": [
+              "tier1",
+              "universal_flags",
+              "tier2_axes",
+              "tier3"
+            ],
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "Internal note for consumers."
+              },
+              "tier1": {
+                "type": "object",
+                "required": [
+                  "select"
+                ],
+                "properties": {
+                  "select": {
+                    "type": "string",
+                    "enum": [
+                      "single"
+                    ],
+                    "description": "Tier 1 is always single-select."
+                  },
+                  "note": {
+                    "type": "string"
+                  }
+                }
+              },
+              "universal_flags": {
+                "type": "object",
+                "description": "Each entry in `flags` matches a key under `universal_flags`.",
+                "required": [
+                  "mode",
+                  "flags"
+                ],
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "per_flag"
+                    ],
+                    "description": "Each flag is independent; open each definition for full options."
+                  },
+                  "note": {
+                    "type": "string"
+                  },
+                  "flags": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "required": [
+                        "select"
+                      ],
+                      "properties": {
+                        "select": {
+                          "type": "string",
+                          "enum": [
+                            "single",
+                            "multi"
+                          ]
+                        },
+                        "max_select": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "tier2_axes": {
+                "type": "object",
+                "required": [
+                  "mode",
+                  "axes"
+                ],
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "per_axis"
+                    ],
+                    "description": "Each axis is one question."
+                  },
+                  "note": {
+                    "type": "string"
+                  },
+                  "axes": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "required": [
+                        "select"
+                      ],
+                      "properties": {
+                        "select": {
+                          "type": "string",
+                          "enum": [
+                            "single",
+                            "multi"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "tier3": {
+                "type": "object",
+                "required": [
+                  "mode",
+                  "default_select",
+                  "multi_select_parents"
+                ],
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "per_tier2_option_id"
+                    ],
+                    "description": "Groups keyed by tier2 option id in options_by_parent."
+                  },
+                  "note": {
+                    "type": "string"
+                  },
+                  "default_select": {
+                    "type": "string",
+                    "enum": [
+                      "single"
+                    ],
+                    "description": "Each drill-down group is single-select unless the parent id is in multi_select_parents."
+                  },
+                  "multi_select_parents": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Tier2 option ids whose tier3 follow-up allows multiple selections."
+                  }
+                }
+              }
+            }
           },
           "tier1": {
             "type": "object",
@@ -4143,6 +4290,8 @@
             "type": "object",
             "description": "Optional drill-down specifics, conditional on tier2 selections.\n\n**Default behaviour: single-select.** Most tier3 groups are mutually exclusive — the user picks exactly one option. Only parent ids listed in `multi_select_parents` allow the user to pick multiple options.\n\n**FE rendering:**\n1. After a tier2 option is chosen, look up `options_by_parent[tier2OptionId]`.\n2. If the array exists → show it as a follow-up question below the tier2 axis.\n3. Check if `tier2OptionId` is in `multi_select_parents`:\n   - YES → render as a **checkbox group** (multi-select, no limit).\n   - NO  → render as a **radio group** (single-select).\n4. If `options_by_parent[tier2OptionId]` is absent → no drill-down for that selection.",
             "required": [
+              "select",
+              "default_select",
               "multi_select_parents",
               "options_by_parent"
             ],
@@ -4150,6 +4299,20 @@
               "description": {
                 "type": "string",
                 "description": "Internal note. Not shown to users."
+              },
+              "select": {
+                "type": "string",
+                "enum": [
+                  "per_parent"
+                ],
+                "description": "Tier 3 is organized as one follow-up group per tier2 option id (parent key in options_by_parent)."
+              },
+              "default_select": {
+                "type": "string",
+                "enum": [
+                  "single"
+                ],
+                "description": "Unless a parent tier2 id is in multi_select_parents, the user picks exactly one tier3 option."
               },
               "multi_select_parents": {
                 "type": "array",

--- a/src/data/plan-creation-tags.json
+++ b/src/data/plan-creation-tags.json
@@ -1,11 +1,43 @@
 {
-  "version": "1.3",
+  "version": "1.4",
   "description": "Chillist plan creation wizard tag schema. Bilingual (en + he). Tier 1 = plan archetype (single-select). Universal flags asked once regardless of Tier 1. Tier 2 = named axes conditional on Tier 1, each axis internally single-select to prevent contradictions. Tier 3 = specifics conditional on Tier 2 values (single-select by default; see multi_select_parents).",
+
+  "selection_by_tier": {
+    "description": "Explicit single- vs multi-select rules per wizard tier. Mirrors the select fields on nested objects; use this for at-a-glance UI logic.",
+    "tier1": {
+      "select": "single",
+      "note": "Exactly one plan archetype id from tier1.options."
+    },
+    "universal_flags": {
+      "mode": "per_flag",
+      "note": "Each key under universal_flags is a separate question; each has its own select field.",
+      "flags": {
+        "destination_scope": { "select": "single" },
+        "group_character": { "select": "multi", "max_select": 3 }
+      }
+    },
+    "tier2_axes": {
+      "mode": "per_axis",
+      "note": "Each key under tier2_axes is one axis; each has its own select field.",
+      "axes": {
+        "sleep": { "select": "single" },
+        "food_strategy": { "select": "single" },
+        "activities": { "select": "multi" },
+        "venue": { "select": "single" }
+      }
+    },
+    "tier3": {
+      "mode": "per_tier2_option_id",
+      "note": "Drill-down groups in options_by_parent, keyed by tier2 option id.",
+      "default_select": "single",
+      "multi_select_parents": ["booked_activity"]
+    }
+  },
 
   "structural_contract": {
     "purpose": "Structural guarantees both consumers (frontend wizard + chatbot service) rely on. Changes to data INSIDE these structures are safe. Changes to the structure ITSELF require coordinated updates to consumer code and bot instructions.",
     "guarantees": [
-      "Top-level keys are stable: 'version', 'tier1', 'universal_flags', 'tier2_axes', 'tier3', 'item_generation_bundles'.",
+      "Top-level keys are stable: 'version', 'selection_by_tier', 'tier1', 'universal_flags', 'tier2_axes', 'tier3', 'item_generation_bundles'.",
       "Every user-facing 'label' field is an object of the shape { en: string, he: string }. Consumers pick the language at render time.",
       "All 'id' values are stable English strings safe to use as database values. Renaming an id is a breaking change; editing a label (en or he) is not.",
       "tier1 has 'select' ('single') and 'options' (array of {id, label, emoji}).",
@@ -23,7 +55,8 @@
       "Adding new entries to tier3.options_by_parent",
       "Adding new bundles to item_generation_bundles",
       "Adding or removing pairs in universal_flags[*].contradictions",
-      "Adding or removing ids in tier3.multi_select_parents"
+      "Adding or removing ids in tier3.multi_select_parents",
+      "Editing selection_by_tier to match nested select fields when axes or flags change"
     ],
     "breaking_changes_consumer_update_required": [
       "Adding a new top-level key (e.g. tier4)",
@@ -190,6 +223,8 @@
 
   "tier3": {
     "description": "Specifics conditional on Tier 2 values. Keyed by Tier 2 option id. Single-select by default. Only parent ids listed in multi_select_parents allow multiple selections.",
+    "select": "per_parent",
+    "default_select": "single",
     "multi_select_parents": ["booked_activity"],
     "options_by_parent": {
       "tent": [
@@ -268,6 +303,10 @@
   },
 
   "changelog": {
+    "1.4": [
+      "Added selection_by_tier — explicit single vs multi (and per-flag / per-axis breakdown) for FE at-a-glance.",
+      "Added tier3.select ('per_parent'), tier3.default_select ('single'), and duplicated multi_select_parents under selection_by_tier.tier3 for consistency."
+    ],
     "1.3": [
       "Added group_character.contradictions — pairs of option ids that cannot both be selected. FE should deselect the previous choice when a contradicting option is picked.",
       "Added tier3.multi_select_parents — array of tier2 option ids whose tier3 drill-downs allow multi-select. All other tier3 groups are single-select.",

--- a/src/schemas/plan-tags.schema.ts
+++ b/src/schemas/plan-tags.schema.ts
@@ -29,6 +29,11 @@
  * ## Stable id contract
  * All `id` values are stable English slugs safe to store in the database.
  * Renaming an id is a breaking change; editing a label text is not.
+ *
+ * ## selection_by_tier
+ * Top-level summary of single vs multi for each tier (`tier1`, `universal_flags.flags`,
+ * `tier2_axes.axes`, `tier3`). Prefer reading nested `select` on each object; use
+ * `selection_by_tier` for quick UI routing.
  */
 
 /** Shared bilingual label shape used on every user-facing string. */
@@ -87,9 +92,12 @@ Labels are bilingual objects \`{ en, he }\` — pick the active locale at render
 All \`id\` values are stable slugs safe to persist as tag values.
 
 **Rendering order:** tier1 → universal_flags → tier2_axes (filtered by chosen tier1) → tier3 (drill-down per chosen tier2 value).
+
+**Selection summary:** Read \`selection_by_tier\` for explicit single vs multi per tier and per flag/axis. Nested objects remain authoritative (\`tier1.select\`, each flag/axis \`select\`, \`tier3.default_select\` + \`multi_select_parents\`).
   `.trim(),
   required: [
     'version',
+    'selection_by_tier',
     'tier1',
     'universal_flags',
     'tier2_axes',
@@ -99,13 +107,117 @@ All \`id\` values are stable slugs safe to persist as tag values.
   properties: {
     version: {
       type: 'string',
-      description: 'Taxonomy version string, e.g. "1.2".',
-      example: '1.2',
+      description: 'Taxonomy version string, e.g. "1.4".',
+      example: '1.4',
     },
 
     description: {
       type: 'string',
       description: 'Human-readable summary of this taxonomy version.',
+    },
+
+    selection_by_tier: {
+      type: 'object',
+      description: `
+At-a-glance summary of **single vs multi-select** for each wizard tier. Mirrors the \`select\` fields on nested definitions; use for routing (radio vs checkbox) without scanning the full tree.
+
+- **tier1.select** — always \`single\`.
+- **universal_flags.flags** — each flag has its own \`select\` (\`single\` or \`multi\` + optional \`max_select\`).
+- **tier2_axes.axes** — each axis has its own \`select\` (only \`activities\` is \`multi\` today).
+- **tier3** — \`default_select\` is \`single\`; parents listed in \`multi_select_parents\` use multi-select for that drill-down group.
+      `.trim(),
+      required: ['tier1', 'universal_flags', 'tier2_axes', 'tier3'],
+      properties: {
+        description: {
+          type: 'string',
+          description: 'Internal note for consumers.',
+        },
+        tier1: {
+          type: 'object',
+          required: ['select'],
+          properties: {
+            select: {
+              type: 'string',
+              enum: ['single'],
+              description: 'Tier 1 is always single-select.',
+            },
+            note: { type: 'string' },
+          },
+        },
+        universal_flags: {
+          type: 'object',
+          description:
+            'Each entry in `flags` matches a key under `universal_flags`.',
+          required: ['mode', 'flags'],
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['per_flag'],
+              description:
+                'Each flag is independent; open each definition for full options.',
+            },
+            note: { type: 'string' },
+            flags: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                required: ['select'],
+                properties: {
+                  select: { type: 'string', enum: ['single', 'multi'] },
+                  max_select: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+        tier2_axes: {
+          type: 'object',
+          required: ['mode', 'axes'],
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['per_axis'],
+              description: 'Each axis is one question.',
+            },
+            note: { type: 'string' },
+            axes: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                required: ['select'],
+                properties: {
+                  select: { type: 'string', enum: ['single', 'multi'] },
+                },
+              },
+            },
+          },
+        },
+        tier3: {
+          type: 'object',
+          required: ['mode', 'default_select', 'multi_select_parents'],
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['per_tier2_option_id'],
+              description:
+                'Groups keyed by tier2 option id in options_by_parent.',
+            },
+            note: { type: 'string' },
+            default_select: {
+              type: 'string',
+              enum: ['single'],
+              description:
+                'Each drill-down group is single-select unless the parent id is in multi_select_parents.',
+            },
+            multi_select_parents: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Tier2 option ids whose tier3 follow-up allows multiple selections.',
+            },
+          },
+        },
+      },
     },
 
     // ─── Tier 1 ────────────────────────────────────────────────────────────
@@ -289,11 +401,28 @@ Optional drill-down specifics, conditional on tier2 selections.
    - NO  → render as a **radio group** (single-select).
 4. If \`options_by_parent[tier2OptionId]\` is absent → no drill-down for that selection.
       `.trim(),
-      required: ['multi_select_parents', 'options_by_parent'],
+      required: [
+        'select',
+        'default_select',
+        'multi_select_parents',
+        'options_by_parent',
+      ],
       properties: {
         description: {
           type: 'string',
           description: 'Internal note. Not shown to users.',
+        },
+        select: {
+          type: 'string',
+          enum: ['per_parent'],
+          description:
+            'Tier 3 is organized as one follow-up group per tier2 option id (parent key in options_by_parent).',
+        },
+        default_select: {
+          type: 'string',
+          enum: ['single'],
+          description:
+            'Unless a parent tier2 id is in multi_select_parents, the user picks exactly one tier3 option.',
         },
         multi_select_parents: {
           type: 'array',

--- a/tests/unit/plan-tags.test.ts
+++ b/tests/unit/plan-tags.test.ts
@@ -6,6 +6,7 @@ describe('getPlanTags', () => {
     const tags = getPlanTags()
     expect(typeof tags).toBe('object')
     expect(tags).toHaveProperty('version')
+    expect(tags).toHaveProperty('selection_by_tier')
     expect(tags).toHaveProperty('tier1')
     expect(tags).toHaveProperty('universal_flags')
     expect(tags).toHaveProperty('tier2_axes')
@@ -13,9 +14,47 @@ describe('getPlanTags', () => {
     expect(tags).toHaveProperty('item_generation_bundles')
   })
 
-  it('version is 1.3', () => {
+  it('version is 1.4', () => {
     const tags = getPlanTags()
-    expect(tags['version']).toBe('1.3')
+    expect(tags['version']).toBe('1.4')
+  })
+
+  it('selection_by_tier matches nested select fields for flags and axes', () => {
+    const tags = getPlanTags()
+    const sel = tags['selection_by_tier'] as {
+      universal_flags: { flags: Record<string, { select: string }> }
+      tier2_axes: { axes: Record<string, { select: string }> }
+    }
+    const uf = tags['universal_flags'] as Record<string, { select: string }>
+    const axes = tags['tier2_axes'] as Record<string, { select: string }>
+
+    expect(Object.keys(sel.universal_flags.flags).sort()).toEqual(
+      Object.keys(uf).sort()
+    )
+    for (const k of Object.keys(uf)) {
+      expect(sel.universal_flags.flags[k].select).toBe(uf[k].select)
+    }
+
+    expect(Object.keys(sel.tier2_axes.axes).sort()).toEqual(
+      Object.keys(axes).sort()
+    )
+    for (const k of Object.keys(axes)) {
+      expect(sel.tier2_axes.axes[k].select).toBe(axes[k].select)
+    }
+
+    expect(sel.tier1.select).toBe('single')
+    expect((tags['tier1'] as { select: string }).select).toBe('single')
+
+    const t3 = tags['tier3'] as {
+      default_select: string
+      multi_select_parents: string[]
+    }
+    const selT3 = sel.tier3 as {
+      default_select: string
+      multi_select_parents: string[]
+    }
+    expect(selT3.default_select).toBe(t3.default_select)
+    expect(selT3.multi_select_parents).toEqual(t3.multi_select_parents)
   })
 
   it('tier1 has options array with id, bilingual label, emoji on each entry', () => {


### PR DESCRIPTION
- Add top-level selection_by_tier with per-tier and per-flag/axis select summary
- Add tier3.select (per_parent) and default_select (single) alongside multi_select_parents
- Extend OpenAPI PlanTagsResponse; regenerate docs/openapi.json
- Unit test: selection_by_tier stays in sync with nested select fields

Made-with: Cursor