### PR TITLE
feat: persist tool_call_details to chatbot_ai_usage

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3859,6 +3859,40 @@
       "def-103": {
         "type": "object",
         "properties": {
+          "toolName": {
+            "type": "string",
+            "description": "Name of the tool invoked"
+          },
+          "args": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Arguments passed to the tool"
+          },
+          "result": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "description": "Result returned by the tool; null on error"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message when the tool call failed"
+          },
+          "durationMs": {
+            "type": "integer",
+            "description": "Wall-clock duration of the tool call in milliseconds"
+          }
+        },
+        "required": [
+          "toolName",
+          "args",
+          "durationMs"
+        ],
+        "title": "ToolCallDetail"
+      },
+      "def-104": {
+        "type": "object",
+        "properties": {
           "id": {
             "type": "string",
             "format": "uuid",
@@ -3923,6 +3957,14 @@
             "type": "integer",
             "description": "Total tool calls in this turn"
           },
+          "toolCallDetails": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/def-103"
+            },
+            "description": "Per-tool details: args, result/error, and duration"
+          },
           "inputTokens": {
             "type": "integer",
             "nullable": true,
@@ -3980,14 +4022,14 @@
         ],
         "title": "ChatbotAiUsageLog"
       },
-      "def-104": {
+      "def-105": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-103"
+          "$ref": "#/components/schemas/def-104"
         },
         "title": "ChatbotAiUsageLogList"
       },
-      "def-105": {
+      "def-106": {
         "type": "object",
         "properties": {
           "modelId": {
@@ -4010,7 +4052,7 @@
         ],
         "title": "ChatbotAiUsageModelSummary"
       },
-      "def-106": {
+      "def-107": {
         "type": "object",
         "properties": {
           "chatType": {
@@ -4033,7 +4075,7 @@
         ],
         "title": "ChatbotAiUsageChatTypeSummary"
       },
-      "def-107": {
+      "def-108": {
         "type": "object",
         "properties": {
           "toolName": {
@@ -4051,7 +4093,7 @@
         ],
         "title": "ChatbotAiUsageToolCallSummary"
       },
-      "def-108": {
+      "def-109": {
         "type": "object",
         "properties": {
           "totalRequests": {
@@ -4074,19 +4116,19 @@
           "byModel": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-105"
+              "$ref": "#/components/schemas/def-106"
             }
           },
           "byChatType": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-106"
+              "$ref": "#/components/schemas/def-107"
             }
           },
           "byToolCalls": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-107"
+              "$ref": "#/components/schemas/def-108"
             }
           }
         },
@@ -4100,7 +4142,7 @@
         ],
         "title": "ChatbotAiUsageSummary"
       },
-      "def-109": {
+      "def-110": {
         "type": "object",
         "properties": {
           "userId": {
@@ -4155,19 +4197,19 @@
         },
         "title": "ChatbotAiUsageQuery"
       },
-      "def-110": {
+      "def-111": {
         "type": "object",
         "description": "Paginated chatbot AI usage with aggregates. Admin only. Table is written by the chatbot service.",
         "properties": {
           "logs": {
-            "$ref": "#/components/schemas/def-104"
+            "$ref": "#/components/schemas/def-105"
           },
           "total": {
             "type": "integer",
             "description": "Total rows matching filters (for pagination)"
           },
           "summary": {
-            "$ref": "#/components/schemas/def-108"
+            "$ref": "#/components/schemas/def-109"
           }
         },
         "required": [
@@ -4177,7 +4219,7 @@
         ],
         "title": "ChatbotAiUsageResponse"
       },
-      "def-111": {
+      "def-112": {
         "type": "object",
         "description": "Plan tag taxonomy served as a static versioned JSON file.\nLabels are bilingual objects `{ en, he }` — pick the active locale at render time.\nAll `id` values are stable slugs safe to persist as tag values.\n\n**Rendering order:** tier1 → universal_flags → tier2_axes (filtered by chosen tier1) → tier3 (drill-down per chosen tier2 value).\n\n**Selection summary:** Read `selection_by_tier` for explicit single vs multi per tier and per flag/axis. Nested objects remain authoritative (`tier1.select`, each flag/axis `select`, `tier3.default_select` + `multi_select_parents`).",
         "required": [
@@ -8546,7 +8588,7 @@
               "application/json": {
                 "schema": {
                   "description": "Paginated logs, total count for filters, and summary aggregates",
-                  "$ref": "#/components/schemas/def-110"
+                  "$ref": "#/components/schemas/def-111"
                 }
               }
             }
@@ -8601,7 +8643,7 @@
               "application/json": {
                 "schema": {
                   "description": "Full plan tag taxonomy",
-                  "$ref": "#/components/schemas/def-111"
+                  "$ref": "#/components/schemas/def-112"
                 }
               }
             }
@@ -9183,7 +9225,7 @@
               "application/json": {
                 "schema": {
                   "description": "Full plan tag taxonomy",
-                  "$ref": "#/components/schemas/def-111"
+                  "$ref": "#/components/schemas/def-112"
                 }
               }
             }
@@ -9295,6 +9337,17 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Internal server error",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
           }
         }
       }
@@ -9346,6 +9399,17 @@
               "application/json": {
                 "schema": {
                   "description": "No plan linked to this WhatsApp group ID",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Internal server error",
                   "$ref": "#/components/schemas/def-0"
                 }
               }

--- a/drizzle/0038_chatbot_tool_call_details.sql
+++ b/drizzle/0038_chatbot_tool_call_details.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chatbot_ai_usage" ADD COLUMN "tool_call_details" jsonb;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -271,7 +271,7 @@
     {
       "idx": 38,
       "version": "7",
-      "when": 1747044000000,
+      "when": 1778587362229,
       "tag": "0038_chatbot_tool_call_details",
       "breakpoints": true
     }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1775700000000,
       "tag": "0037_plan_whatsapp_group_id",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1747044000000,
+      "tag": "0038_chatbot_tool_call_details",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -478,6 +478,14 @@ export const aiSuggestions = pgTable(
 
 // Read-only mirror: rows are owned by the chatbot service; no FK constraints or relations.
 
+export interface ToolCallDetail {
+  toolName: string
+  args: Record<string, unknown>
+  result: Record<string, unknown> | null
+  error?: string
+  durationMs: number
+}
+
 // Mirror of chillist-whatsapp-bot/migrations/004_chatbot_ai_usage.sql — read-only from BE
 export const chatbotAiUsage = pgTable('chatbot_ai_usage', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -492,6 +500,7 @@ export const chatbotAiUsage = pgTable('chatbot_ai_usage', {
   stepCount: integer('step_count').notNull().default(1),
   toolCalls: jsonb('tool_calls').$type<string[]>().notNull().default([]),
   toolCallCount: integer('tool_call_count').notNull().default(0),
+  toolCallDetails: jsonb('tool_call_details').$type<ToolCallDetail[]>(),
   inputTokens: integer('input_tokens'),
   outputTokens: integer('output_tokens'),
   totalTokens: integer('total_tokens'),

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -1129,6 +1129,10 @@ export async function internalRoutes(fastify: FastifyInstance) {
               'This WhatsApp group is already linked to another plan',
             $ref: 'ErrorResponse#',
           },
+          500: {
+            description: 'Internal server error',
+            $ref: 'ErrorResponse#',
+          },
         },
       },
     },
@@ -1141,41 +1145,51 @@ export async function internalRoutes(fastify: FastifyInstance) {
       const { planId } = request.params as { planId: string }
       const { groupId } = request.body as { groupId: string | null }
 
-      const result = await setPlanWhatsappGroupId(
-        fastify.db,
-        planId,
-        userId,
-        groupId
-      )
+      try {
+        const result = await setPlanWhatsappGroupId(
+          fastify.db,
+          planId,
+          userId,
+          groupId
+        )
 
-      if (result === 'not_found') {
-        request.log.warn({ planId }, 'Link WhatsApp group — plan not found')
-        return reply.code(404).send({ message: 'Plan not found' })
-      }
-      if (result === 'forbidden') {
-        request.log.warn(
-          { planId, userId },
-          'Link WhatsApp group — caller is not owner'
+        if (result === 'not_found') {
+          request.log.warn({ planId }, 'Link WhatsApp group — plan not found')
+          return reply.code(404).send({ message: 'Plan not found' })
+        }
+        if (result === 'forbidden') {
+          request.log.warn(
+            { planId, userId },
+            'Link WhatsApp group — caller is not owner'
+          )
+          return reply
+            .code(403)
+            .send({ message: 'Only the plan owner can link a WhatsApp group' })
+        }
+        if (result === 'conflict') {
+          request.log.warn(
+            { planId, groupId },
+            'Link WhatsApp group — group already linked to another plan'
+          )
+          return reply.code(409).send({
+            message: 'This WhatsApp group is already linked to another plan',
+          })
+        }
+
+        request.log.info(
+          { planId, groupId: result.groupId },
+          'WhatsApp group linked'
+        )
+        return result
+      } catch (error) {
+        request.log.error(
+          { err: error, planId, userId },
+          'Link WhatsApp group — unexpected error'
         )
         return reply
-          .code(403)
-          .send({ message: 'Only the plan owner can link a WhatsApp group' })
+          .code(500)
+          .send({ message: 'Failed to link WhatsApp group' })
       }
-      if (result === 'conflict') {
-        request.log.warn(
-          { planId, groupId },
-          'Link WhatsApp group — group already linked to another plan'
-        )
-        return reply.code(409).send({
-          message: 'This WhatsApp group is already linked to another plan',
-        })
-      }
-
-      request.log.info(
-        { planId, groupId: result.groupId },
-        'WhatsApp group linked'
-      )
-      return result
     }
   )
 
@@ -1201,31 +1215,45 @@ export async function internalRoutes(fastify: FastifyInstance) {
             description: 'No plan linked to this WhatsApp group ID',
             $ref: 'ErrorResponse#',
           },
+          500: {
+            description: 'Internal server error',
+            $ref: 'ErrorResponse#',
+          },
         },
       },
     },
     async (request, reply) => {
       const { groupId } = request.params as { groupId: string }
 
-      const plan = await getPlanByWhatsappGroupId(fastify.db, groupId)
+      try {
+        const plan = await getPlanByWhatsappGroupId(fastify.db, groupId)
 
-      if (!plan) {
-        request.log.info({ groupId }, 'WhatsApp group lookup — no plan found')
+        if (!plan) {
+          request.log.info({ groupId }, 'WhatsApp group lookup — no plan found')
+          return reply
+            .code(404)
+            .send({ message: 'No plan linked to this WhatsApp group' })
+        }
+
+        request.log.info(
+          { groupId, planId: plan.planId },
+          'WhatsApp group lookup — plan found'
+        )
+        return {
+          plan: {
+            id: plan.planId,
+            name: plan.title,
+            date: plan.startDate ? plan.startDate.toISOString() : null,
+          },
+        }
+      } catch (error) {
+        request.log.error(
+          { err: error, groupId },
+          'WhatsApp group lookup — unexpected error'
+        )
         return reply
-          .code(404)
-          .send({ message: 'No plan linked to this WhatsApp group' })
-      }
-
-      request.log.info(
-        { groupId, planId: plan.planId },
-        'WhatsApp group lookup — plan found'
-      )
-      return {
-        plan: {
-          id: plan.planId,
-          name: plan.title,
-          date: plan.startDate ? plan.startDate.toISOString() : null,
-        },
+          .code(500)
+          .send({ message: 'Failed to look up WhatsApp group plan' })
       }
     }
   )

--- a/src/schemas/chatbot-ai-usage.schema.ts
+++ b/src/schemas/chatbot-ai-usage.schema.ts
@@ -1,3 +1,31 @@
+export const toolCallDetailSchema = {
+  $id: 'ToolCallDetail',
+  type: 'object',
+  properties: {
+    toolName: { type: 'string', description: 'Name of the tool invoked' },
+    args: {
+      type: 'object',
+      additionalProperties: true,
+      description: 'Arguments passed to the tool',
+    },
+    result: {
+      type: 'object',
+      nullable: true,
+      additionalProperties: true,
+      description: 'Result returned by the tool; null on error',
+    },
+    error: {
+      type: 'string',
+      description: 'Error message when the tool call failed',
+    },
+    durationMs: {
+      type: 'integer',
+      description: 'Wall-clock duration of the tool call in milliseconds',
+    },
+  },
+  required: ['toolName', 'args', 'durationMs'],
+} as const
+
 export const chatbotAiUsageLogSchema = {
   $id: 'ChatbotAiUsageLog',
   type: 'object',
@@ -60,6 +88,12 @@ export const chatbotAiUsageLogSchema = {
     toolCallCount: {
       type: 'integer',
       description: 'Total tool calls in this turn',
+    },
+    toolCallDetails: {
+      type: 'array',
+      nullable: true,
+      items: { $ref: 'ToolCallDetail#' },
+      description: 'Per-tool details: args, result/error, and duration',
     },
     inputTokens: {
       type: 'integer',

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -129,6 +129,7 @@ import {
   aiUsageResponseSchema,
 } from './ai-usage.schema.js'
 import {
+  toolCallDetailSchema,
   chatbotAiUsageLogSchema,
   chatbotAiUsageLogListSchema,
   chatbotAiUsageModelSummarySchema,
@@ -244,6 +245,7 @@ const schemas = [
   aiUsageSummarySchema,
   aiUsageQuerySchema,
   aiUsageResponseSchema,
+  toolCallDetailSchema,
   chatbotAiUsageLogSchema,
   chatbotAiUsageLogListSchema,
   chatbotAiUsageModelSummarySchema,

--- a/tests/integration/admin-chatbot-ai-usage.test.ts
+++ b/tests/integration/admin-chatbot-ai-usage.test.ts
@@ -16,7 +16,10 @@ import {
 } from '../helpers/auth.js'
 import { chatbotAiUsage } from '../../src/db/schema.js'
 import { sql } from 'drizzle-orm'
-import type { NewChatbotAiUsageLog } from '../../src/db/schema.js'
+import type {
+  NewChatbotAiUsageLog,
+  ToolCallDetail,
+} from '../../src/db/schema.js'
 
 const ADMIN_USER_ID = 'dddddddd-1111-2222-3333-444444444444'
 const REGULAR_USER_ID = 'eeeeeeee-1111-2222-3333-444444444444'
@@ -246,6 +249,52 @@ describe('GET /admin/chatbot-ai-usage integration', () => {
     )
     expect(lookup?.count).toBe(1)
     expect(details?.count).toBe(1)
+  })
+
+  it('returns tool_call_details in log rows when populated', async () => {
+    const db = await getTestDb()
+    const toolCallDetails: ToolCallDetail[] = [
+      {
+        toolName: 'getPlanDetails',
+        args: { planName: 'Beach Trip' },
+        result: { ok: true, planId: 'abc-123' },
+        durationMs: 42,
+      },
+    ]
+    await db.insert(chatbotAiUsage).values([
+      makeLog({
+        toolCalls: ['getPlanDetails'],
+        toolCallCount: 1,
+        toolCallDetails,
+      }),
+    ])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/chatbot-ai-usage',
+      headers: { authorization: `Bearer ${adminToken}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.logs).toHaveLength(1)
+    expect(body.logs[0].toolCallDetails).toEqual(toolCallDetails)
+  })
+
+  it('returns null for tool_call_details on rows that predate the column', async () => {
+    const db = await getTestDb()
+    await db.insert(chatbotAiUsage).values([makeLog()])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/chatbot-ai-usage',
+      headers: { authorization: `Bearer ${adminToken}` },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.logs).toHaveLength(1)
+    expect(body.logs[0].toolCallDetails).toBeNull()
   })
 
   it('respects limit and offset pagination', async () => {


### PR DESCRIPTION
## Summary

- Adds nullable `tool_call_details` JSONB column to `chatbot_ai_usage` (migration `0038`) so per-tool args, results/errors, and durations are queryable after the fact — not just in ephemeral Railway logs
- Adds `ToolCallDetail` TypeScript interface and registers `ToolCallDetail` OpenAPI schema; admin `GET /admin/chatbot-ai-usage` now includes `toolCallDetails` on each log row
- Wraps both WhatsApp group endpoints (`PATCH /plans/:planId/whatsapp-group`, `GET /whatsapp-group/:groupId/plan`) in try/catch with `log.error` so unexpected DB failures surface in Railway

## FE follow-up

chillist-fe#245 — update admin chatbot-ai-usage view to display `tool_call_details`

## Bot follow-up

Bot PR needed: extend `onStepFinish` to capture args/result/error/durationMs per tool, pass through `AiResponse.toolCallDetails` → `CreateUsageData` → `postgres-usage-logger.ts` INSERT.

## Test plan

- [x] Integration: `returns tool_call_details in log rows when populated`
- [x] Integration: `returns null for tool_call_details on rows that predate the column`
- [x] All 1207 existing tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] OpenAPI regenerated

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)