### PR TITLE
feat: internal item-assign route for chatbot

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -939,7 +939,7 @@
           "dietaryMembers": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-91"
+                "$ref": "#/components/schemas/def-94"
               },
               {
                 "type": "null"
@@ -1036,7 +1036,7 @@
             "type": "string"
           },
           "dietaryMembers": {
-            "$ref": "#/components/schemas/def-91",
+            "$ref": "#/components/schemas/def-94",
             "description": "Per-person dietary preferences. Optional on create — send to populate structured dietary data for the participant group."
           },
           "notes": {
@@ -1115,7 +1115,7 @@
           "dietaryMembers": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-91"
+                "$ref": "#/components/schemas/def-94"
               },
               {
                 "type": "null"
@@ -1382,7 +1382,7 @@
           "dietaryMembers": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-91"
+                "$ref": "#/components/schemas/def-94"
               },
               {
                 "type": "null"
@@ -1540,7 +1540,7 @@
             "type": "string"
           },
           "dietaryMembers": {
-            "$ref": "#/components/schemas/def-91",
+            "$ref": "#/components/schemas/def-94",
             "description": "Per-person dietary preferences for this join request. Optional — carried through to the participant record on approval."
           },
           "notes": {
@@ -1640,7 +1640,7 @@
           "dietaryMembers": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-91"
+                "$ref": "#/components/schemas/def-94"
               },
               {
                 "type": "null"
@@ -1807,7 +1807,7 @@
           "dietaryMembers": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-91"
+                "$ref": "#/components/schemas/def-94"
               },
               {
                 "type": "null"
@@ -1875,7 +1875,7 @@
           "dietaryMembers": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/def-91"
+                "$ref": "#/components/schemas/def-94"
               },
               {
                 "type": "null"
@@ -3339,6 +3339,63 @@
       },
       "def-90": {
         "type": "object",
+        "description": "Request body for PATCH /api/internal/items/:itemId/assign. Owner can assign any item to any participant. Participant can only self-assign an unassigned item.",
+        "required": [
+          "participantId"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "participantId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the participant to assign the item to."
+          }
+        },
+        "title": "InternalAssignItemBody"
+      },
+      "def-91": {
+        "type": "object",
+        "description": "Item snippet after assignment.",
+        "required": [
+          "id",
+          "name",
+          "assignedParticipantId"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Item UUID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Item name."
+          },
+          "assignedParticipantId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the participant the item was assigned to."
+          }
+        },
+        "title": "InternalAssignItemItem"
+      },
+      "def-92": {
+        "type": "object",
+        "description": "Response for PATCH /api/internal/items/:itemId/assign.",
+        "required": [
+          "item"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "item": {
+            "$ref": "#/components/schemas/def-91"
+          }
+        },
+        "title": "InternalAssignItemResponse"
+      },
+      "def-93": {
+        "type": "object",
         "properties": {
           "type": {
             "type": "string",
@@ -3404,13 +3461,13 @@
         ],
         "title": "DietaryMember"
       },
-      "def-91": {
+      "def-94": {
         "type": "object",
         "properties": {
           "members": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-90"
+              "$ref": "#/components/schemas/def-93"
             },
             "description": "Per-person dietary data for each adult/kid in this participant group. Each entry has a type (adult|kid), a 0-based index within that type, a single diet preference, and an allergies list."
           }
@@ -3420,7 +3477,7 @@
         ],
         "title": "DietaryMembersBody"
       },
-      "def-92": {
+      "def-95": {
         "type": [
           "object",
           "null"
@@ -3440,7 +3497,7 @@
         },
         "title": "AiSuggestionsRequest"
       },
-      "def-93": {
+      "def-96": {
         "type": "object",
         "required": [
           "id",
@@ -3497,7 +3554,7 @@
         },
         "title": "AiSuggestionItem"
       },
-      "def-94": {
+      "def-97": {
         "type": "object",
         "required": [
           "suggestions",
@@ -3508,7 +3565,7 @@
           "suggestions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-93"
+              "$ref": "#/components/schemas/def-96"
             },
             "description": "Generated items for the requested category (post-filtered to match the path category)."
           },
@@ -3524,7 +3581,7 @@
         },
         "title": "AiSuggestionsResponse"
       },
-      "def-95": {
+      "def-98": {
         "type": "object",
         "required": [
           "planId",
@@ -3547,7 +3604,7 @@
         },
         "title": "CategoryParam"
       },
-      "def-96": {
+      "def-99": {
         "type": "object",
         "properties": {
           "id": {
@@ -3684,14 +3741,14 @@
         ],
         "title": "AiUsageLog"
       },
-      "def-97": {
+      "def-100": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-96"
+          "$ref": "#/components/schemas/def-99"
         },
         "title": "AiUsageLogList"
       },
-      "def-98": {
+      "def-101": {
         "type": "object",
         "properties": {
           "featureType": {
@@ -3714,7 +3771,7 @@
         ],
         "title": "AiUsageFeatureSummary"
       },
-      "def-99": {
+      "def-102": {
         "type": "object",
         "properties": {
           "modelId": {
@@ -3737,7 +3794,7 @@
         ],
         "title": "AiUsageModelSummary"
       },
-      "def-100": {
+      "def-103": {
         "type": "object",
         "properties": {
           "totalRequests": {
@@ -3760,13 +3817,13 @@
           "byFeature": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-98"
+              "$ref": "#/components/schemas/def-101"
             }
           },
           "byModel": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-99"
+              "$ref": "#/components/schemas/def-102"
             }
           }
         },
@@ -3779,7 +3836,7 @@
         ],
         "title": "AiUsageSummary"
       },
-      "def-101": {
+      "def-104": {
         "type": "object",
         "properties": {
           "planId": {
@@ -3834,19 +3891,19 @@
         },
         "title": "AiUsageQuery"
       },
-      "def-102": {
+      "def-105": {
         "type": "object",
         "description": "Paginated AI usage logs with aggregated summary. Admin only.",
         "properties": {
           "logs": {
-            "$ref": "#/components/schemas/def-97"
+            "$ref": "#/components/schemas/def-100"
           },
           "total": {
             "type": "integer",
             "description": "Total count of records matching filters (for pagination)"
           },
           "summary": {
-            "$ref": "#/components/schemas/def-100"
+            "$ref": "#/components/schemas/def-103"
           }
         },
         "required": [
@@ -3856,7 +3913,7 @@
         ],
         "title": "AiUsageResponse"
       },
-      "def-103": {
+      "def-106": {
         "type": "object",
         "properties": {
           "toolName": {
@@ -3890,7 +3947,7 @@
         ],
         "title": "ToolCallDetail"
       },
-      "def-104": {
+      "def-107": {
         "type": "object",
         "properties": {
           "id": {
@@ -3961,7 +4018,7 @@
             "type": "array",
             "nullable": true,
             "items": {
-              "$ref": "#/components/schemas/def-103"
+              "$ref": "#/components/schemas/def-106"
             },
             "description": "Per-tool details: args, result/error, and duration"
           },
@@ -4022,14 +4079,14 @@
         ],
         "title": "ChatbotAiUsageLog"
       },
-      "def-105": {
+      "def-108": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-104"
+          "$ref": "#/components/schemas/def-107"
         },
         "title": "ChatbotAiUsageLogList"
       },
-      "def-106": {
+      "def-109": {
         "type": "object",
         "properties": {
           "modelId": {
@@ -4052,7 +4109,7 @@
         ],
         "title": "ChatbotAiUsageModelSummary"
       },
-      "def-107": {
+      "def-110": {
         "type": "object",
         "properties": {
           "chatType": {
@@ -4075,7 +4132,7 @@
         ],
         "title": "ChatbotAiUsageChatTypeSummary"
       },
-      "def-108": {
+      "def-111": {
         "type": "object",
         "properties": {
           "toolName": {
@@ -4093,7 +4150,7 @@
         ],
         "title": "ChatbotAiUsageToolCallSummary"
       },
-      "def-109": {
+      "def-112": {
         "type": "object",
         "properties": {
           "totalRequests": {
@@ -4116,19 +4173,19 @@
           "byModel": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-106"
+              "$ref": "#/components/schemas/def-109"
             }
           },
           "byChatType": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-107"
+              "$ref": "#/components/schemas/def-110"
             }
           },
           "byToolCalls": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/def-108"
+              "$ref": "#/components/schemas/def-111"
             }
           }
         },
@@ -4142,7 +4199,7 @@
         ],
         "title": "ChatbotAiUsageSummary"
       },
-      "def-110": {
+      "def-113": {
         "type": "object",
         "properties": {
           "userId": {
@@ -4197,19 +4254,19 @@
         },
         "title": "ChatbotAiUsageQuery"
       },
-      "def-111": {
+      "def-114": {
         "type": "object",
         "description": "Paginated chatbot AI usage with aggregates. Admin only. Table is written by the chatbot service.",
         "properties": {
           "logs": {
-            "$ref": "#/components/schemas/def-105"
+            "$ref": "#/components/schemas/def-108"
           },
           "total": {
             "type": "integer",
             "description": "Total rows matching filters (for pagination)"
           },
           "summary": {
-            "$ref": "#/components/schemas/def-109"
+            "$ref": "#/components/schemas/def-112"
           }
         },
         "required": [
@@ -4219,7 +4276,7 @@
         ],
         "title": "ChatbotAiUsageResponse"
       },
-      "def-112": {
+      "def-115": {
         "type": "object",
         "description": "Plan tag taxonomy served as a static versioned JSON file.\nLabels are bilingual objects `{ en, he }` — pick the active locale at render time.\nAll `id` values are stable slugs safe to persist as tag values.\n\n**Rendering order:** tier1 → universal_flags → tier2_axes (filtered by chosen tier1) → tier3 (drill-down per chosen tier2 value).\n\n**Selection summary:** Read `selection_by_tier` for explicit single vs multi per tier and per flag/axis. Nested objects remain authoritative (`tier1.select`, each flag/axis `select`, `tier3.default_select` + `multi_select_parents`).",
         "required": [
@@ -8229,7 +8286,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-92"
+                "$ref": "#/components/schemas/def-95"
               }
             }
           }
@@ -8274,7 +8331,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-94"
+                  "$ref": "#/components/schemas/def-97"
                 }
               }
             }
@@ -8442,7 +8499,7 @@
               "application/json": {
                 "schema": {
                   "description": "Paginated logs, total count for the current filters, and summary aggregates",
-                  "$ref": "#/components/schemas/def-102"
+                  "$ref": "#/components/schemas/def-105"
                 }
               }
             }
@@ -8588,7 +8645,7 @@
               "application/json": {
                 "schema": {
                   "description": "Paginated logs, total count for filters, and summary aggregates",
-                  "$ref": "#/components/schemas/def-111"
+                  "$ref": "#/components/schemas/def-114"
                 }
               }
             }
@@ -8643,7 +8700,7 @@
               "application/json": {
                 "schema": {
                   "description": "Full plan tag taxonomy",
-                  "$ref": "#/components/schemas/def-112"
+                  "$ref": "#/components/schemas/def-115"
                 }
               }
             }
@@ -9211,6 +9268,103 @@
         }
       }
     },
+    "/api/internal/items/{itemId}/assign": {
+      "patch": {
+        "summary": "Assign item to a participant",
+        "tags": [
+          "internal"
+        ],
+        "description": "Owner can assign (or reassign) any item to any participant on the plan. Participant can only self-assign an item that has no existing assignments. Headers: x-service-key (service auth) and x-user-id (caller's Supabase UUID). The assigned entry is upserted into assignmentStatusList with status pending.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-90"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "itemId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item assigned. Returns item id, name, and assignedParticipantId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Item assigned. Returns item id, name, and assignedParticipantId.",
+                  "$ref": "#/components/schemas/def-92"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation error.",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing `x-user-id` or `x-service-key` missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Missing `x-user-id` or `x-service-key` missing/invalid.",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller not a participant; viewer role; participant tried to assign to another; participant tried to assign an already-assigned item.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Caller not a participant; viewer role; participant tried to assign to another; participant tried to assign an already-assigned item.",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Item not found or target participant not on this plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Item not found or target participant not on this plan.",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error while assigning item.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unexpected error while assigning item.",
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/internal/plan-tags": {
       "get": {
         "summary": "Get plan tag taxonomy for chatbot",
@@ -9225,7 +9379,7 @@
               "application/json": {
                 "schema": {
                   "description": "Full plan tag taxonomy",
-                  "$ref": "#/components/schemas/def-112"
+                  "$ref": "#/components/schemas/def-115"
                 }
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chillist-be",
-  "version": "1.25.2",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chillist-be",
-      "version": "1.25.2",
+      "version": "1.34.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.71",
         "@ai-sdk/openai": "^2.0.101",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chillist-be",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "description": "Chillist Backend API - Trip planning with shared checklists",
   "type": "module",
   "engines": {

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -1057,6 +1057,172 @@ export async function internalRoutes(fastify: FastifyInstance) {
     }
   )
 
+  fastify.patch(
+    '/items/:itemId/assign',
+    {
+      schema: {
+        tags: ['internal'],
+        summary: 'Assign item to a participant',
+        description:
+          "Owner can assign (or reassign) any item to any participant on the plan. Participant can only self-assign an item that has no existing assignments. Headers: x-service-key (service auth) and x-user-id (caller's Supabase UUID). The assigned entry is upserted into assignmentStatusList with status pending.",
+        params: { $ref: 'ItemIdParam#' },
+        body: { $ref: 'InternalAssignItemBody#' },
+        response: {
+          200: {
+            description:
+              'Item assigned. Returns item id, name, and assignedParticipantId.',
+            $ref: 'InternalAssignItemResponse#',
+          },
+          400: {
+            description: 'Validation error.',
+            $ref: 'ErrorResponse#',
+          },
+          401: {
+            description:
+              'Missing `x-user-id` or `x-service-key` missing/invalid.',
+            $ref: 'ErrorResponse#',
+          },
+          403: {
+            description:
+              'Caller not a participant; viewer role; participant tried to assign to another; participant tried to assign an already-assigned item.',
+            $ref: 'ErrorResponse#',
+          },
+          404: {
+            description:
+              'Item not found or target participant not on this plan.',
+            $ref: 'ErrorResponse#',
+          },
+          500: {
+            description: 'Unexpected error while assigning item.',
+            $ref: 'ErrorResponse#',
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.internalUserId
+      if (!userId) {
+        return reply.code(401).send({ message: 'x-user-id header required' })
+      }
+
+      const { itemId } = request.params as { itemId: string }
+      const { participantId: targetParticipantId } = request.body as {
+        participantId: string
+      }
+
+      const [itemRow] = await fastify.db
+        .select({
+          itemId: items.itemId,
+          planId: items.planId,
+          name: items.name,
+          assignmentStatusList: items.assignmentStatusList,
+          isAllParticipants: items.isAllParticipants,
+        })
+        .from(items)
+        .where(eq(items.itemId, itemId))
+        .limit(1)
+
+      if (!itemRow) {
+        request.log.warn({ itemId }, 'Internal item assign — item not found')
+        return reply.code(404).send({ message: 'Item not found' })
+      }
+
+      const [callerParticipant] = await fastify.db
+        .select({
+          participantId: participants.participantId,
+          role: participants.role,
+        })
+        .from(participants)
+        .where(
+          and(
+            eq(participants.planId, itemRow.planId),
+            eq(participants.userId, userId)
+          )
+        )
+        .limit(1)
+
+      if (!callerParticipant) {
+        request.log.warn(
+          { itemId, planId: itemRow.planId, userId },
+          'Internal item assign — user not a participant'
+        )
+        return reply
+          .code(403)
+          .send({ message: 'User is not a participant on this plan' })
+      }
+
+      if (callerParticipant.role === 'viewer') {
+        request.log.warn(
+          { itemId, userId },
+          'Internal item assign — viewer cannot assign'
+        )
+        return reply.code(403).send({ message: 'Viewers cannot assign items' })
+      }
+
+      const [targetParticipant] = await fastify.db
+        .select({ participantId: participants.participantId })
+        .from(participants)
+        .where(
+          and(
+            eq(participants.planId, itemRow.planId),
+            eq(participants.participantId, targetParticipantId)
+          )
+        )
+        .limit(1)
+
+      if (!targetParticipant) {
+        request.log.warn(
+          { itemId, planId: itemRow.planId, targetParticipantId },
+          'Internal item assign — target participant not on plan'
+        )
+        return reply
+          .code(404)
+          .send({ message: 'Target participant not found on this plan' })
+      }
+
+      if (callerParticipant.role !== 'owner') {
+        if (targetParticipantId !== callerParticipant.participantId) {
+          request.log.warn(
+            { itemId, userId, targetParticipantId },
+            'Internal item assign — participant tried to assign to another'
+          )
+          return reply.code(403).send({
+            message: 'Participants can only assign items to themselves',
+          })
+        }
+
+        const isAssigned =
+          itemRow.assignmentStatusList.length > 0 || itemRow.isAllParticipants
+        if (isAssigned) {
+          request.log.warn(
+            { itemId, userId },
+            'Internal item assign — item already assigned'
+          )
+          return reply.code(403).send({ message: 'Item is already assigned' })
+        }
+      }
+
+      const nextList = [
+        { participantId: targetParticipantId, status: 'pending' as const },
+      ]
+
+      await persistAssignments(fastify.db, itemId, nextList, false)
+
+      request.log.info(
+        { itemId, userId, targetParticipantId },
+        'Internal item assigned'
+      )
+
+      return {
+        item: {
+          id: itemRow.itemId,
+          name: itemRow.name,
+          assignedParticipantId: targetParticipantId,
+        },
+      }
+    }
+  )
+
   fastify.get(
     '/plan-tags',
     {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -108,6 +108,9 @@ import {
   internalLinkWhatsappGroupBodySchema,
   internalLinkWhatsappGroupResponseSchema,
   internalGroupPlanResponseSchema,
+  internalAssignItemBodySchema,
+  internalAssignItemItemSchema,
+  internalAssignItemResponseSchema,
 } from './internal.schema.js'
 import {
   dietaryMemberSchema,
@@ -232,6 +235,9 @@ const schemas = [
   internalLinkWhatsappGroupBodySchema,
   internalLinkWhatsappGroupResponseSchema,
   internalGroupPlanResponseSchema,
+  internalAssignItemBodySchema,
+  internalAssignItemItemSchema,
+  internalAssignItemResponseSchema,
   dietaryMemberSchema,
   dietaryMembersBodySchema,
   aiSuggestionsRequestSchema,

--- a/src/schemas/internal.schema.ts
+++ b/src/schemas/internal.schema.ts
@@ -485,3 +485,47 @@ export const internalCreateExpenseBodySchema = {
   },
   additionalProperties: false,
 } as const
+
+export const internalAssignItemBodySchema = {
+  $id: 'InternalAssignItemBody',
+  type: 'object',
+  description:
+    'Request body for PATCH /api/internal/items/:itemId/assign. Owner can assign any item to any participant. Participant can only self-assign an unassigned item.',
+  required: ['participantId'],
+  additionalProperties: false,
+  properties: {
+    participantId: {
+      type: 'string',
+      format: 'uuid',
+      description: 'UUID of the participant to assign the item to.',
+    },
+  },
+} as const
+
+export const internalAssignItemItemSchema = {
+  $id: 'InternalAssignItemItem',
+  type: 'object',
+  description: 'Item snippet after assignment.',
+  required: ['id', 'name', 'assignedParticipantId'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', format: 'uuid', description: 'Item UUID.' },
+    name: { type: 'string', description: 'Item name.' },
+    assignedParticipantId: {
+      type: 'string',
+      format: 'uuid',
+      description: 'UUID of the participant the item was assigned to.',
+    },
+  },
+} as const
+
+export const internalAssignItemResponseSchema = {
+  $id: 'InternalAssignItemResponse',
+  type: 'object',
+  description: 'Response for PATCH /api/internal/items/:itemId/assign.',
+  required: ['item'],
+  additionalProperties: false,
+  properties: {
+    item: { $ref: 'InternalAssignItemItem#' },
+  },
+} as const

--- a/tests/integration/internal-item-assign.test.ts
+++ b/tests/integration/internal-item-assign.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import { eq } from 'drizzle-orm'
+import {
+  cleanupTestDatabase,
+  closeTestDatabase,
+  setupTestDatabase,
+} from '../helpers/db.js'
+import { setupTestKeys, getTestJWKS, getTestIssuer } from '../helpers/auth.js'
+import { Database } from '../../src/db/index.js'
+import { plans, participants, items } from '../../src/db/schema.js'
+
+const VALID_SERVICE_KEY = 'test-service-key-assign-abc123'
+const OWNER_USER_ID = 'aaaaaaaa-1111-2222-3333-444444444444'
+const PARTICIPANT_USER_ID = 'bbbbbbbb-2222-3333-4444-555555555555'
+const THIRD_USER_ID = 'cccccccc-3333-4444-5555-666666666666'
+
+describe('Internal Item Assign — PATCH /api/internal/items/:itemId/assign', () => {
+  let app: FastifyInstance
+  let db: Database
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    await setupTestKeys()
+    process.env.CHATBOT_SERVICE_KEY = VALID_SERVICE_KEY
+    app = await buildApp(
+      { db },
+      {
+        logger: false,
+        auth: { jwks: getTestJWKS(), issuer: getTestIssuer() },
+        rateLimit: false,
+      }
+    )
+  }, 30000)
+
+  afterAll(async () => {
+    await app.close()
+    await closeTestDatabase()
+    delete process.env.CHATBOT_SERVICE_KEY
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  async function patchAssign(
+    itemId: string,
+    body: { participantId: string },
+    headers: Record<string, string> = {}
+  ) {
+    return app.inject({
+      method: 'PATCH',
+      url: `/api/internal/items/${itemId}/assign`,
+      headers: {
+        'x-service-key': VALID_SERVICE_KEY,
+        'content-type': 'application/json',
+        ...headers,
+      },
+      payload: body,
+    })
+  }
+
+  async function seedPlan() {
+    const [plan] = await db
+      .insert(plans)
+      .values({
+        title: 'Test Plan',
+        status: 'active',
+        visibility: 'invite_only',
+      })
+      .returning()
+
+    const [owner] = await db
+      .insert(participants)
+      .values({
+        planId: plan.planId,
+        name: 'Owner',
+        lastName: 'Test',
+        contactPhone: '+972501111111',
+        userId: OWNER_USER_ID,
+        role: 'owner',
+        displayName: 'Owner Test',
+      })
+      .returning()
+
+    const [participant] = await db
+      .insert(participants)
+      .values({
+        planId: plan.planId,
+        name: 'Participant',
+        lastName: 'Test',
+        contactPhone: '+972502222222',
+        userId: PARTICIPANT_USER_ID,
+        role: 'participant',
+        displayName: 'Participant Test',
+      })
+      .returning()
+
+    const [item] = await db
+      .insert(items)
+      .values({
+        planId: plan.planId,
+        name: 'Tent',
+        category: 'group_equipment',
+        quantity: 1,
+        unit: 'pcs',
+        assignmentStatusList: [],
+        isAllParticipants: false,
+      })
+      .returning()
+
+    return { plan, owner, participant, item }
+  }
+
+  describe('Auth', () => {
+    it('returns 401 when x-service-key is missing', async () => {
+      const fakeId = '00000000-0000-0000-0000-000000000001'
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/api/internal/items/${fakeId}/assign`,
+        headers: {
+          'x-user-id': OWNER_USER_ID,
+          'content-type': 'application/json',
+        },
+        payload: { participantId: fakeId },
+      })
+      expect(response.statusCode).toBe(401)
+      expect(response.json()).toMatchObject({ message: 'Unauthorized' })
+    })
+
+    it('returns 401 when x-user-id is missing', async () => {
+      const { item, owner } = await seedPlan()
+      const response = await patchAssign(item.itemId, {
+        participantId: owner.participantId,
+      })
+      expect(response.statusCode).toBe(401)
+      expect(response.json()).toMatchObject({
+        message: 'x-user-id header required',
+      })
+    })
+  })
+
+  describe('Happy paths', () => {
+    it('owner assigns unassigned item to any participant', async () => {
+      const { item, participant } = await seedPlan()
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: participant.participantId },
+        { 'x-user-id': OWNER_USER_ID }
+      )
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.item.id).toBe(item.itemId)
+      expect(body.item.name).toBe('Tent')
+      expect(body.item.assignedParticipantId).toBe(participant.participantId)
+
+      const [updated] = await db
+        .select({ assignmentStatusList: items.assignmentStatusList })
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+      expect(updated.assignmentStatusList).toEqual([
+        { participantId: participant.participantId, status: 'pending' },
+      ])
+    })
+
+    it('owner reassigns item already assigned to another participant (replaces previous assignee)', async () => {
+      const { item, owner, participant } = await seedPlan()
+
+      // pre-assign to owner
+      await db
+        .update(items)
+        .set({
+          assignmentStatusList: [
+            { participantId: owner.participantId, status: 'pending' },
+          ],
+        })
+        .where(eq(items.itemId, item.itemId))
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: participant.participantId },
+        { 'x-user-id': OWNER_USER_ID }
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().item.assignedParticipantId).toBe(
+        participant.participantId
+      )
+
+      const [updated] = await db
+        .select({ assignmentStatusList: items.assignmentStatusList })
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+      expect(updated.assignmentStatusList).toEqual([
+        { participantId: participant.participantId, status: 'pending' },
+      ])
+      expect(updated.assignmentStatusList).not.toContainEqual({
+        participantId: owner.participantId,
+        status: 'pending',
+      })
+    })
+
+    it('owner assigns item to themselves', async () => {
+      const { item, owner } = await seedPlan()
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: owner.participantId },
+        { 'x-user-id': OWNER_USER_ID }
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().item.assignedParticipantId).toBe(
+        owner.participantId
+      )
+    })
+
+    it('participant self-assigns unassigned item', async () => {
+      const { item, participant } = await seedPlan()
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: participant.participantId },
+        { 'x-user-id': PARTICIPANT_USER_ID }
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json().item.assignedParticipantId).toBe(
+        participant.participantId
+      )
+
+      const [updated] = await db
+        .select({ assignmentStatusList: items.assignmentStatusList })
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+      expect(updated.assignmentStatusList).toEqual([
+        { participantId: participant.participantId, status: 'pending' },
+      ])
+    })
+
+    it('owner reassign clears isAllParticipants flag', async () => {
+      const { item, owner } = await seedPlan()
+
+      await db
+        .update(items)
+        .set({ isAllParticipants: true })
+        .where(eq(items.itemId, item.itemId))
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: owner.participantId },
+        { 'x-user-id': OWNER_USER_ID }
+      )
+
+      expect(response.statusCode).toBe(200)
+      const [updated] = await db
+        .select({
+          assignmentStatusList: items.assignmentStatusList,
+          isAllParticipants: items.isAllParticipants,
+        })
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+      expect(updated.isAllParticipants).toBe(false)
+      expect(updated.assignmentStatusList).toEqual([
+        { participantId: owner.participantId, status: 'pending' },
+      ])
+    })
+  })
+
+  describe('Error paths', () => {
+    it('returns 404 when item does not exist', async () => {
+      const fakeId = '00000000-0000-0000-0000-000000000099'
+      const response = await patchAssign(
+        fakeId,
+        { participantId: fakeId },
+        { 'x-user-id': OWNER_USER_ID }
+      )
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toMatchObject({ message: 'Item not found' })
+    })
+
+    it('returns 403 when caller is not a participant on the plan', async () => {
+      const { item, owner } = await seedPlan()
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: owner.participantId },
+        { 'x-user-id': THIRD_USER_ID }
+      )
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        message: 'User is not a participant on this plan',
+      })
+    })
+
+    it('returns 404 when target participant is not on the plan', async () => {
+      const { item } = await seedPlan()
+      const fakeParticipantId = '00000000-0000-0000-0000-000000000077'
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: fakeParticipantId },
+        { 'x-user-id': OWNER_USER_ID }
+      )
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toMatchObject({
+        message: 'Target participant not found on this plan',
+      })
+    })
+
+    it('returns 403 when participant tries to assign to another participant', async () => {
+      const { item, owner } = await seedPlan()
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: owner.participantId },
+        { 'x-user-id': PARTICIPANT_USER_ID }
+      )
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        message: 'Participants can only assign items to themselves',
+      })
+    })
+
+    it('returns 403 when participant tries to assign an already-assigned item', async () => {
+      const { item, owner, participant } = await seedPlan()
+
+      await db
+        .update(items)
+        .set({
+          assignmentStatusList: [
+            { participantId: owner.participantId, status: 'pending' },
+          ],
+        })
+        .where(eq(items.itemId, item.itemId))
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: participant.participantId },
+        { 'x-user-id': PARTICIPANT_USER_ID }
+      )
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        message: 'Item is already assigned',
+      })
+    })
+
+    it('returns 403 when participant tries to assign an isAllParticipants item', async () => {
+      const { item, participant } = await seedPlan()
+
+      await db
+        .update(items)
+        .set({ isAllParticipants: true })
+        .where(eq(items.itemId, item.itemId))
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: participant.participantId },
+        { 'x-user-id': PARTICIPANT_USER_ID }
+      )
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        message: 'Item is already assigned',
+      })
+    })
+
+    it('returns 403 when viewer tries to assign', async () => {
+      const { plan, item } = await seedPlan()
+
+      const [viewer] = await db
+        .insert(participants)
+        .values({
+          planId: plan.planId,
+          name: 'Viewer',
+          lastName: 'Test',
+          contactPhone: '+972503333333',
+          userId: THIRD_USER_ID,
+          role: 'viewer',
+          displayName: 'Viewer Test',
+        })
+        .returning()
+
+      const response = await patchAssign(
+        item.itemId,
+        { participantId: viewer.participantId },
+        { 'x-user-id': THIRD_USER_ID }
+      )
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        message: 'Viewers cannot assign items',
+      })
+    })
+  })
+
+  describe('No side effects on failure', () => {
+    it('failed 403 does not modify assignmentStatusList', async () => {
+      const { item, owner, participant } = await seedPlan()
+
+      await db
+        .update(items)
+        .set({
+          assignmentStatusList: [
+            { participantId: owner.participantId, status: 'pending' },
+          ],
+        })
+        .where(eq(items.itemId, item.itemId))
+
+      await patchAssign(
+        item.itemId,
+        { participantId: participant.participantId },
+        { 'x-user-id': PARTICIPANT_USER_ID }
+      )
+
+      const [unchanged] = await db
+        .select({ assignmentStatusList: items.assignmentStatusList })
+        .from(items)
+        .where(eq(items.itemId, item.itemId))
+      expect(unchanged.assignmentStatusList).toEqual([
+        { participantId: owner.participantId, status: 'pending' },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/internal/items/:itemId/assign` for the WhatsApp chatbot service.
- **Owner** may assign any item to any participant on the plan.
- **Participant** may only self-assign, and only when the item has no existing assignments (empty `assignmentStatusList` and `isAllParticipants=false`).
- Replaces `assignmentStatusList` with `[{ participantId, pending }]` and clears `isAllParticipants` — mirrors owner replace semantics in `computeFinalAssignmentState`.
- Viewers rejected.
- Auth: `x-service-key` + `x-user-id` (same as other internal routes).
- Version: 1.33.x → 1.34.0.
- OpenAPI regenerated; whatsapp + current/status docs updated in chillist-docs.

## Errors

| Code | When |
|------|------|
| 200 | Assigned |
| 401 | Missing `x-user-id` / invalid service key |
| 403 | Caller not on plan; viewer; participant assigns to another; participant assigns already-assigned item |
| 404 | Item not found; target participant not on plan |

## Test plan

- [x] Integration tests `tests/integration/internal-item-assign.test.ts` — 15 scenarios (auth, owner assign / reassign / clears isAllParticipants, participant self-assign, all 403/404 paths, no-side-effect-on-failure)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Full `npm run test:run` — 1222 passed (pre-push hook)
- [x] `npm run openapi:generate`
- [ ] Manual smoke via chatbot service after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)