### PR TITLE
feat(participants): co-owner copy in OpenAPI and schema (rebased on m…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1083,7 +1083,7 @@
               "participant",
               "viewer"
             ],
-            "description": "Set to owner to add a co-owner: only a current owner (participants.role owner on this plan) may set this, with no other body fields. Target must be linked to a user. Does not change plans.ownerParticipantId or createdByUserId."
+            "description": "Set to owner to add a co-owner: only a current owner (`participants.role` owner on this plan) may set this, with no other body fields. Target must be linked to a user. Does not change `plans.ownerParticipantId` or `createdByUserId`."
           },
           "avatarUrl": {
             "type": "string",
@@ -5655,7 +5655,7 @@
         "tags": [
           "participants"
         ],
-        "description": "Update an existing participant by its ID. The plan creator can update any participant; linked participants can only update their own record. Set role to owner to add a co-owner: any current owner participant (role owner on this plan) may call with body { \"role\": \"owner\" } only. The target must be linked to a user account. plans.createdByUserId and plans.ownerParticipantId are not modified.",
+        "description": "Update an existing participant by its ID. The plan creator can update any participant; linked participants can only update their own record. Set `role` to `owner` to add a co-owner: any participant with `role` owner on this plan may call with body `{ \"role\": \"owner\" }` only. Target must be linked to a user. Does not change `plans.createdByUserId` or `plans.ownerParticipantId`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5689,11 +5689,11 @@
             }
           },
           "400": {
-            "description": "Bad request — FST_ERR_VALIDATION for shape/enum. Application codes: owner_promotion_invalid_body (body mixes role owner with other fields), participant_not_linked (target not linked to a user).",
+            "description": "Bad request — FST_ERR_VALIDATION for shape/enum. Application codes: owner_promotion_invalid_body (body mixes `role: owner` with other fields), participant_not_linked (target not linked to a user).",
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Bad request — FST_ERR_VALIDATION for shape/enum. Application codes: owner_promotion_invalid_body (body mixes role owner with other fields), participant_not_linked (target not linked to a user).",
+                  "description": "Bad request — FST_ERR_VALIDATION for shape/enum. Application codes: owner_promotion_invalid_body (body mixes `role: owner` with other fields), participant_not_linked (target not linked to a user).",
                   "$ref": "#/components/schemas/def-0"
                 }
               }
@@ -5711,11 +5711,11 @@
             }
           },
           "403": {
-            "description": "Forbidden — insufficient permissions, or not_plan_owner (caller is not a current owner on this plan when using role owner).",
+            "description": "Forbidden — insufficient permissions, or not_plan_owner (caller is not a current owner on this plan when using `role: owner`).",
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Forbidden — insufficient permissions, or not_plan_owner (caller is not a current owner on this plan when using role owner).",
+                  "description": "Forbidden — insufficient permissions, or not_plan_owner (caller is not a current owner on this plan when using `role: owner`).",
                   "$ref": "#/components/schemas/def-0"
                 }
               }

--- a/src/routes/participants.route.ts
+++ b/src/routes/participants.route.ts
@@ -392,7 +392,7 @@ export async function participantsRoutes(fastify: FastifyInstance) {
         tags: ['participants'],
         summary: 'Update a participant',
         description:
-          'Update an existing participant by its ID. The plan creator can update any participant; linked participants can only update their own record. Set role to owner to add a co-owner: any current owner participant (role owner on this plan) may call with body { "role": "owner" } only. The target must be linked to a user account. plans.createdByUserId and plans.ownerParticipantId are not modified.',
+          'Update an existing participant by its ID. The plan creator can update any participant; linked participants can only update their own record. Set `role` to `owner` to add a co-owner: any participant with `role` owner on this plan may call with body `{ "role": "owner" }` only. Target must be linked to a user. Does not change `plans.createdByUserId` or `plans.ownerParticipantId`.',
         params: { $ref: 'ParticipantIdParam#' },
         body: { $ref: 'UpdateParticipantBody#' },
         response: {
@@ -402,7 +402,7 @@ export async function participantsRoutes(fastify: FastifyInstance) {
           },
           400: {
             description:
-              'Bad request — FST_ERR_VALIDATION for shape/enum. Application codes: owner_promotion_invalid_body (body mixes role owner with other fields), participant_not_linked (target not linked to a user).',
+              'Bad request — FST_ERR_VALIDATION for shape/enum. Application codes: owner_promotion_invalid_body (body mixes `role: owner` with other fields), participant_not_linked (target not linked to a user).',
             $ref: 'ErrorResponse#',
           },
           401: {
@@ -412,7 +412,7 @@ export async function participantsRoutes(fastify: FastifyInstance) {
           },
           403: {
             description:
-              'Forbidden — insufficient permissions, or not_plan_owner (caller is not a current owner on this plan when using role owner).',
+              'Forbidden — insufficient permissions, or not_plan_owner (caller is not a current owner on this plan when using `role: owner`).',
             $ref: 'ErrorResponse#',
           },
           404: {

--- a/src/schemas/participant.schema.ts
+++ b/src/schemas/participant.schema.ts
@@ -107,7 +107,7 @@ export const updateParticipantBodySchema = {
       type: 'string',
       enum: ['owner', 'participant', 'viewer'],
       description:
-        'Set to owner to add a co-owner: only a current owner (participants.role owner on this plan) may set this, with no other body fields. Target must be linked to a user. Does not change plans.ownerParticipantId or createdByUserId.',
+        'Set to owner to add a co-owner: only a current owner (`participants.role` owner on this plan) may set this, with no other body fields. Target must be linked to a user. Does not change `plans.ownerParticipantId` or `createdByUserId`.',
     },
     avatarUrl: { type: 'string', nullable: true },
     contactEmail: { type: 'string', maxLength: 255, nullable: true },

--- a/tests/integration/participants.test.ts
+++ b/tests/integration/participants.test.ts
@@ -619,7 +619,7 @@ describe('Participants Route', () => {
         payload: { role: 'owner' },
       })
 
-      const body = response.json()
+      const body = response.json() as { role: string; code?: string }
       expect(response.statusCode).toBe(200)
       expect(body.code).not.toBe('FST_ERR_VALIDATION')
       expect(body.role).toBe('owner')
@@ -629,8 +629,8 @@ describe('Participants Route', () => {
         .from(plans)
         .where(eq(plans.planId, plan.planId))
 
-      expect(planAfter.ownerParticipantId).toBe(planBefore.ownerParticipantId)
-      expect(planAfter.createdByUserId).toBe(planBefore.createdByUserId)
+      expect(planAfter.ownerParticipantId).toBe(planBefore!.ownerParticipantId)
+      expect(planAfter.createdByUserId).toBe(planBefore!.createdByUserId)
 
       const [prevOwner] = await db
         .select()
@@ -696,7 +696,9 @@ describe('Participants Route', () => {
       })
 
       expect(promote2.statusCode).toBe(200)
-      expect(promote2.json().code).not.toBe('FST_ERR_VALIDATION')
+      expect((promote2.json() as { code?: string }).code).not.toBe(
+        'FST_ERR_VALIDATION'
+      )
 
       const ownerRows = await db
         .select()


### PR DESCRIPTION
…ain)

Tighten PATCH participant descriptions (backticks, error codes). Regenerate docs/openapi.json. Tests: typing for co-owner assertions.

Made-with: Cursor