### PR TITLE
feat: AI suggestion tracking, plan tags data, and OpenAPI v1.31.0

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -589,6 +589,20 @@
             "type": "boolean",
             "description": "True when this item is assigned to all participants. When a new participant joins the plan, they are automatically added to items with this flag."
           },
+          "source": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "ai_suggestion"
+            ],
+            "description": "How the item was added: manual (user-entered) or ai_suggestion (accepted from AI suggestions)"
+          },
+          "aiSuggestionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "ID of the ai_suggestions row this item was created from. Null for manually added items."
+          },
           "assignmentStatusList": {
             "type": "array",
             "description": "Per-participant assignment and status tracking (replaces the old top-level status field). Each entry is { participantId, status } where status is one of: pending, purchased, packed, canceled. Response visibility: owner/admin sees full list; non-owner sees only their own entry.",
@@ -632,6 +646,8 @@
           "quantity",
           "unit",
           "isAllParticipants",
+          "source",
+          "aiSuggestionId",
           "assignmentStatusList",
           "createdAt",
           "updatedAt"
@@ -722,6 +738,11 @@
           "isAllParticipants": {
             "type": "boolean",
             "description": "Owner-only on create. true means this item is for all participants and new participants should be auto-added later. false (or omitted) means regular assignment list behavior."
+          },
+          "aiSuggestionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional. When provided, links this item to an AI suggestion row (marks the suggestion as accepted). Must belong to the same plan and have status \"suggested\"."
           }
         },
         "required": [
@@ -3099,6 +3120,7 @@
       "def-82": {
         "type": "object",
         "required": [
+          "id",
           "name",
           "category",
           "subcategory",
@@ -3107,6 +3129,11 @@
           "reason"
         ],
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique ID of this AI suggestion row — pass as aiSuggestionId when calling bulk create to link accepted items"
+          },
           "name": {
             "type": "string"
           },
@@ -3150,9 +3177,15 @@
       "def-83": {
         "type": "object",
         "required": [
-          "suggestions"
+          "suggestions",
+          "aiUsageLogId"
         ],
         "properties": {
+          "aiUsageLogId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the ai_usage_logs row for this generation session"
+          },
           "suggestions": {
             "type": "array",
             "items": {
@@ -3807,8 +3840,8 @@
         "properties": {
           "version": {
             "type": "string",
-            "description": "Taxonomy version string, e.g. \"1.4\".",
-            "example": "1.4"
+            "description": "Taxonomy version string, e.g. \"1.5\".",
+            "example": "1.5"
           },
           "description": {
             "type": "string",

--- a/drizzle/0034_ai_suggestion_tracking.sql
+++ b/drizzle/0034_ai_suggestion_tracking.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "public"."item_source" AS ENUM('manual', 'ai_suggestion');
+CREATE TYPE "public"."ai_suggestion_status" AS ENUM('suggested', 'accepted');
+
+CREATE TABLE "ai_suggestions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "ai_usage_log_id" uuid REFERENCES "ai_usage_logs"("id") ON DELETE SET NULL,
+  "plan_id" uuid NOT NULL REFERENCES "plans"("plan_id") ON DELETE CASCADE,
+  "name" varchar(255) NOT NULL,
+  "category" "item_category" NOT NULL,
+  "subcategory" varchar(255),
+  "quantity" numeric(10, 2) NOT NULL,
+  "unit" "unit" NOT NULL,
+  "reason" text,
+  "status" "ai_suggestion_status" NOT NULL DEFAULT 'suggested',
+  "item_id" uuid REFERENCES "items"("item_id") ON DELETE SET NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX "ai_suggestions_plan_id_idx" ON "ai_suggestions" ("plan_id");
+CREATE INDEX "ai_suggestions_ai_usage_log_id_idx" ON "ai_suggestions" ("ai_usage_log_id");
+
+ALTER TABLE "items"
+  ADD COLUMN "source" "item_source" NOT NULL DEFAULT 'manual',
+  ADD COLUMN "ai_suggestion_id" uuid REFERENCES "ai_suggestions"("id") ON DELETE SET NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1775300000000,
       "tag": "0033_drop_plan_tag_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1775400000000,
+      "tag": "0034_ai_suggestion_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/data/plan-creation-tags.json
+++ b/src/data/plan-creation-tags.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.5",
   "description": "Chillist plan creation wizard tag schema. Bilingual (en + he). Tier 1 = plan archetype (single-select). Universal flags asked once regardless of Tier 1. Tier 2 = named axes conditional on Tier 1, each axis internally single-select to prevent contradictions. Tier 3 = specifics conditional on Tier 2 values (single-select by default; see multi_select_parents).",
 
   "selection_by_tier": {
@@ -72,7 +72,7 @@
     "Each Tier 2 axis is internally single-select to prevent contradictions. 'Mix' is its own value, not two checkboxes.",
     "Activities is the only multi-select Tier 2 axis.",
     "Tier 3 is single-select by default. Only groups listed in tier3.multi_select_parents allow multiple selections.",
-    "No 'Other' Tier 1 — absence signals which archetype is missing for v1.4.",
+    "No 'Other' Tier 1 — absence signals which archetype is missing for v1.5.",
     "Group composition (kids, pets, dietary) and weather/season are excluded — derived later from participants and dates."
   ],
 
@@ -160,7 +160,7 @@
       "label": { "en": "How will food work?", "he": "איך מסתדרים עם האוכל?" },
       "key": "food_strategy",
       "select": "single",
-      "shown_for_tier1": ["camping", "hotel_stay", "airbnb_stay", "hiking", "road_trip", "day_trip", "beach_day", "city_day", "festival", "dinner", "party"],
+      "shown_for_tier1": ["camping", "hotel_stay", "airbnb_stay", "hiking", "road_trip", "day_trip", "beach_day", "city_day", "festival"],
       "options": [
         { "id": "cooking_ourselves", "label": { "en": "We're cooking our own food",      "he": "מבשלים לעצמנו" } },
         { "id": "eating_out",        "label": { "en": "Eating out / restaurants",        "he": "אוכלים בחוץ / מסעדות" } },
@@ -179,12 +179,9 @@
         "day_trip": "packed_food",
         "beach_day": "packed_food",
         "city_day": "eating_out",
-        "festival": "eating_out",
-        "dinner": "potluck",
-        "party": "potluck"
+        "festival": "eating_out"
       },
       "hidden_options_by_tier1": {
-        "dinner": ["packed_food", "drinks_only"],
         "games_gathering": ["all_inclusive", "packed_food"],
         "hiking": ["all_inclusive", "potluck"]
       }
@@ -285,6 +282,11 @@
       "restaurant_venue": [
         { "id": "venue_prebooked", "label": { "en": "Pre-booked / reserved", "he": "הזמנו מראש" } },
         { "id": "venue_walk_in",   "label": { "en": "Walk-in / flexible",    "he": "נכנסים בלי הזמנה" } }
+      ],
+      "rented_space": [
+        { "id": "rented_catered", "label": { "en": "Catered / hired chef",      "he": "קייטרינג / שף" } },
+        { "id": "rented_potluck", "label": { "en": "Everyone brings something", "he": "כל אחד מביא משהו" } },
+        { "id": "rented_ordered", "label": { "en": "Ordering food in",          "he": "מזמינים אוכל" } }
       ]
     }
   },
@@ -303,6 +305,11 @@
   },
 
   "changelog": {
+    "1.5": [
+      "Removed dinner and party from food_strategy.shown_for_tier1 — venue Tier 3 covers food logistics for gathering plans; avoids asking about food twice.",
+      "Removed food_strategy.defaults_by_tier1 and hidden_options_by_tier1 entries for dinner (axis no longer shown for that Tier 1).",
+      "Added tier3.options_by_parent.rented_space — catered vs potluck vs ordering in, for dinner/party at a rented hall."
+    ],
     "1.4": [
       "Added selection_by_tier — explicit single vs multi (and per-flag / per-axis breakdown) for FE at-a-glance.",
       "Added tier3.select ('per_parent'), tier3.default_select ('single'), and duplicated multi_select_parents under selection_by_tier.tier3 for consistency."

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -115,6 +115,17 @@ export const aiUsageStatusEnum = pgEnum('ai_usage_status', [
   'partial',
   'error',
 ])
+
+export const itemSourceEnum = pgEnum('item_source', ['manual', 'ai_suggestion'])
+export const ITEM_SOURCE_VALUES = itemSourceEnum.enumValues
+export type ItemSource = (typeof ITEM_SOURCE_VALUES)[number]
+
+export const aiSuggestionStatusEnum = pgEnum('ai_suggestion_status', [
+  'suggested',
+  'accepted',
+])
+export const AI_SUGGESTION_STATUS_VALUES = aiSuggestionStatusEnum.enumValues
+export type AiSuggestionStatus = (typeof AI_SUGGESTION_STATUS_VALUES)[number]
 export const unitEnum = pgEnum('unit', [
   'pcs',
   'kg',
@@ -257,6 +268,8 @@ export const items = pgTable('items', {
     .notNull()
     .$type<Array<{ participantId: string; status: ItemStatus }>>()
     .default([]),
+  source: itemSourceEnum('source').default('manual').notNull(),
+  aiSuggestionId: uuid('ai_suggestion_id'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()
     .notNull(),
@@ -429,6 +442,34 @@ export const aiUsageLogs = pgTable('ai_usage_logs', {
     .notNull(),
 })
 
+export const aiSuggestions = pgTable(
+  'ai_suggestions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    aiUsageLogId: uuid('ai_usage_log_id').references(() => aiUsageLogs.id, {
+      onDelete: 'set null',
+    }),
+    planId: uuid('plan_id')
+      .notNull()
+      .references(() => plans.planId, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 255 }).notNull(),
+    category: itemCategoryEnum('category').notNull(),
+    subcategory: varchar('subcategory', { length: 255 }),
+    quantity: numeric('quantity', { precision: 10, scale: 2 }).notNull(),
+    unit: unitEnum('unit').notNull(),
+    reason: text('reason'),
+    status: aiSuggestionStatusEnum('status').default('suggested').notNull(),
+    itemId: uuid('item_id'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index('ai_suggestions_plan_id_idx').on(table.planId),
+    index('ai_suggestions_ai_usage_log_id_idx').on(table.aiUsageLogId),
+  ]
+)
+
 // Read-only mirror: rows are owned by the chatbot service; no FK constraints or relations.
 
 // Mirror of chillist-whatsapp-bot/migrations/004_chatbot_ai_usage.sql — read-only from BE
@@ -495,6 +536,7 @@ export const plansRelations = relations(plans, ({ many }) => ({
   expenses: many(participantExpenses),
   whatsappNotifications: many(whatsappNotifications),
   aiUsageLogs: many(aiUsageLogs),
+  aiSuggestions: many(aiSuggestions),
 }))
 
 export const itemsRelations = relations(items, ({ one, many }) => ({
@@ -577,10 +619,22 @@ export const whatsappNotificationsRelations = relations(
   })
 )
 
-export const aiUsageLogsRelations = relations(aiUsageLogs, ({ one }) => ({
+export const aiUsageLogsRelations = relations(aiUsageLogs, ({ one, many }) => ({
   plan: one(plans, {
     fields: [aiUsageLogs.planId],
     references: [plans.planId],
+  }),
+  suggestions: many(aiSuggestions),
+}))
+
+export const aiSuggestionsRelations = relations(aiSuggestions, ({ one }) => ({
+  plan: one(plans, {
+    fields: [aiSuggestions.planId],
+    references: [plans.planId],
+  }),
+  aiUsageLog: one(aiUsageLogs, {
+    fields: [aiSuggestions.aiUsageLogId],
+    references: [aiUsageLogs.id],
   }),
 }))
 
@@ -608,6 +662,8 @@ export type WhatsappNotification = typeof whatsappNotifications.$inferSelect
 export type NewWhatsappNotification = typeof whatsappNotifications.$inferInsert
 export type AiUsageLog = typeof aiUsageLogs.$inferSelect
 export type NewAiUsageLog = typeof aiUsageLogs.$inferInsert
+export type AiSuggestion = typeof aiSuggestions.$inferSelect
+export type NewAiSuggestion = typeof aiSuggestions.$inferInsert
 export type ChatbotAiUsageLog = typeof chatbotAiUsage.$inferSelect
 export type NewChatbotAiUsageLog = typeof chatbotAiUsage.$inferInsert
 export type Session = typeof sessions.$inferSelect

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -11,6 +11,7 @@ import {
   participantExpenses,
   participantJoinRequests,
   aiUsageLogs,
+  aiSuggestions,
   chatbotAiUsage,
   type Location,
   type Assignment,
@@ -52,7 +53,7 @@ async function seed() {
 
   try {
     await db.execute(
-      sql`TRUNCATE plans, participants, items, plan_invites, participant_join_requests, participant_expenses, guest_profiles, users, whatsapp_notifications, ai_usage_logs, chatbot_ai_usage CASCADE`
+      sql`TRUNCATE plans, participants, items, ai_suggestions, plan_invites, participant_join_requests, participant_expenses, guest_profiles, users, whatsapp_notifications, ai_usage_logs, chatbot_ai_usage CASCADE`
     )
     console.log('Cleared all tables')
 
@@ -407,6 +408,81 @@ async function seed() {
 
     const tent = negevItems.find((i) => i.name === 'Tent')!
     const sleepingBag = negevItems.find((i) => i.name === 'Sleeping Bag')!
+
+    const [negevAiUsageLog] = await db
+      .insert(aiUsageLogs)
+      .values({
+        featureType: 'item_suggestions',
+        planId: negevPlan.planId,
+        userId: seedOwnerUserId,
+        provider: 'anthropic',
+        modelId: 'claude-haiku-4-5-20251001',
+        lang: 'he',
+        status: 'success',
+        inputTokens: 1200,
+        outputTokens: 800,
+        totalTokens: 2000,
+        durationMs: 4200,
+        resultCount: 4,
+        metadata: { planTitle: negevPlan.title, seed: true },
+      })
+      .returning()
+
+    const insertedAiSuggestions = await db
+      .insert(aiSuggestions)
+      .values([
+        {
+          aiUsageLogId: negevAiUsageLog.id,
+          planId: negevPlan.planId,
+          name: 'Tent',
+          category: 'group_equipment',
+          subcategory: 'Shelter',
+          quantity: '1',
+          unit: 'pcs',
+          reason:
+            'Desert nights get cold — seed sample (accepted, linked to Tent item)',
+          status: 'accepted',
+          itemId: tent.itemId,
+        },
+        {
+          aiUsageLogId: negevAiUsageLog.id,
+          planId: negevPlan.planId,
+          name: 'Portable shade canopy',
+          category: 'group_equipment',
+          subcategory: 'Shelter',
+          quantity: '1',
+          unit: 'pcs',
+          reason:
+            'Extra UV protection for toddlers — seed sample (still suggested)',
+          status: 'suggested',
+        },
+        {
+          aiUsageLogId: negevAiUsageLog.id,
+          planId: negevPlan.planId,
+          name: 'Wet wipes pack',
+          category: 'personal_equipment',
+          subcategory: 'Hygiene',
+          quantity: '2',
+          unit: 'pack',
+          reason: 'Hand cleanup for kids — seed sample (still suggested)',
+          status: 'suggested',
+        },
+      ])
+      .returning()
+
+    const sugAccepted = insertedAiSuggestions[0]!
+
+    await db
+      .update(items)
+      .set({
+        source: 'ai_suggestion',
+        aiSuggestionId: sugAccepted.id,
+      })
+      .where(eq(items.itemId, tent.itemId))
+
+    console.log(
+      'Created AI usage log + 3 ai_suggestions (1 accepted→Tent, 2 suggested); Tent linked as ai_suggestion source'
+    )
     const campingStove = negevItems.find((i) => i.name === 'Camping Stove')!
     const cooler = negevItems.find((i) => i.name === 'Cooler')!
     const water = negevItems.find((i) => i.name === 'Water')!

--- a/src/routes/ai-suggestions.route.ts
+++ b/src/routes/ai-suggestions.route.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { and, eq, inArray, sql } from 'drizzle-orm'
-import { participants, plans } from '../db/schema.js'
+import { participants, plans, aiSuggestions } from '../db/schema.js'
 import { checkPlanAccess } from '../utils/plan-access.js'
 import { config } from '../config.js'
 import {
@@ -171,7 +171,7 @@ export async function aiSuggestionsRoutes(fastify: FastifyInstance) {
           .set({ aiGenerationCount: sql`${plans.aiGenerationCount} + 1` })
           .where(eq(plans.planId, planId))
 
-        recordAiUsage(fastify.db, {
+        const aiUsageLogId = await recordAiUsage(fastify.db, {
           featureType: 'item_suggestions',
           planId,
           userId: request.user?.id,
@@ -192,6 +192,37 @@ export async function aiSuggestionsRoutes(fastify: FastifyInstance) {
           metadata: { planTitle: plan.title },
         })
 
+        let storedSuggestions: Array<{ id: string }> = []
+        if (result.suggestions.length > 0) {
+          try {
+            storedSuggestions = await fastify.db
+              .insert(aiSuggestions)
+              .values(
+                result.suggestions.map((s) => ({
+                  aiUsageLogId: aiUsageLogId ?? null,
+                  planId,
+                  name: s.name,
+                  category: s.category,
+                  subcategory: s.subcategory,
+                  quantity: String(s.quantity),
+                  unit: s.unit,
+                  reason: s.reason,
+                }))
+              )
+              .returning({ id: aiSuggestions.id })
+          } catch (err) {
+            request.log.error(
+              { err, planId },
+              'Failed to persist AI suggestion rows — returning suggestions without IDs'
+            )
+          }
+        }
+
+        const suggestionsWithIds = result.suggestions.map((s, i) => ({
+          id: storedSuggestions[i]?.id ?? '',
+          ...s,
+        }))
+
         const durationSec = (durationMs / 1000).toFixed(1)
         request.log.info(
           {
@@ -206,7 +237,10 @@ export async function aiSuggestionsRoutes(fastify: FastifyInstance) {
           `AI item suggestions generated in ${durationSec}s — ${result.suggestions.length} items, ${result.usage.totalTokens ?? '?'} tokens (${model.modelId})`
         )
 
-        return { suggestions: result.suggestions }
+        return {
+          aiUsageLogId: aiUsageLogId ?? '',
+          suggestions: suggestionsWithIds,
+        }
       } catch (error) {
         request.log.error(
           { err: error, planId },

--- a/src/routes/items.route.ts
+++ b/src/routes/items.route.ts
@@ -3,6 +3,7 @@ import { eq, and, inArray } from 'drizzle-orm'
 import {
   items,
   participants,
+  aiSuggestions,
   ItemCategory,
   Unit,
   Item,
@@ -14,6 +15,8 @@ import {
   checkItemMutationAccess,
   createPlanItems,
   processItemUpdate,
+  scheduleMarkAiSuggestionsAccepted,
+  validateAiSuggestionForCreate,
   type BulkItemError,
 } from '../services/item.service.js'
 import { filterAssignmentForParticipant } from '../utils/assignment-helpers.js'
@@ -31,6 +34,7 @@ interface CreateItemBody {
   notes?: string | null
   assignmentStatusList?: Assignment[]
   isAllParticipants?: boolean
+  aiSuggestionId?: string | null
 }
 
 interface UpdateItemBody {
@@ -114,9 +118,23 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         const isOwner =
           access.participant?.role === 'owner' || !access.participant
 
+        const suggestionCheck = await validateAiSuggestionForCreate(
+          fastify.db,
+          planId,
+          request.body.aiSuggestionId
+        )
+        if (!suggestionCheck.ok) {
+          return reply.status(400).send({ message: suggestionCheck.message })
+        }
+
+        const createInput: CreateItemInput = {
+          ...(request.body as CreateItemInput),
+          aiSuggestionId: suggestionCheck.suggestionId,
+        }
+
         const result = await createPlanItems(fastify.db, {
           planId,
-          inputs: [request.body as CreateItemInput],
+          inputs: [createInput],
           isOwner,
           changedBy: { userId: request.user?.id ?? null },
           sessionId: request.sessionId ?? null,
@@ -127,6 +145,19 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         }
 
         const createdItem = result.items[0]
+        if (createdItem.aiSuggestionId) {
+          scheduleMarkAiSuggestionsAccepted(
+            fastify.db,
+            planId,
+            [
+              {
+                suggestionId: createdItem.aiSuggestionId,
+                itemId: createdItem.itemId,
+              },
+            ],
+            (ctx, msg) => request.log.error(ctx, msg)
+          )
+        }
         request.log.info({ itemId: createdItem.itemId, planId }, 'Item created')
         fastify.notifyItemChange(planId)
 
@@ -408,26 +439,123 @@ export async function itemsRoutes(fastify: FastifyInstance) {
         const isOwner =
           access.participant?.role === 'owner' || !access.participant
 
-        const { items: createdItems, errors } = await createPlanItems(
-          fastify.db,
-          {
+        const suggestionIds = itemsToCreate
+          .map((it) => it.aiSuggestionId)
+          .filter((id): id is string => !!id)
+
+        const validatedSuggestionIds = new Set<string>()
+        if (suggestionIds.length > 0) {
+          const rows = await fastify.db
+            .select({
+              id: aiSuggestions.id,
+              planId: aiSuggestions.planId,
+              status: aiSuggestions.status,
+            })
+            .from(aiSuggestions)
+            .where(inArray(aiSuggestions.id, suggestionIds))
+
+          const rowMap = new Map(rows.map((r) => [r.id, r]))
+          for (const id of suggestionIds) {
+            const row = rowMap.get(id)
+            if (!row) continue
+            if (row.planId !== planId) continue
+            if (row.status !== 'suggested') continue
+            validatedSuggestionIds.add(id)
+          }
+        }
+
+        const inputs: CreateItemInput[] = itemsToCreate.map((it) => {
+          const sid = it.aiSuggestionId ?? null
+          const isValidSuggestion = sid
+            ? validatedSuggestionIds.has(sid)
+            : false
+          return {
+            ...it,
+            aiSuggestionId: isValidSuggestion ? sid : null,
+          } as CreateItemInput
+        })
+
+        const itemErrors: Array<{ name: string; message: string }> = []
+        for (const it of itemsToCreate) {
+          const sid = it.aiSuggestionId
+          if (!sid) continue
+          if (!validatedSuggestionIds.has(sid)) {
+            const rows = await fastify.db
+              .select({
+                id: aiSuggestions.id,
+                planId: aiSuggestions.planId,
+                status: aiSuggestions.status,
+              })
+              .from(aiSuggestions)
+              .where(eq(aiSuggestions.id, sid))
+            const row = rows[0]
+            if (!row) {
+              itemErrors.push({
+                name: it.name,
+                message: `aiSuggestionId ${sid} not found`,
+              })
+            } else if (row.planId !== planId) {
+              itemErrors.push({
+                name: it.name,
+                message: `aiSuggestionId ${sid} belongs to a different plan`,
+              })
+            } else if (row.status !== 'suggested') {
+              itemErrors.push({
+                name: it.name,
+                message: `aiSuggestionId ${sid} already accepted`,
+              })
+            }
+          }
+        }
+
+        const validInputs = inputs.filter((_inp, idx) => {
+          const sid = itemsToCreate[idx].aiSuggestionId
+          if (!sid) return true
+          return validatedSuggestionIds.has(sid)
+        })
+        const skippedCount = inputs.length - validInputs.length
+
+        const { items: createdItems, errors: createErrors } =
+          await createPlanItems(fastify.db, {
             planId,
-            inputs: itemsToCreate as CreateItemInput[],
+            inputs: validInputs,
             isOwner,
             changedBy: { userId: request.user?.id ?? null },
             sessionId: request.sessionId ?? null,
-          }
-        )
+          })
 
-        const statusCode = errors.length === 0 ? 200 : 207
+        if (createdItems.length > 0) {
+          const pairs = createdItems
+            .filter((item) => item.aiSuggestionId)
+            .map((item) => ({
+              suggestionId: item.aiSuggestionId!,
+              itemId: item.itemId,
+            }))
+          scheduleMarkAiSuggestionsAccepted(
+            fastify.db,
+            planId,
+            pairs,
+            (ctx, msg) => request.log.error(ctx, msg)
+          )
+        }
+
+        const allErrors = [...itemErrors, ...createErrors]
+        const statusCode = allErrors.length === 0 ? 200 : 207
         request.log.info(
-          { planId, created: createdItems.length, failed: errors.length },
+          {
+            planId,
+            created: createdItems.length,
+            failed: allErrors.length,
+            skipped: skippedCount,
+          },
           'Bulk items created'
         )
         if (createdItems.length > 0) {
           fastify.notifyItemChange(planId)
         }
-        return reply.status(statusCode).send({ items: createdItems, errors })
+        return reply
+          .status(statusCode)
+          .send({ items: createdItems, errors: allErrors })
       } catch (error) {
         request.log.error({ err: error, planId }, 'Failed to bulk create items')
         const classified = classifyDbError(error, 'Failed to bulk create items')

--- a/src/schemas/ai-suggestions.schema.ts
+++ b/src/schemas/ai-suggestions.schema.ts
@@ -1,8 +1,22 @@
 export const aiSuggestionItemSchema = {
   $id: 'AiSuggestionItem',
   type: 'object',
-  required: ['name', 'category', 'subcategory', 'quantity', 'unit', 'reason'],
+  required: [
+    'id',
+    'name',
+    'category',
+    'subcategory',
+    'quantity',
+    'unit',
+    'reason',
+  ],
   properties: {
+    id: {
+      type: 'string',
+      format: 'uuid',
+      description:
+        'Unique ID of this AI suggestion row — pass as aiSuggestionId when calling bulk create to link accepted items',
+    },
     name: { type: 'string' },
     category: {
       type: 'string',
@@ -21,8 +35,13 @@ export const aiSuggestionItemSchema = {
 export const aiSuggestionsResponseSchema = {
   $id: 'AiSuggestionsResponse',
   type: 'object',
-  required: ['suggestions'],
+  required: ['suggestions', 'aiUsageLogId'],
   properties: {
+    aiUsageLogId: {
+      type: 'string',
+      format: 'uuid',
+      description: 'ID of the ai_usage_logs row for this generation session',
+    },
     suggestions: {
       type: 'array',
       items: { $ref: 'AiSuggestionItem#' },

--- a/src/schemas/item.schema.ts
+++ b/src/schemas/item.schema.ts
@@ -2,6 +2,7 @@ import {
   UNIT_VALUES,
   ITEM_CATEGORY_VALUES,
   ITEM_STATUS_VALUES,
+  ITEM_SOURCE_VALUES,
 } from '../db/schema.js'
 
 export const itemSchema = {
@@ -23,6 +24,19 @@ export const itemSchema = {
       type: 'boolean',
       description:
         'True when this item is assigned to all participants. When a new participant joins the plan, they are automatically added to items with this flag.',
+    },
+    source: {
+      type: 'string',
+      enum: [...ITEM_SOURCE_VALUES],
+      description:
+        'How the item was added: manual (user-entered) or ai_suggestion (accepted from AI suggestions)',
+    },
+    aiSuggestionId: {
+      type: 'string',
+      format: 'uuid',
+      nullable: true,
+      description:
+        'ID of the ai_suggestions row this item was created from. Null for manually added items.',
     },
     assignmentStatusList: {
       type: 'array',
@@ -48,6 +62,8 @@ export const itemSchema = {
     'quantity',
     'unit',
     'isAllParticipants',
+    'source',
+    'aiSuggestionId',
     'assignmentStatusList',
     'createdAt',
     'updatedAt',
@@ -96,6 +112,12 @@ export const createItemBodySchema = {
       type: 'boolean',
       description:
         'Owner-only on create. true means this item is for all participants and new participants should be auto-added later. false (or omitted) means regular assignment list behavior.',
+    },
+    aiSuggestionId: {
+      type: 'string',
+      format: 'uuid',
+      description:
+        'Optional. When provided, links this item to an AI suggestion row (marks the suggestion as accepted). Must belong to the same plan and have status "suggested".',
     },
   },
   required: ['name', 'category', 'quantity'],

--- a/src/schemas/plan-tags.schema.ts
+++ b/src/schemas/plan-tags.schema.ts
@@ -107,8 +107,8 @@ All \`id\` values are stable slugs safe to persist as tag values.
   properties: {
     version: {
       type: 'string',
-      description: 'Taxonomy version string, e.g. "1.4".',
-      example: '1.4',
+      description: 'Taxonomy version string, e.g. "1.5".',
+      example: '1.5',
     },
 
     description: {

--- a/src/services/ai/usage-tracking.ts
+++ b/src/services/ai/usage-tracking.ts
@@ -53,7 +53,7 @@ export function estimateModelCost(
 export async function recordAiUsage(
   db: Database,
   record: AiUsageRecord
-): Promise<void> {
+): Promise<string | null> {
   try {
     const cost = estimateModelCost(
       record.modelId,
@@ -61,30 +61,36 @@ export async function recordAiUsage(
       record.outputTokens
     )
 
-    await db.insert(aiUsageLogs).values({
-      featureType: record.featureType,
-      planId: record.planId ?? null,
-      userId: record.userId ?? null,
-      sessionId: record.sessionId ?? null,
-      provider: record.provider,
-      modelId: record.modelId,
-      lang: record.lang ?? null,
-      status: record.status,
-      inputTokens: record.inputTokens ?? null,
-      outputTokens: record.outputTokens ?? null,
-      totalTokens: record.totalTokens ?? null,
-      estimatedCost: cost?.toFixed(6) ?? null,
-      durationMs: record.durationMs,
-      promptLength: record.promptLength ?? null,
-      promptText: record.promptText ?? null,
-      resultCount: record.resultCount ?? null,
-      errorMessage: record.errorMessage ?? null,
-      errorType: record.errorType ?? null,
-      finishReason: record.finishReason ?? null,
-      rawResponseText: record.rawResponseText ?? null,
-      metadata: record.metadata ?? null,
-    })
+    const [row] = await db
+      .insert(aiUsageLogs)
+      .values({
+        featureType: record.featureType,
+        planId: record.planId ?? null,
+        userId: record.userId ?? null,
+        sessionId: record.sessionId ?? null,
+        provider: record.provider,
+        modelId: record.modelId,
+        lang: record.lang ?? null,
+        status: record.status,
+        inputTokens: record.inputTokens ?? null,
+        outputTokens: record.outputTokens ?? null,
+        totalTokens: record.totalTokens ?? null,
+        estimatedCost: cost?.toFixed(6) ?? null,
+        durationMs: record.durationMs,
+        promptLength: record.promptLength ?? null,
+        promptText: record.promptText ?? null,
+        resultCount: record.resultCount ?? null,
+        errorMessage: record.errorMessage ?? null,
+        errorType: record.errorType ?? null,
+        finishReason: record.finishReason ?? null,
+        rawResponseText: record.rawResponseText ?? null,
+        metadata: record.metadata ?? null,
+      })
+      .returning({ id: aiUsageLogs.id })
+
+    return row?.id ?? null
   } catch (err) {
     console.error('[ai-usage-tracking] Failed to record AI usage:', err)
+    return null
   }
 }

--- a/src/services/item.service.ts
+++ b/src/services/item.service.ts
@@ -1,6 +1,6 @@
 import { eq, and, inArray } from 'drizzle-orm'
 import type { Database } from '../db/index.js'
-import { items, participants } from '../db/schema.js'
+import { items, participants, aiSuggestions } from '../db/schema.js'
 import type { Item, Assignment, Unit } from '../db/schema.js'
 import type { JwtUser } from '../plugins/auth.js'
 import { recordItemCreated, recordItemUpdated } from '../utils/item-changes.js'
@@ -216,6 +216,72 @@ export interface BulkItemError {
   message: string
 }
 
+export function scheduleMarkAiSuggestionsAccepted(
+  db: Database,
+  planId: string,
+  pairs: Array<{ suggestionId: string; itemId: string }>,
+  logError: (ctx: { err: unknown; planId: string }, msg: string) => void
+): void {
+  if (pairs.length === 0) return
+  const ids = pairs.map((p) => p.suggestionId)
+  const itemBySuggestion = new Map(
+    pairs.map((p) => [p.suggestionId, p.itemId] as const)
+  )
+  void db
+    .update(aiSuggestions)
+    .set({ status: 'accepted' })
+    .where(inArray(aiSuggestions.id, ids))
+    .then(() =>
+      Promise.all(
+        ids.map((sid) =>
+          db
+            .update(aiSuggestions)
+            .set({ itemId: itemBySuggestion.get(sid) ?? null })
+            .where(eq(aiSuggestions.id, sid))
+        )
+      )
+    )
+    .catch((err) => {
+      logError({ err, planId }, 'Failed to mark AI suggestions as accepted')
+    })
+}
+
+export async function validateAiSuggestionForCreate(
+  db: Database,
+  planId: string,
+  aiSuggestionId: string | null | undefined
+): Promise<
+  { ok: true; suggestionId: string | null } | { ok: false; message: string }
+> {
+  if (!aiSuggestionId) {
+    return { ok: true, suggestionId: null }
+  }
+  const [row] = await db
+    .select({
+      id: aiSuggestions.id,
+      planId: aiSuggestions.planId,
+      status: aiSuggestions.status,
+    })
+    .from(aiSuggestions)
+    .where(eq(aiSuggestions.id, aiSuggestionId))
+  if (!row) {
+    return { ok: false, message: `aiSuggestionId ${aiSuggestionId} not found` }
+  }
+  if (row.planId !== planId) {
+    return {
+      ok: false,
+      message: `aiSuggestionId ${aiSuggestionId} belongs to a different plan`,
+    }
+  }
+  if (row.status !== 'suggested') {
+    return {
+      ok: false,
+      message: `aiSuggestionId ${aiSuggestionId} already accepted`,
+    }
+  }
+  return { ok: true, suggestionId: aiSuggestionId }
+}
+
 export async function createPlanItems(
   db: Database,
   options: {
@@ -238,6 +304,8 @@ export async function createPlanItems(
     notes?: string | null
     assignmentStatusList: Assignment[]
     isAllParticipants: boolean
+    source: Item['source']
+    aiSuggestionId?: string | null
   }> = []
   const errors: BulkItemError[] = []
 
@@ -247,7 +315,11 @@ export async function createPlanItems(
       errors.push({ name: input.name, message: prepared.error })
       continue
     }
-    validValues.push({ planId, ...prepared.values })
+    validValues.push({
+      planId,
+      ...prepared.values,
+      source: prepared.values.aiSuggestionId ? 'ai_suggestion' : 'manual',
+    })
   }
 
   let createdItems: Item[] = []

--- a/src/utils/item-mutation.ts
+++ b/src/utils/item-mutation.ts
@@ -15,6 +15,7 @@ export interface CreateItemInput {
   notes?: string | null
   assignmentStatusList?: Assignment[]
   isAllParticipants?: boolean
+  aiSuggestionId?: string | null
 }
 
 export type PreparedItemValues = {
@@ -26,6 +27,7 @@ export type PreparedItemValues = {
   notes?: string | null
   assignmentStatusList: Assignment[]
   isAllParticipants: boolean
+  aiSuggestionId?: string | null
 }
 
 export function prepareItemForCreate(
@@ -64,6 +66,7 @@ export function prepareItemForCreate(
       notes: input.notes ?? null,
       assignmentStatusList: resolved,
       isAllParticipants: isAll,
+      aiSuggestionId: input.aiSuggestionId ?? null,
     },
   }
 }

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -42,13 +42,44 @@ export async function cleanupTestDatabase() {
   await testDb.delete(schema.sessions)
   await testDb.delete(schema.participantExpenses)
   await testDb.delete(schema.itemChanges)
+  await testDb.delete(schema.aiSuggestions)
   await testDb.delete(schema.items)
+  await testDb.delete(schema.aiUsageLogs)
   await testDb.delete(schema.planInvites)
   await testDb.delete(schema.participantJoinRequests)
   await testDb.delete(schema.participants)
   await testDb.delete(schema.plans)
   await testDb.delete(schema.guestProfiles)
   await testDb.delete(schema.users)
+}
+
+export async function seedTestAiSuggestions(
+  planId: string,
+  count: number = 3,
+  options?: {
+    aiUsageLogId?: string | null
+    status?: 'suggested' | 'accepted'
+  }
+): Promise<schema.AiSuggestion[]> {
+  const testDb = await getTestDb()
+
+  const suggestions = Array.from({ length: count }, (_, i) => ({
+    planId,
+    aiUsageLogId: options?.aiUsageLogId ?? null,
+    name: `AI Suggestion ${i + 1}`,
+    category: 'group_equipment' as const,
+    subcategory: 'Camping Gear',
+    quantity: '1',
+    unit: 'pcs' as const,
+    reason: `Reason for suggestion ${i + 1}`,
+    status: (options?.status ?? 'suggested') as 'suggested' | 'accepted',
+  }))
+
+  const inserted = await testDb
+    .insert(schema.aiSuggestions)
+    .values(suggestions)
+    .returning()
+  return inserted
 }
 
 export async function closeTestDatabase() {

--- a/tests/integration/ai-suggestion-tracking.test.ts
+++ b/tests/integration/ai-suggestion-tracking.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  getTestDb,
+  seedTestAiSuggestions,
+  seedTestParticipants,
+  seedTestPlans,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import { aiSuggestions, items } from '../../src/db/schema.js'
+import { eq } from 'drizzle-orm'
+import {
+  setupTestKeys,
+  getTestJWKS,
+  getTestIssuer,
+  signTestJwt,
+} from '../helpers/auth.js'
+
+const TEST_USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+
+describe('AI Suggestion Tracking', () => {
+  let app: FastifyInstance
+  let token: string
+
+  beforeAll(async () => {
+    const db = await setupTestDatabase()
+    await setupTestKeys()
+    token = await signTestJwt({ sub: TEST_USER_ID })
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+      }
+    )
+  })
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  describe('POST /plans/:planId/items/bulk — source field', () => {
+    it('items created without aiSuggestionId have source=manual', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [{ name: 'Tent', category: 'group_equipment', quantity: 1 }],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items[0].source).toBe('manual')
+      expect(body.items[0].aiSuggestionId).toBeNull()
+    })
+
+    it('items created with valid aiSuggestionId have source=ai_suggestion', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const [suggestion] = await seedTestAiSuggestions(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Tent',
+              category: 'group_equipment',
+              quantity: 1,
+              aiSuggestionId: suggestion.id,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items[0].source).toBe('ai_suggestion')
+      expect(body.items[0].aiSuggestionId).toBe(suggestion.id)
+    })
+
+    it('marks matching suggestion as accepted in DB after bulk create', async () => {
+      const testDb = await getTestDb()
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const [suggestion] = await seedTestAiSuggestions(plan.planId, 1)
+
+      await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: suggestion.name,
+              category: suggestion.category,
+              quantity: 1,
+              aiSuggestionId: suggestion.id,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      await new Promise((r) => setTimeout(r, 50))
+
+      const [updatedSuggestion] = await testDb
+        .select()
+        .from(aiSuggestions)
+        .where(eq(aiSuggestions.id, suggestion.id))
+
+      expect(updatedSuggestion.status).toBe('accepted')
+      expect(updatedSuggestion.itemId).toBeTruthy()
+    })
+
+    it('sets item_id back-link on the accepted suggestion', async () => {
+      const testDb = await getTestDb()
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const [suggestion] = await seedTestAiSuggestions(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: suggestion.name,
+              category: suggestion.category,
+              quantity: 1,
+              aiSuggestionId: suggestion.id,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      await new Promise((r) => setTimeout(r, 50))
+
+      const createdItemId = response.json().items[0].itemId
+
+      const [updatedSuggestion] = await testDb
+        .select()
+        .from(aiSuggestions)
+        .where(eq(aiSuggestions.id, suggestion.id))
+
+      expect(updatedSuggestion.itemId).toBe(createdItemId)
+    })
+
+    it('bulk create with mix of manual and AI items works correctly', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const [suggestion] = await seedTestAiSuggestions(plan.planId, 1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            { name: 'Manual item', category: 'group_equipment', quantity: 1 },
+            {
+              name: suggestion.name,
+              category: suggestion.category,
+              quantity: 1,
+              aiSuggestionId: suggestion.id,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.items).toHaveLength(2)
+      expect(body.items[0].source).toBe('manual')
+      expect(body.items[0].aiSuggestionId).toBeNull()
+      expect(body.items[1].source).toBe('ai_suggestion')
+      expect(body.items[1].aiSuggestionId).toBe(suggestion.id)
+    })
+  })
+
+  describe('POST /plans/:planId/items/bulk — aiSuggestionId validation', () => {
+    it('returns 207 error for item with aiSuggestionId not found', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const nonExistentId = '00000000-0000-0000-0000-000000000099'
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Tent',
+              category: 'group_equipment',
+              quantity: 1,
+              aiSuggestionId: nonExistentId,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(207)
+      const body = response.json()
+      expect(body.errors).toHaveLength(1)
+      expect(body.errors[0].message).toContain('not found')
+      expect(body.items).toHaveLength(0)
+    })
+
+    it('returns 207 error for aiSuggestionId belonging to a different plan', async () => {
+      const [plan1] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      const [plan2] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan1.planId, 1, {
+        ownerUserId: TEST_USER_ID,
+      })
+      const [suggestion] = await seedTestAiSuggestions(plan2.planId, 1)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan1.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Tent',
+              category: 'group_equipment',
+              quantity: 1,
+              aiSuggestionId: suggestion.id,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(207)
+      const body = response.json()
+      expect(body.errors).toHaveLength(1)
+      expect(body.errors[0].message).toContain('different plan')
+    })
+
+    it('returns 207 error for aiSuggestionId already accepted', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const [suggestion] = await seedTestAiSuggestions(plan.planId, 1, {
+        status: 'accepted',
+      })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            {
+              name: 'Tent',
+              category: 'group_equipment',
+              quantity: 1,
+              aiSuggestionId: suggestion.id,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(207)
+      const body = response.json()
+      expect(body.errors).toHaveLength(1)
+      expect(body.errors[0].message).toContain('already accepted')
+    })
+
+    it('valid aiSuggestionId items succeed alongside items with no id in same bulk call', async () => {
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+      const [goodSuggestion] = await seedTestAiSuggestions(plan.planId, 1)
+      const nonExistentId = '00000000-0000-0000-0000-000000000099'
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/plans/${plan.planId}/items/bulk`,
+        payload: {
+          items: [
+            { name: 'Manual item', category: 'group_equipment', quantity: 1 },
+            {
+              name: goodSuggestion.name,
+              category: goodSuggestion.category,
+              quantity: 1,
+              aiSuggestionId: goodSuggestion.id,
+            },
+            {
+              name: 'Bad suggestion item',
+              category: 'group_equipment',
+              quantity: 1,
+              aiSuggestionId: nonExistentId,
+            },
+          ],
+        },
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(207)
+      const body = response.json()
+      expect(body.items).toHaveLength(2)
+      expect(body.errors).toHaveLength(1)
+    })
+  })
+
+  describe('GET /plans/:planId/items — source field returned', () => {
+    it('returns source field on all items', async () => {
+      const testDb = await getTestDb()
+      const [plan] = await seedTestPlans(1, { createdByUserId: TEST_USER_ID })
+      await seedTestParticipants(plan.planId, 1, { ownerUserId: TEST_USER_ID })
+
+      await testDb.insert(items).values([
+        {
+          planId: plan.planId,
+          name: 'Manual item',
+          category: 'group_equipment',
+          quantity: 1,
+          unit: 'pcs',
+          source: 'manual',
+        },
+        {
+          planId: plan.planId,
+          name: 'AI item',
+          category: 'group_equipment',
+          quantity: 1,
+          unit: 'pcs',
+          source: 'ai_suggestion',
+        },
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/plans/${plan.planId}/items`,
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body).toHaveLength(2)
+      const sources = body.map((i: { source: string }) => i.source)
+      expect(sources).toContain('manual')
+      expect(sources).toContain('ai_suggestion')
+    })
+  })
+})

--- a/tests/unit/ai-suggestions.route.test.ts
+++ b/tests/unit/ai-suggestions.route.test.ts
@@ -59,12 +59,26 @@ const FAKE_SUGGESTIONS = [
   },
 ]
 
+const FAKE_USAGE_LOG_ID = 'cccccccc-0000-0000-0000-000000000001'
+
 function createMockDb() {
   return {
     select: vi.fn(),
     update: vi.fn(),
+    insert: vi.fn(),
     query: { plans: { findFirst: vi.fn() } },
   }
+}
+
+function mockAiSuggestionsInsert(
+  mockDb: ReturnType<typeof createMockDb>,
+  ids: string[] = []
+) {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(ids.map((id) => ({ id }))),
+    }),
+  })
 }
 
 function createMockModel(suggestions = FAKE_SUGGESTIONS) {
@@ -146,12 +160,13 @@ describe('AI Suggestions Route', () => {
     vi.clearAllMocks()
     mockDb = createMockDb()
     mockAiGenerationIncrement(mockDb)
+    mockAiSuggestionsInsert(mockDb, ['sug-id-1', 'sug-id-2', 'sug-id-3'])
     const model = createMockModel()
     generateSpy = vi.spyOn(itemSuggestions, 'generateItemSuggestions')
     vi.spyOn(modelProvider, 'resolveLanguageModel').mockReturnValue(model)
     recordUsageSpy = vi
       .spyOn(usageTracking, 'recordAiUsage')
-      .mockResolvedValue(undefined)
+      .mockResolvedValue(FAKE_USAGE_LOG_ID)
 
     app = Fastify({ logger: false })
     app.decorate('db', mockDb)
@@ -203,7 +218,9 @@ describe('AI Suggestions Route', () => {
 
     expect(response.statusCode).toBe(200)
     const body = response.json()
+    expect(body.aiUsageLogId).toBe(FAKE_USAGE_LOG_ID)
     expect(body.suggestions).toHaveLength(3)
+    expect(body.suggestions[0].id).toBe('sug-id-1')
     expect(body.suggestions[0].name).toBe('Sunscreen')
     expect(body.suggestions[0].category).toBe('personal_equipment')
     expect(body.suggestions[2].category).toBe('food')
@@ -266,7 +283,9 @@ describe('AI Suggestions Route', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json().suggestions).toHaveLength(1)
+    const partialBody = response.json()
+    expect(partialBody.aiUsageLogId).toBeDefined()
+    expect(partialBody.suggestions).toHaveLength(1)
     expect(recordUsageSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -329,7 +348,9 @@ describe('AI Suggestions Route', () => {
     })
 
     const body = response.json()
+    expect(body).toHaveProperty('aiUsageLogId')
     for (const item of body.suggestions) {
+      expect(item).toHaveProperty('id')
       expect(item).toHaveProperty('name')
       expect(item).toHaveProperty('category')
       expect(item).toHaveProperty('subcategory')

--- a/tests/unit/ai/usage-tracking.test.ts
+++ b/tests/unit/ai/usage-tracking.test.ts
@@ -80,14 +80,24 @@ describe('MODEL_PRICING sync with resolveLanguageModel', () => {
   })
 })
 
+function createInsertMock(
+  returningRows: Array<{ id: string }> = [
+    { id: '00000000-0000-0000-0000-00000000aa01' },
+  ]
+) {
+  const returningMock = vi.fn().mockResolvedValue(returningRows)
+  const valuesMock = vi.fn().mockReturnValue({ returning: returningMock })
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({ values: valuesMock }),
+  }
+  return { mockDb, valuesMock, returningMock }
+}
+
 describe('recordAiUsage', () => {
   it('inserts a usage record via db.insert (fire-and-forget)', async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined)
-    const mockDb = {
-      insert: vi.fn().mockReturnValue({ values: valuesMock }),
-    }
+    const { mockDb, valuesMock } = createInsertMock()
 
-    await recordAiUsage(mockDb as never, {
+    const logId = await recordAiUsage(mockDb as never, {
       featureType: 'item_suggestions',
       planId: '00000000-0000-0000-0000-000000000001',
       userId: 'aaaaaaaa-1111-2222-3333-444444444444',
@@ -103,6 +113,7 @@ describe('recordAiUsage', () => {
       resultCount: 30,
     })
 
+    expect(logId).toBe('00000000-0000-0000-0000-00000000aa01')
     expect(mockDb.insert).toHaveBeenCalledOnce()
     expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -119,10 +130,7 @@ describe('recordAiUsage', () => {
   })
 
   it('persists sessionId when provided', async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined)
-    const mockDb = {
-      insert: vi.fn().mockReturnValue({ values: valuesMock }),
-    }
+    const { mockDb, valuesMock } = createInsertMock()
     const sid = '550e8400-e29b-41d4-a716-446655440000'
 
     await recordAiUsage(mockDb as never, {
@@ -140,10 +148,7 @@ describe('recordAiUsage', () => {
   })
 
   it('persists promptText and rawResponseText when provided', async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined)
-    const mockDb = {
-      insert: vi.fn().mockReturnValue({ values: valuesMock }),
-    }
+    const { mockDb, valuesMock } = createInsertMock()
 
     await recordAiUsage(mockDb as never, {
       featureType: 'item_suggestions',
@@ -167,10 +172,7 @@ describe('recordAiUsage', () => {
   })
 
   it('persists errorType and defaults new fields to null when absent', async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined)
-    const mockDb = {
-      insert: vi.fn().mockReturnValue({ values: valuesMock }),
-    }
+    const { mockDb, valuesMock } = createInsertMock()
 
     await recordAiUsage(mockDb as never, {
       featureType: 'item_suggestions',
@@ -196,7 +198,9 @@ describe('recordAiUsage', () => {
   it('does not throw when db.insert fails', async () => {
     const mockDb = {
       insert: vi.fn().mockReturnValue({
-        values: vi.fn().mockRejectedValue(new Error('DB down')),
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error('DB down')),
+        }),
       }),
     }
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -210,7 +214,7 @@ describe('recordAiUsage', () => {
         durationMs: 1000,
         errorMessage: 'Test error',
       })
-    ).resolves.not.toThrow()
+    ).resolves.toBeNull()
 
     expect(consoleSpy).toHaveBeenCalledWith(
       '[ai-usage-tracking] Failed to record AI usage:',
@@ -220,10 +224,7 @@ describe('recordAiUsage', () => {
   })
 
   it('stores null estimatedCost for unknown model', async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined)
-    const mockDb = {
-      insert: vi.fn().mockReturnValue({ values: valuesMock }),
-    }
+    const { mockDb, valuesMock } = createInsertMock()
 
     await recordAiUsage(mockDb as never, {
       featureType: 'item_suggestions',

--- a/tests/unit/plan-tags.test.ts
+++ b/tests/unit/plan-tags.test.ts
@@ -14,9 +14,9 @@ describe('getPlanTags', () => {
     expect(tags).toHaveProperty('item_generation_bundles')
   })
 
-  it('version is 1.4', () => {
+  it('version is 1.5', () => {
     const tags = getPlanTags()
-    expect(tags['version']).toBe('1.4')
+    expect(tags['version']).toBe('1.5')
   })
 
   it('selection_by_tier matches nested select fields for flags and axes', () => {


### PR DESCRIPTION
- Add ai_suggestions table, item source/aiSuggestionId, migration 0034
- Persist suggestions on AI generate; return ids and aiUsageLogId
- Item create/bulk accept aiSuggestionId; mark suggestions accepted
- recordAiUsage returns inserted log id; tests and seed updated
- Plan creation tags JSON and plan-tags schema/unit test updates

Made-with: Cursor