### PR TITLE
fix: enforce phone uniqueness across users table

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7074,7 +7074,7 @@
         "tags": [
           "auth"
         ],
-        "description": "Creates or updates the authenticated user's app preferences. When `phone` is set, the value is normalized to E.164 and written to `users.phone`, and all `participants.contact_phone` rows for this user are updated to match. Returns 401 if no valid JWT is provided.",
+        "description": "Creates or updates the authenticated user's app preferences. When `phone` is set, the value is normalized to E.164 and written to `users.phone`, and all `participants.contact_phone` rows for this user are updated to match. Returns 401 if no valid JWT is provided. Returns 409 if the phone is already linked to another account.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -7106,6 +7106,17 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Phone number already linked to another account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Phone number already linked to another account",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
           }
         }
       }
@@ -7116,7 +7127,7 @@
         "tags": [
           "auth"
         ],
-        "description": "Updates all participant records linked to the authenticated user with identity fields from the JWT (name, email, phone, avatar). Call this after updating the user profile in Supabase so all plans reflect the latest data.",
+        "description": "Updates all participant records linked to the authenticated user with identity fields from the JWT (name, email, phone, avatar). Call this after updating the user profile in Supabase so all plans reflect the latest data. If the phone in Supabase metadata conflicts with another user, the phone write is skipped and phoneConflict: true is returned.",
         "responses": {
           "200": {
             "description": "Number of participant records synced",
@@ -7128,6 +7139,10 @@
                   "properties": {
                     "synced": {
                       "type": "integer"
+                    },
+                    "phoneConflict": {
+                      "type": "boolean",
+                      "description": "True if the phone in Supabase metadata is already linked to another account. The phone was not written to users.phone."
                     }
                   },
                   "required": [
@@ -8471,7 +8486,7 @@
         "tags": [
           "internal"
         ],
-        "description": "Identifies a registered user by their phone number. Returns the Supabase userId and display name. Returns 404 if the phone is not linked to any registered Chillist account.",
+        "description": "Identifies a registered user by their phone number. Returns the Supabase userId and display name. Returns 404 if the phone is not linked to any registered Chillist account. Returns 409 if multiple users share the same phone (data integrity issue).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8510,6 +8525,17 @@
               "application/json": {
                 "schema": {
                   "description": "No registered user linked to this phone number",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Multiple users share this phone number — data must be deduplicated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Multiple users share this phone number — data must be deduplicated",
                   "$ref": "#/components/schemas/def-0"
                 }
               }

--- a/drizzle/0035_users_phone_unique.sql
+++ b/drizzle/0035_users_phone_unique.sql
@@ -1,0 +1,8 @@
+-- Migration: Add partial unique index on users.phone
+-- This ensures no two users can have the same non-null phone number.
+-- Null phones are allowed (multiple users can have phone = NULL).
+-- IMPORTANT: Run dedup script first to clear existing duplicates before deploying.
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_phone_unique_idx 
+ON users (phone) 
+WHERE phone IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1775400000000,
       "tag": "0034_ai_suggestion_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1775500000000,
+      "tag": "0035_users_phone_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,6 +39,9 @@ export const users = pgTable(
   'users',
   {
     userId: uuid('user_id').primaryKey(),
+    // phone has a partial unique index: users_phone_unique_idx (WHERE phone IS NOT NULL)
+    // This ensures no two users can share the same non-null phone.
+    // See migration 0035_users_phone_unique.sql
     phone: varchar('phone', { length: 50 }),
     preferredLang: varchar('preferred_lang', { length: 10 }),
     foodPreferences: text('food_preferences'),

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -6,6 +6,11 @@ import { syncContactPhoneForAllUserParticipants } from '../services/phone-sync.j
 import { fetchSupabaseUserMetadata } from '../utils/supabase-admin.js'
 import { normalizePhone } from '../utils/phone.js'
 import { endSession } from '../services/session.service.js'
+import {
+  assertPhoneNotOwnedByOtherUser,
+  checkPhoneOwnership,
+  PhoneConflictError,
+} from '../services/phone-guard.js'
 
 const AUTH_RATE_LIMIT = {
   max: 10,
@@ -115,7 +120,7 @@ export async function authRoutes(fastify: FastifyInstance) {
         tags: ['auth'],
         summary: 'Update user preferences',
         description:
-          "Creates or updates the authenticated user's app preferences. When `phone` is set, the value is normalized to E.164 and written to `users.phone`, and all `participants.contact_phone` rows for this user are updated to match. Returns 401 if no valid JWT is provided.",
+          "Creates or updates the authenticated user's app preferences. When `phone` is set, the value is normalized to E.164 and written to `users.phone`, and all `participants.contact_phone` rows for this user are updated to match. Returns 401 if no valid JWT is provided. Returns 409 if the phone is already linked to another account.",
         body: { $ref: 'UpdateProfileBody#' },
         response: {
           200: {
@@ -124,6 +129,10 @@ export async function authRoutes(fastify: FastifyInstance) {
           },
           401: {
             description: 'JWT token missing or invalid',
+            $ref: 'ErrorResponse#',
+          },
+          409: {
+            description: 'Phone number already linked to another account',
             $ref: 'ErrorResponse#',
           },
         },
@@ -158,6 +167,24 @@ export async function authRoutes(fastify: FastifyInstance) {
         body.phone === undefined || body.phone === null
           ? body.phone
           : normalizePhone(body.phone)
+
+      if (normalizedPhone) {
+        try {
+          await assertPhoneNotOwnedByOtherUser(
+            fastify.db,
+            request.user.id,
+            normalizedPhone
+          )
+        } catch (err) {
+          if (err instanceof PhoneConflictError) {
+            return reply.status(409).send({
+              message:
+                'This phone number is already linked to another account.',
+            })
+          }
+          throw err
+        }
+      }
 
       const [row] = await fastify.db
         .insert(users)
@@ -218,13 +245,18 @@ export async function authRoutes(fastify: FastifyInstance) {
         tags: ['auth'],
         summary: 'Sync JWT identity to all participant records',
         description:
-          'Updates all participant records linked to the authenticated user with identity fields from the JWT (name, email, phone, avatar). Call this after updating the user profile in Supabase so all plans reflect the latest data.',
+          'Updates all participant records linked to the authenticated user with identity fields from the JWT (name, email, phone, avatar). Call this after updating the user profile in Supabase so all plans reflect the latest data. If the phone in Supabase metadata conflicts with another user, the phone write is skipped and phoneConflict: true is returned.',
         response: {
           200: {
             description: 'Number of participant records synced',
             type: 'object',
             properties: {
               synced: { type: 'integer' },
+              phoneConflict: {
+                type: 'boolean',
+                description:
+                  'True if the phone in Supabase metadata is already linked to another account. The phone was not written to users.phone.',
+              },
             },
             required: ['synced'],
           },
@@ -250,23 +282,39 @@ export async function authRoutes(fastify: FastifyInstance) {
           request.log
         )
 
+        let phoneConflict = false
+
         if (supabaseMeta?.phone) {
           const normalizedPhone = normalizePhone(supabaseMeta.phone)
-          await fastify.db
-            .insert(users)
-            .values({ userId: request.user.id, phone: normalizedPhone })
-            .onConflictDoUpdate({
-              target: users.userId,
-              set: { phone: normalizedPhone, updatedAt: new Date() },
-            })
-          request.log.info(
-            { userId: request.user.id },
-            'users.phone upserted from Supabase metadata'
+          const ownership = await checkPhoneOwnership(
+            fastify.db,
+            request.user.id,
+            normalizedPhone
           )
+
+          if (ownership.conflict) {
+            request.log.warn(
+              { userId: request.user.id, ownerId: ownership.ownerId },
+              'Skipping users.phone write — phone already owned by another user'
+            )
+            phoneConflict = true
+          } else {
+            await fastify.db
+              .insert(users)
+              .values({ userId: request.user.id, phone: normalizedPhone })
+              .onConflictDoUpdate({
+                target: users.userId,
+                set: { phone: normalizedPhone, updatedAt: new Date() },
+              })
+            request.log.info(
+              { userId: request.user.id },
+              'users.phone upserted from Supabase metadata'
+            )
+          }
         }
 
         const user =
-          supabaseMeta?.phone && !request.user.phone
+          supabaseMeta?.phone && !request.user.phone && !phoneConflict
             ? { ...request.user, phone: supabaseMeta.phone }
             : request.user
 
@@ -276,7 +324,7 @@ export async function authRoutes(fastify: FastifyInstance) {
           request.log
         )
 
-        return { synced }
+        return { synced, ...(phoneConflict && { phoneConflict: true }) }
       } catch (error) {
         request.log.error(
           { err: error, userId: request.user.id },

--- a/src/routes/claim.route.ts
+++ b/src/routes/claim.route.ts
@@ -146,7 +146,12 @@ export async function claimRoutes(fastify: FastifyInstance) {
           updateFields.contactPhone = normalizePhone(userRow.phone)
         } else if (participant.contactPhone) {
           const normalized = normalizePhone(participant.contactPhone)
-          await bootstrapUsersPhoneIfNull(fastify.db, userId, normalized)
+          await bootstrapUsersPhoneIfNull(
+            fastify.db,
+            userId,
+            normalized,
+            request.log
+          )
           updateFields.contactPhone = normalized
         }
 

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -4,6 +4,7 @@ import { eq, inArray, count, and, asc, or, isNull, gte, sql } from 'drizzle-orm'
 import {
   resolveUserByPhone,
   resolveOwnerForInternalPlan,
+  isAmbiguousPhoneLookup,
 } from '../services/internal-auth.service.js'
 import { bootstrapUsersPhoneIfNull } from '../services/phone-sync.js'
 import { persistAssignments } from '../services/item.service.js'
@@ -104,7 +105,7 @@ export async function internalRoutes(fastify: FastifyInstance) {
         tags: ['internal'],
         summary: 'Resolve a WhatsApp phone number to a Chillist user',
         description:
-          'Identifies a registered user by their phone number. Returns the Supabase userId and display name. Returns 404 if the phone is not linked to any registered Chillist account.',
+          'Identifies a registered user by their phone number. Returns the Supabase userId and display name. Returns 404 if the phone is not linked to any registered Chillist account. Returns 409 if multiple users share the same phone (data integrity issue).',
         body: { $ref: 'IdentifyRequest#' },
         response: {
           200: {
@@ -120,6 +121,11 @@ export async function internalRoutes(fastify: FastifyInstance) {
             description: 'No registered user linked to this phone number',
             $ref: 'ErrorResponse#',
           },
+          409: {
+            description:
+              'Multiple users share this phone number — data must be deduplicated',
+            $ref: 'ErrorResponse#',
+          },
         },
       },
     },
@@ -129,19 +135,26 @@ export async function internalRoutes(fastify: FastifyInstance) {
 
       request.log.info({ phonePrefix }, 'Identifying user by phone')
 
-      const user = await resolveUserByPhone(
+      const result = await resolveUserByPhone(
         fastify.db,
         phoneNumber,
         request.log
       )
 
-      if (!user) {
+      if (isAmbiguousPhoneLookup(result)) {
+        return reply.code(409).send({
+          message:
+            'Multiple Chillist accounts share this phone number. Sign in with one account in the app or remove the duplicate phone from the other profile before using WhatsApp.',
+        })
+      }
+
+      if (!result) {
         request.log.info({ phonePrefix }, 'User not found')
         return reply.code(404).send({ message: 'User not found' })
       }
 
       request.log.info({ phonePrefix }, 'User identified')
-      return user
+      return result
     }
   )
 
@@ -390,7 +403,8 @@ export async function internalRoutes(fastify: FastifyInstance) {
           await bootstrapUsersPhoneIfNull(
             tx,
             userId,
-            normalizePhone(owner.contactPhone)
+            normalizePhone(owner.contactPhone),
+            request.log
           )
 
           return updatedPlan

--- a/src/routes/join-request.route.ts
+++ b/src/routes/join-request.route.ts
@@ -185,7 +185,8 @@ export async function joinRequestRoutes(fastify: FastifyInstance) {
         await bootstrapUsersPhoneIfNull(
           fastify.db,
           userId,
-          normalizePhone(body.contactPhone)
+          normalizePhone(body.contactPhone),
+          request.log
         )
 
         request.log.info(

--- a/src/routes/plans.route.ts
+++ b/src/routes/plans.route.ts
@@ -187,7 +187,8 @@ export async function plansRoutes(fastify: FastifyInstance) {
           await bootstrapUsersPhoneIfNull(
             tx,
             authenticatedUserId,
-            normalizePhone(owner.contactPhone)
+            normalizePhone(owner.contactPhone),
+            request.log
           )
 
           return {

--- a/src/services/internal-auth.service.ts
+++ b/src/services/internal-auth.service.ts
@@ -29,6 +29,22 @@ export interface IdentifiedUser {
   displayName: string
 }
 
+export interface AmbiguousPhoneLookup {
+  ambiguous: true
+  userIds: string[]
+}
+
+export type ResolveUserByPhoneResult =
+  | IdentifiedUser
+  | null
+  | AmbiguousPhoneLookup
+
+export function isAmbiguousPhoneLookup(
+  r: ResolveUserByPhoneResult
+): r is AmbiguousPhoneLookup {
+  return r !== null && typeof r === 'object' && 'ambiguous' in r && r.ambiguous
+}
+
 export interface ResolvedInternalPlanOwner {
   name: string
   lastName: string
@@ -120,23 +136,32 @@ export async function resolveUserByPhone(
   db: Database,
   phone: string,
   log?: MinimalLogger
-): Promise<IdentifiedUser | null> {
+): Promise<ResolveUserByPhoneResult> {
   const normalized = normalizePhone(phone)
   const phonePrefix = normalized.slice(0, 4) + '***'
 
   log?.info({ phonePrefix }, 'Normalized phone for DB lookup')
 
-  const [row] = await db
+  const rows = await db
     .select({ userId: users.userId })
     .from(users)
     .where(eq(users.phone, normalized))
-    .limit(1)
 
-  if (!row) {
+  if (rows.length === 0) {
     log?.info({ phonePrefix }, 'No user row found for phone')
     return null
   }
 
+  if (rows.length > 1) {
+    const userIds = rows.map((r) => r.userId).sort()
+    log?.warn(
+      { phonePrefix, userIds },
+      'Multiple users share canonical phone — identify refused'
+    )
+    return { ambiguous: true, userIds }
+  }
+
+  const row = rows[0]!
   log?.info({ phonePrefix, userId: row.userId }, 'User found in DB')
 
   const supabaseMeta = await fetchSupabaseUserMetadata(row.userId, log)

--- a/src/services/phone-guard.ts
+++ b/src/services/phone-guard.ts
@@ -1,0 +1,58 @@
+import { eq, and, ne } from 'drizzle-orm'
+import type { Database } from '../db/index.js'
+import { users } from '../db/schema.js'
+import { normalizePhone } from '../utils/phone.js'
+
+type DbOrTransaction =
+  | Database
+  | Parameters<Parameters<Database['transaction']>[0]>[0]
+
+export class PhoneConflictError extends Error {
+  readonly code = 'PHONE_CONFLICT'
+  constructor(
+    message = 'This phone number is already linked to another account'
+  ) {
+    super(message)
+    this.name = 'PhoneConflictError'
+  }
+}
+
+export interface PhoneGuardResult {
+  conflict: boolean
+  ownerId?: string
+}
+
+export async function checkPhoneOwnership(
+  db: DbOrTransaction,
+  userId: string,
+  phone: string | null
+): Promise<PhoneGuardResult> {
+  if (!phone) {
+    return { conflict: false }
+  }
+
+  const normalized = normalizePhone(phone)
+
+  const [existing] = await db
+    .select({ userId: users.userId })
+    .from(users)
+    .where(and(eq(users.phone, normalized), ne(users.userId, userId)))
+    .limit(1)
+
+  if (existing) {
+    return { conflict: true, ownerId: existing.userId }
+  }
+
+  return { conflict: false }
+}
+
+export async function assertPhoneNotOwnedByOtherUser(
+  db: DbOrTransaction,
+  userId: string,
+  phone: string | null
+): Promise<void> {
+  const result = await checkPhoneOwnership(db, userId, phone)
+  if (result.conflict) {
+    throw new PhoneConflictError()
+  }
+}

--- a/src/services/phone-sync.ts
+++ b/src/services/phone-sync.ts
@@ -1,16 +1,37 @@
 import { eq, isNull } from 'drizzle-orm'
 import type { Database } from '../db/index.js'
 import { participants, users } from '../db/schema.js'
+import { checkPhoneOwnership } from './phone-guard.js'
 
 type DbOrTransaction =
   | Database
   | Parameters<Parameters<Database['transaction']>[0]>[0]
 
+interface MinimalLogger {
+  warn: (obj: Record<string, unknown>, msg: string) => void
+}
+
+export interface BootstrapResult {
+  skipped: boolean
+  reason?: 'conflict' | 'already_set'
+}
+
 export async function bootstrapUsersPhoneIfNull(
   db: DbOrTransaction,
   userId: string,
-  normalizedPhone: string
-): Promise<void> {
+  normalizedPhone: string,
+  log?: MinimalLogger
+): Promise<BootstrapResult> {
+  const ownership = await checkPhoneOwnership(db, userId, normalizedPhone)
+
+  if (ownership.conflict) {
+    log?.warn(
+      { userId, ownerId: ownership.ownerId },
+      'Skipping users.phone bootstrap — phone already owned by another user'
+    )
+    return { skipped: true, reason: 'conflict' }
+  }
+
   await db
     .insert(users)
     .values({ userId, phone: normalizedPhone })
@@ -19,6 +40,8 @@ export async function bootstrapUsersPhoneIfNull(
       set: { phone: normalizedPhone, updatedAt: new Date() },
       setWhere: isNull(users.phone),
     })
+
+  return { skipped: false }
 }
 
 export async function syncContactPhoneForAllUserParticipants(

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -17,6 +17,8 @@ import {
   signJwtWithWrongKey,
   signJwtWithWrongIssuer,
 } from '../helpers/auth.js'
+import { Database } from '../../src/db/index.js'
+import { users } from '../../src/db/schema.js'
 
 describe('JWT Auth (injected JWKS)', () => {
   let app: FastifyInstance
@@ -227,6 +229,103 @@ describe('JWT Auth (injected JWKS)', () => {
   describe('jwtEnabled flag', () => {
     it('sets jwtEnabled to true when JWKS is configured', () => {
       expect(app.jwtEnabled).toBe(true)
+    })
+  })
+})
+
+describe('Phone conflict handling', () => {
+  let app: FastifyInstance
+  let db: Database
+
+  const USER_A_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+  const USER_B_ID = 'bbbbbbbb-5555-6666-7777-888888888888'
+  const PHONE_A = '+972501234567'
+  const PHONE_B = '+972509876543'
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+        rateLimit: false,
+      }
+    )
+  }, 30000)
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+
+    await db.insert(users).values([
+      { userId: USER_A_ID, phone: PHONE_A },
+      { userId: USER_B_ID, phone: PHONE_B },
+    ])
+  })
+
+  describe('PATCH /auth/profile — phone conflict returns 409', () => {
+    it('returns 200 when setting phone to a free number', async () => {
+      const jwt = await signTestJwt({ sub: USER_A_ID })
+      const newPhone = '+972500000000'
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${jwt}` },
+        payload: { phone: newPhone },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().preferences.phone).toBe(newPhone)
+    })
+
+    it('returns 200 when setting phone to own current number (idempotent)', async () => {
+      const jwt = await signTestJwt({ sub: USER_A_ID })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${jwt}` },
+        payload: { phone: PHONE_A },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().preferences.phone).toBe(PHONE_A)
+    })
+
+    it('returns 409 when trying to set phone owned by another user', async () => {
+      const jwt = await signTestJwt({ sub: USER_A_ID })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${jwt}` },
+        payload: { phone: PHONE_B },
+      })
+
+      expect(response.statusCode).toBe(409)
+      expect(response.json().message).toContain('already linked')
+    })
+
+    it('returns 200 when clearing phone to null', async () => {
+      const jwt = await signTestJwt({ sub: USER_A_ID })
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/profile',
+        headers: { authorization: `Bearer ${jwt}` },
+        payload: { phone: null },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().preferences.phone).toBeNull()
     })
   })
 })

--- a/tests/integration/internal-auth.test.ts
+++ b/tests/integration/internal-auth.test.ts
@@ -265,6 +265,42 @@ describe('Internal Auth — POST /api/internal/auth/identify', () => {
     })
   })
 
+  describe('Phone uniqueness constraint', () => {
+    const OTHER_USER_ID = 'dddddddd-4444-5555-6666-777777777777'
+
+    it('prevents inserting duplicate phone via DB unique index', async () => {
+      await expect(
+        db.insert(users).values({
+          userId: OTHER_USER_ID,
+          phone: REGISTERED_PHONE,
+        })
+      ).rejects.toThrow()
+    })
+
+    it('allows inserting different phone numbers', async () => {
+      await expect(
+        db.insert(users).values({
+          userId: OTHER_USER_ID,
+          phone: '+972599999999',
+        })
+      ).resolves.toBeDefined()
+    })
+
+    it('allows inserting null phone (multiple users can have null)', async () => {
+      await db
+        .update(users)
+        .set({ phone: null })
+        .where(eq(users.userId, REGISTERED_USER_ID))
+
+      await expect(
+        db.insert(users).values({
+          userId: OTHER_USER_ID,
+          phone: null,
+        })
+      ).resolves.toBeDefined()
+    })
+  })
+
   describe('Cross-endpoint: phone set via PATCH profile → chatbot identify', () => {
     const E2E_USER_ID = 'cccccccc-3333-4444-5555-666666666666'
     const E2E_PHONE = '+14155550001'

--- a/tests/unit/internal-auth/resolve-user-by-phone.test.ts
+++ b/tests/unit/internal-auth/resolve-user-by-phone.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolveUserByPhone } from '../../../src/services/internal-auth.service.js'
+import {
+  resolveUserByPhone,
+  isAmbiguousPhoneLookup,
+} from '../../../src/services/internal-auth.service.js'
 
 vi.mock('../../../src/utils/supabase-admin.js', () => ({
   fetchSupabaseUserMetadata: vi.fn(),
@@ -8,19 +11,24 @@ vi.mock('../../../src/utils/supabase-admin.js', () => ({
 import { fetchSupabaseUserMetadata } from '../../../src/utils/supabase-admin.js'
 
 const USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const OTHER_USER_ID = 'bbbbbbbb-5555-6666-7777-888888888888'
 
 function makeDb(
-  usersRow: Record<string, unknown> | null,
+  usersRows: Array<Record<string, unknown>>,
   participantRow?: Record<string, unknown> | null
 ) {
-  let callCount = 0
+  let queryIndex = 0
   const queryBuilder = {
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
+    where: vi.fn().mockImplementation(() => {
+      queryIndex++
+      if (queryIndex === 1) {
+        return Promise.resolve(usersRows)
+      }
+      return queryBuilder
+    }),
     limit: vi.fn().mockImplementation(() => {
-      callCount++
-      if (callCount === 1) return Promise.resolve(usersRow ? [usersRow] : [])
       return Promise.resolve(participantRow ? [participantRow] : [])
     }),
   }
@@ -33,7 +41,7 @@ describe('resolveUserByPhone', () => {
   })
 
   it('returns null when no user row matches the phone', async () => {
-    const db = makeDb(null)
+    const db = makeDb([])
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue(null)
 
     const result = await resolveUserByPhone(db, '+972501234567')
@@ -43,7 +51,7 @@ describe('resolveUserByPhone', () => {
   })
 
   it('uses Supabase displayName when available', async () => {
-    const db = makeDb({ userId: USER_ID })
+    const db = makeDb([{ userId: USER_ID }])
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue({
       displayName: 'Alex Guberman',
       phone: '+972501234567',
@@ -56,10 +64,11 @@ describe('resolveUserByPhone', () => {
   })
 
   it('falls back to participant displayName when Supabase returns null', async () => {
-    const db = makeDb(
-      { userId: USER_ID },
-      { name: 'Alex', lastName: 'G', displayName: 'Alex G (custom)' }
-    )
+    const db = makeDb([{ userId: USER_ID }], {
+      name: 'Alex',
+      lastName: 'G',
+      displayName: 'Alex G (custom)',
+    })
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue(null)
 
     const result = await resolveUserByPhone(db, '+972501234567')
@@ -68,10 +77,11 @@ describe('resolveUserByPhone', () => {
   })
 
   it('falls back to name + lastName when Supabase returns null and displayName is null', async () => {
-    const db = makeDb(
-      { userId: USER_ID },
-      { name: 'Alex', lastName: 'Guberman', displayName: null }
-    )
+    const db = makeDb([{ userId: USER_ID }], {
+      name: 'Alex',
+      lastName: 'Guberman',
+      displayName: null,
+    })
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue(null)
 
     const result = await resolveUserByPhone(db, '+972501234567')
@@ -80,7 +90,7 @@ describe('resolveUserByPhone', () => {
   })
 
   it('returns null when Supabase returns null and no participant record exists', async () => {
-    const db = makeDb({ userId: USER_ID }, null)
+    const db = makeDb([{ userId: USER_ID }], null)
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue(null)
 
     const result = await resolveUserByPhone(db, '+972501234567')
@@ -89,12 +99,28 @@ describe('resolveUserByPhone', () => {
   })
 
   it('normalizes phone — strips non-digits and adds + prefix', async () => {
-    const db = makeDb(null)
+    const db = makeDb([])
     vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue(null)
 
     const result = await resolveUserByPhone(db, '972501234567')
 
     expect(result).toBeNull()
+    expect(fetchSupabaseUserMetadata).not.toHaveBeenCalled()
+  })
+
+  it('returns AmbiguousPhoneLookup when multiple users have the same phone', async () => {
+    const db = makeDb([{ userId: USER_ID }, { userId: OTHER_USER_ID }])
+    vi.mocked(fetchSupabaseUserMetadata).mockResolvedValue(null)
+
+    const result = await resolveUserByPhone(db, '+972501234567')
+
+    expect(isAmbiguousPhoneLookup(result)).toBe(true)
+    if (isAmbiguousPhoneLookup(result)) {
+      expect(result.ambiguous).toBe(true)
+      expect(result.userIds).toHaveLength(2)
+      expect(result.userIds).toContain(USER_ID)
+      expect(result.userIds).toContain(OTHER_USER_ID)
+    }
     expect(fetchSupabaseUserMetadata).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/phone-guard/assert-phone-not-owned.test.ts
+++ b/tests/unit/phone-guard/assert-phone-not-owned.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  checkPhoneOwnership,
+  assertPhoneNotOwnedByOtherUser,
+  PhoneConflictError,
+} from '../../../src/services/phone-guard.js'
+
+const CALLER_USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const OTHER_USER_ID = 'bbbbbbbb-5555-6666-7777-888888888888'
+
+function makeDb(existingOwner: { userId: string } | null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(existingOwner ? [existingOwner] : []),
+  } as unknown as Parameters<typeof checkPhoneOwnership>[0]
+}
+
+describe('checkPhoneOwnership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns conflict: false when phone is null', async () => {
+    const db = makeDb(null)
+    const result = await checkPhoneOwnership(db, CALLER_USER_ID, null)
+    expect(result).toEqual({ conflict: false })
+  })
+
+  it('returns conflict: false when phone is empty string', async () => {
+    const db = makeDb(null)
+    const result = await checkPhoneOwnership(db, CALLER_USER_ID, '')
+    expect(result).toEqual({ conflict: false })
+  })
+
+  it('returns conflict: false when no other user owns the phone', async () => {
+    const db = makeDb(null)
+    const result = await checkPhoneOwnership(
+      db,
+      CALLER_USER_ID,
+      '+972501234567'
+    )
+    expect(result).toEqual({ conflict: false })
+  })
+
+  it('returns conflict: true with ownerId when another user owns the phone', async () => {
+    const db = makeDb({ userId: OTHER_USER_ID })
+    const result = await checkPhoneOwnership(
+      db,
+      CALLER_USER_ID,
+      '+972501234567'
+    )
+    expect(result).toEqual({ conflict: true, ownerId: OTHER_USER_ID })
+  })
+
+  it('normalizes the phone before checking (strips spaces, adds +)', async () => {
+    const db = makeDb(null)
+    await checkPhoneOwnership(db, CALLER_USER_ID, '972 50 123 4567')
+    expect(db.select).toHaveBeenCalled()
+  })
+})
+
+describe('assertPhoneNotOwnedByOtherUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not throw when phone is null', async () => {
+    const db = makeDb(null)
+    await expect(
+      assertPhoneNotOwnedByOtherUser(db, CALLER_USER_ID, null)
+    ).resolves.toBeUndefined()
+  })
+
+  it('does not throw when phone is free', async () => {
+    const db = makeDb(null)
+    await expect(
+      assertPhoneNotOwnedByOtherUser(db, CALLER_USER_ID, '+972501234567')
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws PhoneConflictError when another user owns the phone', async () => {
+    const db = makeDb({ userId: OTHER_USER_ID })
+    await expect(
+      assertPhoneNotOwnedByOtherUser(db, CALLER_USER_ID, '+972501234567')
+    ).rejects.toThrow(PhoneConflictError)
+  })
+
+  it('throws with the correct error code', async () => {
+    const db = makeDb({ userId: OTHER_USER_ID })
+    try {
+      await assertPhoneNotOwnedByOtherUser(db, CALLER_USER_ID, '+972501234567')
+      expect.fail('Expected PhoneConflictError to be thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(PhoneConflictError)
+      expect((err as PhoneConflictError).code).toBe('PHONE_CONFLICT')
+    }
+  })
+})


### PR DESCRIPTION
Problem: users.phone had no unique constraint, allowing multiple users to share the same phone. This caused the WhatsApp chatbot to non-deterministically resolve to either user during identify, creating plans on the wrong account.

Solution:
- Add assertPhoneNotOwnedByOtherUser helper (phone-guard.ts)
- Wire guard into all 6 phone-writing paths:
  - PATCH /auth/profile: hard 409 on conflict
  - POST /auth/sync-profile: soft skip, returns phoneConflict: true
  - POST /plans, join-requests, claim, internal plans: soft skip + warn log
- Add partial unique index on users.phone (WHERE phone IS NOT NULL)
- Update resolveUserByPhone to detect and return 409 on ambiguous lookups

Note: Prod data was manually deduped before this migration.

Closes #204

Made-with: Cursor